### PR TITLE
Add version adornments.

### DIFF
--- a/src/client/app/components/HeaderComponent.jsx
+++ b/src/client/app/components/HeaderComponent.jsx
@@ -31,10 +31,6 @@ export default function HeaderComponent(props) {
 		// Displays the admin button link only if the user is logged in (auth token exists)
 		display: localStorage.getItem('token') ? 'inline' : 'none'
 	};
-	const versionLabelStyle = {
-		fontWeight: 'bold',
-		margin: '10px'
-	};
 	return (
 		<div className="container-fluid">
 			<div className="col-xs-4">
@@ -49,7 +45,6 @@ export default function HeaderComponent(props) {
 				</div>
 				<Link style={loginLinkStyle} to="/login"><Button bsStyle="default">Log In</Button></Link>
 				<Link style={adminLinkStyle} to="/admin"><Button bsStyle="default">Admin panel</Button></Link>
-				<span style={versionLabelStyle}>{`${VERSION}`}</span>
 			</div>
 		</div>
 	);

--- a/src/client/app/components/HeaderComponent.jsx
+++ b/src/client/app/components/HeaderComponent.jsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router';
 import { Button } from 'react-bootstrap';
 import LogoComponent from './LogoComponent';
 import UIModalComponent from './UIModalComponent';
-import VERSION from '../../../common/version';
 
 /**
  * React component that controls the header strip at the top of all pages

--- a/src/client/app/components/HeaderComponent.jsx
+++ b/src/client/app/components/HeaderComponent.jsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router';
 import { Button } from 'react-bootstrap';
 import LogoComponent from './LogoComponent';
 import UIModalComponent from './UIModalComponent';
+import VERSION from '../../../common/version';
 
 /**
  * React component that controls the header strip at the top of all pages
@@ -30,6 +31,10 @@ export default function HeaderComponent(props) {
 		// Displays the admin button link only if the user is logged in (auth token exists)
 		display: localStorage.getItem('token') ? 'inline' : 'none'
 	};
+	const versionLabelStyle = {
+		fontWeight: 'bold',
+		margin: '10px'
+	};
 	return (
 		<div className="container-fluid">
 			<div className="col-xs-4">
@@ -44,6 +49,7 @@ export default function HeaderComponent(props) {
 				</div>
 				<Link style={loginLinkStyle} to="/login"><Button bsStyle="default">Log In</Button></Link>
 				<Link style={adminLinkStyle} to="/admin"><Button bsStyle="default">Admin panel</Button></Link>
+				<span style={versionLabelStyle}>{`${VERSION}`}</span>
 			</div>
 		</div>
 	);

--- a/src/client/app/components/LogoComponent.jsx
+++ b/src/client/app/components/LogoComponent.jsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+import VERSION from '../../../common/version';
 
 /**
  * React component that creates an logo image from a file path
@@ -18,6 +19,6 @@ export default function LogoComponent(props) {
 		position: 'absolute'
 	};
 	return (
-		<img src={props.url} alt="Logo" style={imgStyle} />
+		<img src={props.url} alt="Logo" title={`Open Energy Dashboard ${VERSION}`} style={imgStyle} />
 	);
 }

--- a/src/common/version.js
+++ b/src/common/version.js
@@ -6,10 +6,17 @@
  * Creates a new VERSION object, which contains a major, minor, and patch release level.
  * OED is compliant with Semver.
  */
+
+const pkgJson = require('../../package.json');
+
 function OEDVersion() {
-	this.major = 0;
-	this.minor = 1;
-	this.patch = 0;
+	const versionParts = pkgJson.version.split('.');
+	if (versionParts.length !== 3) {
+		console.error('package.json version string is not in semver x.y.z format!'); // eslint-disable-line no-console
+	}
+	this.major = versionParts[0];
+	this.minor = versionParts[1];
+	this.patch = versionParts[2];
 }
 
 /**

--- a/src/common/version.js
+++ b/src/common/version.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Creates a new VERSION object, which contains a major, minor, and patch release level.
+ * OED is compliant with Semver.
+ */
+function OEDVersion() {
+	this.major = 0;
+	this.minor = 1;
+	this.patch = 0;
+}
+
+/**
+ * @returns {string} a string representation of the Semver version of the application,
+ * in the form v1.2.3
+ */
+OEDVersion.prototype.toString = function toString() {
+	return `v${this.major}.${this.minor}.${this.patch}`;
+};
+
+const VERSION = new OEDVersion();
+module.exports = VERSION;

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -13,6 +13,7 @@ const readings = require('./routes/readings');
 const meters = require('./routes/meters');
 const login = require('./routes/login');
 const verification = require('./routes/verification');
+const VERSION = require('../common/version');
 
 const app = express();
 
@@ -28,6 +29,13 @@ app.use('/api/meters', meters);
 app.use('/api/readings', readings);
 app.use('/api/login', login);
 app.use('/api/verification', verification);
+
+/**
+ * Returns the version of the application to the client.
+ */
+app.get('/api/version', (req, res) => {
+	res.json(VERSION);
+});
 
 app.get('*', (req, res) => {
 	res.sendFile(path.resolve(__dirname, '..', 'client', 'index.html'));

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -13,7 +13,7 @@ const readings = require('./routes/readings');
 const meters = require('./routes/meters');
 const login = require('./routes/login');
 const verification = require('./routes/verification');
-const VERSION = require('../common/version');
+const version = require('./routes/version');
 
 const app = express();
 
@@ -29,13 +29,7 @@ app.use('/api/meters', meters);
 app.use('/api/readings', readings);
 app.use('/api/login', login);
 app.use('/api/verification', verification);
-
-/**
- * Returns the version of the application to the client.
- */
-app.get('/api/version', (req, res) => {
-	res.json(VERSION);
-});
+app.use('/api/version', version);
 
 app.get('*', (req, res) => {
 	res.sendFile(path.resolve(__dirname, '..', 'client', 'index.html'));

--- a/src/server/routes/version.js
+++ b/src/server/routes/version.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const express = require('express');
+const VERSION = require('../../common/version');
+
+const router = express.Router();
+/**
+ * Returns the version of the application to the client.
+ */
+router.get('/', (req, res) => {
+	res.json(VERSION);
+});
+
+module.exports = router;


### PR DESCRIPTION
Relevant to #142.

The file "common/version.js" should be updated in the LAST commit before a tag is made for that version. 

The contents of the created version object are displayed on the app and are available as JSON in the API, from /api/version, in case we ever want to make mobile apps or support very long-running displays (e.g. the "wall graph" use case).