### PR TITLE
Reduce the length of the date labels on BarChartContainer.

### DIFF
--- a/src/client/app/containers/BarChartContainer.js
+++ b/src/client/app/containers/BarChartContainer.js
@@ -32,7 +32,7 @@ function mapStateToProps(state) {
 			});
 			// Add only the unique time intervals to the label set
 			for (const element of _.flatten(readingsData.readings.map(arr => arr[0]))) {
-				labelsSet.add(`${moment(element).format('MMM DD, YYYY, hh:mm a')} - ${moment(element).add(barDuration).format('MMM DD, YYYY, hh:mm a')}`);
+				labelsSet.add(`${moment(element).format('MMM DD')} - ${moment(element).add(barDuration).format('MMM DD YYYY')}`);
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the issue of the graph looking tiny with lots of labels (small timescale).