### PR TITLE
Update README to reflect our current URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Open Energy Dashboard #
-[![Build Status](https://travis-ci.org/beloitcollegecomputerscience/OED.svg?branch=master)](https://travis-ci.org/beloitcollegecomputerscience/OED)
+[![Build Status](https://travis-ci.org/OpenEnergyDashboard/OED.svg?branch=master)](https://travis-ci.org/OpenEnergyDashboard/OED)
 
 The Open Energy Dashboard is a user-friendly way to display energy information from smart energy meters, designed and built by faculty and students at Beloit College. It is designed for institutions of higher education, and is optimized for non-technical users with a simple interface that provides access to your institution's energy data through the powerful Chart.js data graphing system. To learn more, see [our website](https://openenergydashboard.github.io/).
 
@@ -65,13 +65,13 @@ By default, the app will run on the port 3000 with secret key ?, which should de
 
 This application was created by a team of Beloit College CS students led by Prof. Steven Huss-Lederman
 
-For a list of contributors, [click here](https://github.com/beloitcollegecomputerscience/ED-JS/graphs/contributors)
+For a list of contributors, [click here](https://github.com/OpenEnergyDashboard/OED/graphs/contributors)
 
 ### Licensing ###
 
 This project is licensed under the MPL version 2.0.
 
-See the full licensing agreement [here](https://github.com/beloitcollegecomputerscience/ED-JS/blob/master/License.txt)
+See the full licensing agreement [here](License.txt)
 
 ### Contributions ###
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ See the full licensing agreement [here](License.txt)
 
 We welcome others to contribute to this project by writing code for submission or collaborating with us. Before contributing, please sign our Contributor License Agreement [here](https://goo.gl/forms/nR9MtVHUOqYn8WbP2).
 If you have any questions or concerns feel free to email us at oed@beloit.edu.
-### Contact: ###
+
+### Contact ###
 
 To contact us, send an email to oed@beloit.edu or open an issue on GitHub.
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ The Open Energy Dashboard is a user-friendly way to display energy information f
 
 The Open Energy Dashboard is available under the Mozilla Public Licence, and contributions, in the form of bug reports, feature requests, and code contributions, are welcome.
 
-### Built With: ###
+### Built With ###
 Chart.js - Javascript library used to generate data charts ([chartjs.org](http://www.chartjs.org))
 
 PostgreSQL - Database management system ([postgresql.org](https://www.postgresql.org))
 
 Node.js - Javascript runtime environment ([nodejs.org](https://nodejs.org/en/))
 
-### Developer installation: ###
+### Developer Installation ###
 
 You can either use Docker Compose to install Node and PostgreSQL in containers, or install Node and PostgreSQL on your system.
 


### PR DESCRIPTION
Changes links in the README to refer to the current location, OpenEnergyDashboard/OED, where needed, and use relative URLs [where possible](https://github.com/blog/1395-relative-links-in-markup-files).