### PR TITLE
Add MPL header to log module

### DIFF
--- a/src/server/log.js
+++ b/src/server/log.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 const fs = require('fs');
 const logFile = require('./config').logFile;
 /**


### PR DESCRIPTION
This fixes the failing Travis build on master. We may need to investigate why the Travis build did not fail before merging.