### PR TITLE
Fix bar chart labels out of order

### DIFF
--- a/src/client/app/containers/BarChartContainer.js
+++ b/src/client/app/containers/BarChartContainer.js
@@ -32,12 +32,12 @@ function mapStateToProps(state) {
 			});
 			// Add only the unique time intervals to the label set
 			for (const element of _.flatten(readingsData.readings.map(arr => arr[0]))) {
-				labelsSet.add(`${moment(element).format('MMM DD')} - ${moment(element).add(barDuration).format('MMM DD YYYY')}`);
+				labelsSet.add(`${moment(element).format('MMM DD, YYYY')} - ${moment(element).add(barDuration).format('MMM DD, YYYY')}`);
 			}
 		}
 	}
     // Converts the label set into an array for Chart.js and sorts the labels based on the first date of the time interval
-	data.labels = Array.from(labelsSet).sort((x, y) => moment(x.split(' - ')[0], 'MMM DD, YYYY, hh:mm a').format('x') - moment(y.split(' - ')[0], 'MMM DD, YYYY, hh:mm a').format('x'));
+	data.labels = Array.from(labelsSet).sort((x, y) => moment(x.split(' - ')[0], 'MMM DD, YYYY').format('x') - moment(y.split(' - ')[0], 'MMM DD, YYYY').format('x'));
 
 	const options = {
 		animation: {


### PR DESCRIPTION
Fixes bar chart labels out of order (sorts based on month instead of year). Partially reverts PR #132, but shrinks overall size of the labels.