### PR TITLE
Move tooltip to the right of the slider handle.

### DIFF
--- a/src/client/app/components/UIOptionsComponent.jsx
+++ b/src/client/app/components/UIOptionsComponent.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Slider from 'react-rangeslider';
 import moment from 'moment';
 import 'react-rangeslider/lib/index.css';
+import '../styles/react-rangeslider-fix.css';
 import MultiSelectComponent from './MultiSelectComponent';
 import { chartTypes } from '../reducers/graph';
 import ExportContainer from '../containers/ExportContainer';

--- a/src/client/app/styles/react-rangeslider-fix.css
+++ b/src/client/app/styles/react-rangeslider-fix.css
@@ -1,0 +1,12 @@
+.rangeslider__tooltip::after {
+	border-top: 8px solid transparent !important;
+	border-bottom: 8px solid transparent !important;
+	border-right: 8px solid rgba(0, 0, 0, 0.8) !important;
+	left: -15px !important;
+	top: 12px !important;
+}
+
+.rangeslider-horizontal .rangeslider__tooltip {
+	top: -5px !important;
+	left: 40px !important;
+}


### PR DESCRIPTION
Fixes #96, bug where the tooltip would cover the stacking checkbox for some slider values.