### PR TITLE
Re-factor group graphing actions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
@@ -1678,7 +1678,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY="
     },
     "base64url": {
       "version": "2.0.0",
@@ -1707,7 +1707,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
     },
     "body-parser": {
       "version": "1.15.2",
@@ -2161,7 +2161,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
@@ -2445,7 +2445,7 @@
     "crypto-browserify": {
       "version": "3.11.1",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "integrity": "sha1-lIlF78Z1ekANbl5a9HGU0QBkJ58=",
       "requires": {
         "browserify-cipher": "1.0.0",
         "browserify-sign": "4.0.4",
@@ -5514,7 +5514,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "requires": {
         "md5.js": "1.3.4",
         "safe-buffer": "5.1.1"
@@ -6077,7 +6077,7 @@
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
@@ -6422,7 +6422,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -7373,7 +7373,7 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
       "requires": {
         "execa": "0.7.0",
         "lcid": "1.0.0",
@@ -7461,7 +7461,7 @@
     "pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "integrity": "sha1-o14TxkeZsGzhUyD0WcIw5o5zut4=",
       "requires": {
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
@@ -7816,7 +7816,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -7853,7 +7853,7 @@
     "randombytes": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
       "requires": {
         "safe-buffer": "5.1.1"
       },
@@ -8927,7 +8927,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "requires": {
         "is-equal-shallow": "0.1.3"
       }
@@ -9176,7 +9176,7 @@
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+      "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU="
     },
     "source-map": {
       "version": "0.5.7",
@@ -9240,7 +9240,7 @@
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.3",
@@ -9304,7 +9304,7 @@
     "timers-browserify": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "integrity": "sha1-lspT9LeUpefA4b18yIo3Ipj6AeY=",
       "requires": {
         "setimmediate": "1.0.5"
       },
@@ -9556,7 +9556,7 @@
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "integrity": "sha1-xzVkNqTRMSO+LiQmoF0drZy+Zc8=",
       "requires": {
         "source-list-map": "2.0.0",
         "source-map": "0.5.7"

--- a/src/client/app/actions/barReadings.js
+++ b/src/client/app/actions/barReadings.js
@@ -119,14 +119,14 @@ function fetchGroupBarReadings(groupIDs, timeInterval) {
 }
 
 function fetchCompareReadings(meterIDs, timeInterval) {
-    return (dispatch, getState) => {
-        const barDuration = getState().graph.compareDuration;
-        dispatch(requestBarReadings(meterIDs, timeInterval, barDuration));
-        const stringifiedMeterIDs = meterIDs.join(',');
-        return axios.get(`/api/readings/bar/${stringifiedMeterIDs}`, {
-            params: { timeInterval: timeInterval.toString(), barDuration: barDuration.toISOString() }
-        }).then(response => dispatch(receiveBarReadings(meterIDs, timeInterval, barDuration, response.data)));
-    };
+	return (dispatch, getState) => {
+		const barDuration = getState().graph.compareDuration;
+		dispatch(requestMeterBarReadings(meterIDs, timeInterval, barDuration));
+		const stringifiedMeterIDs = meterIDs.join(',');
+		return axios.get(`/api/readings/bar/meters/${stringifiedMeterIDs}`, {
+			params: { timeInterval: timeInterval.toString(), barDuration: barDuration.toISOString() }
+		}).then(response => dispatch(receiveMeterBarReadings(meterIDs, timeInterval, barDuration, response.data)));
+	};
 }
 
 /**
@@ -160,12 +160,12 @@ export function fetchNeededBarReadings(timeInterval) {
 }
 
 export function fetchNeededCompareReadings(timeInterval) {
-    return (dispatch, getState) => {
-        const state = getState();
-        const meterIDsToFetchForBar = state.graph.selectedMeters.filter(id => shouldFetchBarReadings(state, id, timeInterval, state.graph.compareDuration));
-        if (meterIDsToFetchForBar.length > 0) {
-            return dispatch(fetchCompareReadings(meterIDsToFetchForBar, timeInterval));
-        }
-        return Promise.resolve();
-    };
+	return (dispatch, getState) => {
+		const state = getState();
+		const meterIDsToFetchForBar = state.graph.selectedMeters.filter(id => shouldFetchMeterBarReadings(state, id, timeInterval, state.graph.compareDuration));
+		if (meterIDsToFetchForBar.length > 0) {
+			return dispatch(fetchCompareReadings(meterIDsToFetchForBar, timeInterval));
+		}
+		return Promise.resolve();
+	};
 }

--- a/src/client/app/actions/lineReadings.js
+++ b/src/client/app/actions/lineReadings.js
@@ -5,80 +5,144 @@
  */
 
 import axios from 'axios';
-import { DATA_TYPE_METER, DATA_TYPE_GROUP } from '../utils/Datasources';
 
-export const REQUEST_LINE_READINGS = 'REQUEST_LINE_READINGS';
-export const RECEIVE_LINE_READINGS = 'RECEIVE_LINE_READINGS';
+export const REQUEST_GROUP_LINE_READINGS = 'REQUEST_GROUP_LINE_READINGS';
+export const RECEIVE_GROUP_LINE_READINGS = 'RECEIVE_GROUP_LINE_READINGS';
+
+export const REQUEST_METER_LINE_READINGS = 'REQUEST_METER_LINE_READINGS';
+export const RECEIVE_METER_LINE_READINGS = 'RECEIVE_METER_LINE_READINGS';
 
 /**
- * @param {State} state
- * @param {number} dsID
- * @param {TimeInterval} timeInterval
- * @param {String} type either DATA_TYPE_METER, DATA_TYPE_GROUP
+ * @param {State} state The current Redux state
+ * @param {number} groupID The ID of the group to check
+ * @param {TimeInterval} timeInterval The time interval to check
+ * @returns {bool} True if the line readings for the given group at the given time are missing, false otherwise
  */
-function shouldFetchLineReadings(state, dsID, timeInterval, type) {
-	let dsArray;
-	if (type === DATA_TYPE_GROUP) {
-		dsArray = state.readings.line.byGroupID;
-	} else if (type === DATA_TYPE_METER) {
-		dsArray = state.readings.line.byMeterID;
-	}
-
-	const readingsForID = dsArray[dsID];
+function shouldFetchGroupLineReadings(state, groupID, timeInterval) {
+	const readingsForID = state.readings.line.byGroupID[groupID];
 	if (readingsForID === undefined) {
 		return true;
 	}
+
+	const readingsForTimeInterval = readingsForID[timeInterval];
 	if (readingsForID[timeInterval] === undefined) {
 		return true;
 	}
-	const readingsForTimeInterval = dsArray[dsID][timeInterval];
-	return readingsForTimeInterval === undefined && !readingsForTimeInterval.isFetching;
+
+	return !readingsForTimeInterval.isFetching;
 }
 
-function requestLineReadings(dsIDs, timeInterval, dstype) {
-	return { type: REQUEST_LINE_READINGS, dsIDs, timeInterval, dstype };
+/**
+ * @param {State} state The current Redux state
+ * @param {number} meterID The ID of the meter to check
+ * @param {TimeInterval} timeInterval The time interval to check
+ * @returns {bool} True if the line readings for the given meter at the given time are missing, false otherwise
+ */
+function shouldFetchMeterLineReadings(state, meterID, timeInterval) {
+	const readingsForID = state.readings.line.byMeterID[meterID];
+	if (readingsForID === undefined) {
+		return true;
+	}
+
+	const readingsForTimeInterval = readingsForID[timeInterval];
+	if (readingsForID[timeInterval] === undefined) {
+		return true;
+	}
+
+	return !readingsForTimeInterval.isFetching;
 }
 
-function receiveLineReadings(dsIDs, timeInterval, readings, dstype) {
-	return { type: RECEIVE_LINE_READINGS, dsIDs, timeInterval, readings, dstype };
+/**
+ * @param {[number]} meterIDs The IDs of the meters whose data should be fetched
+ * @param {TimeInterval} timeInterval The time interval over which data should be fetched
+ */
+function requestMeterLineReadings(meterIDs, timeInterval) {
+	return { type: REQUEST_METER_LINE_READINGS, meterIDs, timeInterval };
 }
 
-function fetchLineReadings(dsIDs, timeInterval, dstype) {
+/**
+ * @param {[number]} meterIDs The IDs of the meters whose data has been fetched
+ * @param {TimeInterval} timeInterval The time interval over which data has been fetched
+ * @param {*} readings The data that has been fetched, indexed by meter ID.
+ */
+function receiveMeterLineReadings(meterIDs, timeInterval, readings) {
+	return { type: RECEIVE_METER_LINE_READINGS, meterIDs, timeInterval, readings };
+}
+
+/**
+ * @param {[number]} groupIDs The IDs of the groups whose data should be fetched
+ * @param {TimeInterval} timeInterval The time interval over which data should be fetched
+ */
+function requestGroupLineReadings(groupIDs, timeInterval) {
+	return { type: REQUEST_GROUP_LINE_READINGS, groupIDs, timeInterval };
+}
+
+/**
+ * @param {[number]} groupIDs The IDs of the groups whose data has been fetched
+ * @param {TimeInterval} timeInterval The time interval over which data has been fetched
+ * @param {*} readings The data that has been fetched, indexed by group ID.
+ */
+function receiveGroupLineReadings(groupIDs, timeInterval, readings) {
+	return { type: RECEIVE_GROUP_LINE_READINGS, groupIDs, timeInterval, readings };
+}
+
+/**
+ * Fetch the data for the given meters over the given interval. Fully manages the Redux lifecycle.
+ * @param {[number]} meterIDs The IDs of the meters whose data should be fetched
+ * @param {TimeInterval} timeInterval The time interval over which data should be fetched
+ */
+function fetchMeterLineReadings(meterIDs, timeInterval) {
 	return dispatch => {
-		dispatch(requestLineReadings(dsIDs, timeInterval, dstype));
-		// The api expects the meter ids to be a comma-separated list.
-		const stringifiedIDs = dsIDs.join(',');
-		let endpoint;
-		if (dstype === DATA_TYPE_GROUP) {
-			endpoint = '/api/readings/line/groups';
-		} else if (dstype === DATA_TYPE_METER) {
-			endpoint = '/api/readings/line/meters';
-		} else {
-			console.error('Unknown datatype requested in fetchLineReadings: ', dstype);
-			return Promise.resolve();
-		}
-		return axios.get(`${endpoint}/${stringifiedIDs}`, {
+		dispatch(requestMeterLineReadings(meterIDs, timeInterval));
+		// The api expects the meter IDs to be a comma-separated list.
+		const stringifiedIDs = meterIDs.join(',');
+		return axios.get(`/api/readings/line/meters/${stringifiedIDs}`, {
 			params: { timeInterval: timeInterval.toString() }
-		}).then(response => dispatch(receiveLineReadings(dsIDs, timeInterval, response.data, dstype)));
+		}).then(response => dispatch(receiveMeterLineReadings(meterIDs, timeInterval, response.data)));
 	};
 }
 
 /**
- * Fetches readings for the line chart of all selected meterIDs if they are not already fetched or being fetched
+ * Fetch the data for the given groups over the given interval. Fully manages the Redux lifecycle.
+ * @param {[number]} groupIDs The IDs of the groups whose data should be fetched
+ * @param {TimeInterval} timeInterval The time interval over which data should be fetched
+ */
+function fetchGroupLineReadings(groupIDs, timeInterval) {
+	return dispatch => {
+		dispatch(requestGroupLineReadings(groupIDs, timeInterval));
+		// The api expects the group IDs to be a comma-separated list.
+		const stringifiedIDs = groupIDs.join(',');
+		return axios.get(`/api/readings/line/groups/${stringifiedIDs}`, {
+			params: { timeInterval: timeInterval.toString() }
+		}).then(response => dispatch(receiveGroupLineReadings(groupIDs, timeInterval, response.data)));
+	};
+}
+
+/**
+ * Fetches readings for the line chart of all selected meters and groups, if needed.
  * @param {TimeInterval} timeInterval The time interval to fetch readings for on the line chart
- * @return {*} An action to fetch the needed readings
+ * @return {*} Promise resolution of async actions to fetch the needed readings.
  */
 export function fetchNeededLineReadings(timeInterval) {
 	return (dispatch, getState) => {
 		const state = getState();
-		const meterIDsToFetchForLine = state.graph.selectedMeters.filter(id => shouldFetchLineReadings(state, id, timeInterval, DATA_TYPE_METER));
+
+		// Determine which meters are missing data for this time interval
+		const meterIDsToFetchForLine = state.graph.selectedMeters.filter(
+			id => shouldFetchMeterLineReadings(state, id, timeInterval)
+		);
 		if (meterIDsToFetchForLine.length > 0) {
-			return dispatch(fetchLineReadings(meterIDsToFetchForLine, timeInterval, DATA_TYPE_METER));
+			return dispatch(fetchMeterLineReadings(meterIDsToFetchForLine, timeInterval));
 		}
-		const groupIDsToFetchForLine = state.graph.selectedGroups.filter(id => shouldFetchLineReadings(state, id, timeInterval, DATA_TYPE_GROUP));
+
+		// Determine which groups are missing data for this time interval
+		const groupIDsToFetchForLine = state.graph.selectedGroups.filter(
+			id => shouldFetchGroupLineReadings(state, id, timeInterval)
+		);
 		if (groupIDsToFetchForLine.length > 0) {
-			return dispatch(fetchLineReadings(groupIDsToFetchForLine, timeInterval, DATA_TYPE_GROUP));
+			return dispatch(fetchGroupLineReadings(groupIDsToFetchForLine, timeInterval));
 		}
+
 		return Promise.resolve();
 	};
 }

--- a/src/client/app/components/DashboardComponent.jsx
+++ b/src/client/app/components/DashboardComponent.jsx
@@ -7,7 +7,7 @@ import { defaults } from 'react-chartjs-2';
 import UIOptionsContainer from '../containers/UIOptionsContainer';
 import LineChartContainer from '../containers/LineChartContainer';
 import BarChartContainer from '../containers/BarChartContainer';
-import CompareChartContainer from '../containers/CompareChartContainer'
+import CompareChartContainer from '../containers/CompareChartContainer';
 import { chartTypes } from '../reducers/graph';
 
 defaults.global.plugins.datalabels.display = false;
@@ -21,13 +21,11 @@ export default function DashboardComponent(props) {
 	};
 	let ChartToRender = '';
 	if (props.chartToRender === chartTypes.line) {
-		 ChartToRender = LineChartContainer;
-	}
-	else if (props.chartToRender === chartTypes.compare) {
+		ChartToRender = LineChartContainer;
+	} else if (props.chartToRender === chartTypes.compare) {
 		ChartToRender = CompareChartContainer;
-	}
-	else {
-		 ChartToRender = BarChartContainer;
+	} else {
+		ChartToRender = BarChartContainer;
 	}
 
 	return (

--- a/src/client/app/components/MultiSelectComponent.jsx
+++ b/src/client/app/components/MultiSelectComponent.jsx
@@ -51,12 +51,10 @@ MultiSelectComponent.propTypes = {
 	placeholder: PropTypes.string,
 	options: PropTypes.arrayOf(PropTypes.shape({
 		label: PropTypes.string.isRequired,
-		type: PropTypes.string.isRequired,
 		value: PropTypes.number,
 	})),
 	selectedOptions: PropTypes.arrayOf(PropTypes.shape({
 		label: PropTypes.string.isRequired,
-		type: PropTypes.string.isRequired,
 		value: PropTypes.number,
 	})),
 	onValuesChange: PropTypes.func.isRequired,

--- a/src/client/app/components/UIOptionsComponent.jsx
+++ b/src/client/app/components/UIOptionsComponent.jsx
@@ -43,7 +43,7 @@ export default class UIOptionsComponent extends React.Component {
 	 * @param {Object[]} selection An array of {label: string, value: {type: string, id: int}} representing the current selection
 	 */
 	handleMeterSelect(selection) {
-		this.props.selectMeters(selection);
+		this.props.selectMeters(selection.map(s => s.value));
 	}
 
 	/**
@@ -51,7 +51,7 @@ export default class UIOptionsComponent extends React.Component {
 	 * @param {Object[]} selection An array of {label: string, value: {type: string, id: int}} representing the current selection
 	 */
 	handleGroupSelect(selection) {
-		this.props.selectGroups(selection);
+		this.props.selectGroups(selection.map(s => s.value));
 	}
 
 	/**

--- a/src/client/app/components/UIOptionsComponent.jsx
+++ b/src/client/app/components/UIOptionsComponent.jsx
@@ -10,7 +10,6 @@ import '../styles/react-rangeslider-fix.css';
 import MultiSelectComponent from './MultiSelectComponent';
 import { chartTypes } from '../reducers/graph';
 import ExportContainer from '../containers/ExportContainer';
-import { DATA_TYPE_METER, DATA_TYPE_GROUP, metersFilterReduce, groupsFilterReduce } from '../utils/Datasources';
 
 export default class UIOptionsComponent extends React.Component {
 	/**
@@ -19,7 +18,8 @@ export default class UIOptionsComponent extends React.Component {
 	 */
 	constructor(props) {
 		super(props);
-		this.handleDatasourceSelect = this.handleDatasourceSelect.bind(this);
+		this.handleMeterSelect = this.handleMeterSelect.bind(this);
+		this.handleGroupSelect = this.handleGroupSelect.bind(this);
 		this.handleBarDurationChange = this.handleBarDurationChange.bind(this);
 		this.handleBarDurationChangeComplete = this.handleBarDurationChangeComplete.bind(this);
 		this.handleChangeChartType = this.handleChangeChartType.bind(this);
@@ -39,16 +39,19 @@ export default class UIOptionsComponent extends React.Component {
 	}
 
 	/**
-	 * Handles a change in data source selection
+	 * Handles a change in meter selection
 	 * @param {Object[]} selection An array of {label: string, value: {type: string, id: int}} representing the current selection
-	 * @param {String} type either DATA_TYPE_GROUPS or DATA_TYPE_METERS
 	 */
-	handleDatasourceSelect(selection, type) {
-		if (type === DATA_TYPE_METER) {
-			this.props.selectMeters(selection.reduce(metersFilterReduce, []));
-		} else if (type === DATA_TYPE_GROUP) {
-			this.props.selectGroups(selection.reduce(groupsFilterReduce, []));
-		}
+	handleMeterSelect(selection) {
+		this.props.selectMeters(selection);
+	}
+
+	/**
+	 * Handles a change in group selection
+	 * @param {Object[]} selection An array of {label: string, value: {type: string, id: int}} representing the current selection
+	 */
+	handleGroupSelect(selection) {
+		this.props.selectGroups(selection);
 	}
 
 	/**
@@ -93,12 +96,9 @@ export default class UIOptionsComponent extends React.Component {
 			width: '10px',
 		};
 
-		// Construct the options of the MultiSelect. Because value can be any JavaScript object, here we load it with both the type
-		// and ID. Currently this is useless, but when groups graphing is introduced it will be important
 		const meterSelectOptions = this.props.meters.map(meter => (
 			{
 				label: meter.name,
-				type: DATA_TYPE_METER,
 				value: meter.id
 			}
 		));
@@ -106,7 +106,6 @@ export default class UIOptionsComponent extends React.Component {
 		const groupSelectOptions = this.props.groups.map(group => (
 			{
 				label: group.name,
-				type: DATA_TYPE_GROUP,
 				value: group.id
 			}
 		));
@@ -118,7 +117,7 @@ export default class UIOptionsComponent extends React.Component {
 						options={groupSelectOptions}
 						selectedOptions={this.props.selectedGroups}
 						placeholder="Select Groups"
-						onValuesChange={s => this.handleDatasourceSelect(s, DATA_TYPE_GROUP)}
+						onValuesChange={s => this.handleGroupSelect(s)}
 					/>
 				</div>
 				<p style={labelStyle}>Meters:</p>
@@ -127,7 +126,7 @@ export default class UIOptionsComponent extends React.Component {
 						options={meterSelectOptions}
 						selectedOptions={this.props.selectedMeters}
 						placeholder="Select Meters"
-						onValuesChange={s => this.handleDatasourceSelect(s, DATA_TYPE_METER)}
+						onValuesChange={s => this.handleMeterSelect(s)}
 					/>
 				</div>
 				<p style={labelStyle}>Graph Type:</p>

--- a/src/client/app/containers/UIOptionsContainer.js
+++ b/src/client/app/containers/UIOptionsContainer.js
@@ -8,7 +8,6 @@ import UIOptionsComponent from '../components/UIOptionsComponent';
 import { changeSelectedMeters, changeSelectedGroups, changeBarDuration, changeChartToRender, changeBarStacking } from '../actions/graph';
 import { fetchMetersDetailsIfNeeded } from '../actions/meters';
 import { fetchGroupsDetailsIfNeeded } from '../actions/groups';
-import { DATA_TYPE_GROUP, DATA_TYPE_METER } from '../utils/Datasources';
 
 /**
  * @param {State} state
@@ -23,14 +22,12 @@ function mapStateToProps(state) {
 		selectedGroups: state.graph.selectedGroups.map(groupID => (
 			{
 				label: state.groups.byGroupID[groupID].name,
-				type: DATA_TYPE_GROUP,
 				value: groupID
 			}
 		)),
 		selectedMeters: state.graph.selectedMeters.map(meterID => (
 			{
 				label: state.meters.byMeterID[meterID].name,
-				type: DATA_TYPE_METER,
 				value: meterID
 			}
 		)),

--- a/src/client/app/reducers/barReadings.js
+++ b/src/client/app/reducers/barReadings.js
@@ -6,7 +6,6 @@
  */
 
 import * as readingsActions from '../actions/barReadings';
-import { DATA_TYPE_METER, DATA_TYPE_GROUP } from '../utils/Datasources';
 
 /**
  * @typedef {Object} State~BarReadings
@@ -27,72 +26,88 @@ const defaultState = {
  * @return {State~Readings}
  */
 export default function readings(state = defaultState, action) {
+	console.log(action);
 	switch (action.type) {
-		case readingsActions.REQUEST_BAR_READINGS: {
+		case readingsActions.REQUEST_METER_BAR_READINGS: {
 			const timeInterval = action.timeInterval;
 			const barDuration = action.barDuration;
 			const newState = {
 				...state,
 				byMeterID: {
 					...state.byMeterID
-				},
-				byGroupID: {
-					...state.byGroupID
 				}
 			};
 
-			if (action.dstype === DATA_TYPE_METER) {
-				for (const meterID of action.dsIDs) {
-					if (newState.byMeterID[meterID] === undefined) {
-						newState.byMeterID[meterID] = {};
-					}
-					if (newState.byMeterID[meterID][timeInterval] === undefined) {
-						newState.byMeterID[meterID][timeInterval] = {};
-					} else if (newState.byMeterID[meterID][timeInterval][barDuration] === undefined) {
-						newState.byMeterID[meterID][timeInterval][barDuration] = { isFetching: true };
-					} else {
-						newState.byMeterID[meterID][timeInterval][barDuration] = { ...newState.byMeterID[meterID][timeInterval][barDuration], isFetching: true };
-					}
+			for (const meterID of action.meterIDs) {
+				if (newState.byMeterID[meterID] === undefined) {
+					newState.byMeterID[meterID] = {};
 				}
-			} else if (action.dstype === DATA_TYPE_GROUP) {
-				for (const groupID of action.dsIDs) {
-					if (newState.byGroupID[groupID] === undefined) {
-						newState.byGroupID[groupID] = {};
-					}
-					if (newState.byGroupID[groupID][timeInterval] === undefined) {
-						newState.byGroupID[groupID][timeInterval] = {};
-					} else if (newState.byGroupID[groupID][timeInterval][barDuration] === undefined) {
-						newState.byGroupID[groupID][timeInterval][barDuration] = { isFetching: true };
-					} else {
-						newState.byGroupID[groupID][timeInterval][barDuration] = { ...newState.byGroupID[groupID][timeInterval][barDuration], isFetching: true };
-					}
+				if (newState.byMeterID[meterID][timeInterval] === undefined) {
+					newState.byMeterID[meterID][timeInterval] = {};
+				} else if (newState.byMeterID[meterID][timeInterval][barDuration] === undefined) {
+					newState.byMeterID[meterID][timeInterval][barDuration] = { isFetching: true };
+				} else {
+					newState.byMeterID[meterID][timeInterval][barDuration] = { ...newState.byMeterID[meterID][timeInterval][barDuration], isFetching: true };
 				}
 			}
 
 			return newState;
 		}
-		case readingsActions.RECEIVE_BAR_READINGS: {
+		case readingsActions.REQUEST_GROUP_BAR_READINGS: {
+			const timeInterval = action.timeInterval;
+			const barDuration = action.barDuration;
+			const newState = {
+				...state,
+				byGroupID: {
+					...state.byGroupID
+				}
+			};
+
+			for (const groupID of action.groupIDs) {
+				if (newState.byGroupID[groupID] === undefined) {
+					newState.byGroupID[groupID] = {};
+				}
+				if (newState.byGroupID[groupID][timeInterval] === undefined) {
+					newState.byGroupID[groupID][timeInterval] = {};
+				} else if (newState.byGroupID[groupID][timeInterval][barDuration] === undefined) {
+					newState.byGroupID[groupID][timeInterval][barDuration] = { isFetching: true };
+				} else {
+					newState.byGroupID[groupID][timeInterval][barDuration] = { ...newState.byGroupID[groupID][timeInterval][barDuration], isFetching: true };
+				}
+			}
+
+			return newState;
+		}
+		case readingsActions.RECEIVE_METER_BAR_READINGS: {
 			const timeInterval = action.timeInterval;
 			const barDuration = action.barDuration;
 			const newState = {
 				...state,
 				byMeterID: {
 					...state.byMeterID
-				},
+				}
+			};
+
+			for (const meterID of action.meterIDs) {
+				const readingsForMeter = action.readings[meterID];
+				newState.byMeterID[meterID][timeInterval][barDuration] = { isFetching: false, readings: readingsForMeter };
+			}
+
+			return newState;
+		}
+		case readingsActions.RECEIVE_GROUP_BAR_READINGS: {
+			const timeInterval = action.timeInterval;
+			const barDuration = action.barDuration;
+			const newState = {
+				...state,
 				byGroupID: {
 					...state.byGroupID
 				}
 			};
-			if (action.dstype === DATA_TYPE_METER) {
-				for (const meterID of action.dsIDs) {
-					const readingsForMeter = action.readings[meterID];
-					newState.byMeterID[meterID][timeInterval][barDuration] = { isFetching: false, readings: readingsForMeter };
-				}
-			} else if (action.dstype === DATA_TYPE_GROUP) {
-				for (const groupID of action.dsIDs) {
-					const readingsForGroup = action.readings[groupID];
-					newState.byGroupID[groupID][timeInterval][barDuration] = { isFetching: false, readings: readingsForGroup };
-				}
+
+			for (const groupID of action.groupIDs) {
+				const readingsForGroup = action.readings[groupID];
+				newState.byGroupID[groupID][timeInterval][barDuration] = { isFetching: false, readings: readingsForGroup };
 			}
 			return newState;
 		}

--- a/src/client/app/reducers/barReadings.js
+++ b/src/client/app/reducers/barReadings.js
@@ -26,7 +26,6 @@ const defaultState = {
  * @return {State~Readings}
  */
 export default function readings(state = defaultState, action) {
-	console.log(action);
 	switch (action.type) {
 		case readingsActions.REQUEST_METER_BAR_READINGS: {
 			const timeInterval = action.timeInterval;

--- a/src/client/app/reducers/lineReadings.js
+++ b/src/client/app/reducers/lineReadings.js
@@ -6,7 +6,6 @@
  */
 
 import * as readingsActions from '../actions/lineReadings';
-import { DATA_TYPE_METER, DATA_TYPE_GROUP } from '../utils/Datasources';
 
 /**
  * @typedef {Object} State~BarReadings
@@ -28,62 +27,73 @@ const defaultState = {
  */
 export default function readings(state = defaultState, action) {
 	switch (action.type) {
-		case readingsActions.REQUEST_LINE_READINGS: {
+		case readingsActions.REQUEST_METER_LINE_READINGS: {
 			const timeInterval = action.timeInterval;
 			const newState = {
 				...state,
 				byMeterID: {
 					...state.byMeterID
-				},
-				byGroupID: {
-					...state.byGroupID
 				}
 			};
-			if (action.dstype === DATA_TYPE_METER) {
-				for (const meterID of action.dsIDs) {
-					if (newState.byMeterID[meterID] === undefined) {
-						newState.byMeterID[meterID] = {};
-					} else if (newState.byMeterID[meterID][timeInterval] === undefined) {
-						newState.byMeterID[meterID][timeInterval] = { isFetching: true };
-					} else {
-						newState.byMeterID[meterID][timeInterval] = { ...newState.byMeterID[meterID][timeInterval], isFetching: true };
-					}
-				}
-			} else if (action.dstype === DATA_TYPE_GROUP) {
-				for (const groupID of action.dsIDs) {
-					if (newState.byGroupID[groupID] === undefined) {
-						newState.byGroupID[groupID] = {};
-					} else if (newState.byGroupID[groupID][timeInterval] === undefined) {
-						newState.byGroupID[groupID][timeInterval] = { isFetching: true };
-					} else {
-						newState.byGroupID[groupID][timeInterval] = { ...newState.byGroupID[groupID][timeInterval], isFetching: true };
-					}
+
+			for (const meterID of action.meterIDs) {
+				if (newState.byMeterID[meterID] === undefined) {
+					newState.byMeterID[meterID] = {};
+				} else if (newState.byMeterID[meterID][timeInterval] === undefined) {
+					newState.byMeterID[meterID][timeInterval] = { isFetching: true };
+				} else {
+					newState.byMeterID[meterID][timeInterval] = { ...newState.byMeterID[meterID][timeInterval], isFetching: true };
 				}
 			}
 			return newState;
 		}
-		case readingsActions.RECEIVE_LINE_READINGS: {
+		case readingsActions.REQUEST_GROUP_LINE_READINGS: {
 			const timeInterval = action.timeInterval;
 			const newState = {
 				...state,
-				byMeterID: {
-					...state.byMeterID,
-				},
 				byGroupID: {
 					...state.byGroupID
 				}
 			};
 
-			if (action.dstype === DATA_TYPE_METER) {
-				for (const meterID of action.dsIDs) {
-					const readingsForMeter = action.readings[meterID];
-					newState.byMeterID[meterID][timeInterval] = { isFetching: false, readings: readingsForMeter };
+			for (const groupID of action.groupIDs) {
+				if (newState.byGroupID[groupID] === undefined) {
+					newState.byGroupID[groupID] = {};
+				} else if (newState.byGroupID[groupID][timeInterval] === undefined) {
+					newState.byGroupID[groupID][timeInterval] = { isFetching: true };
+				} else {
+					newState.byGroupID[groupID][timeInterval] = { ...newState.byGroupID[groupID][timeInterval], isFetching: true };
 				}
-			} else if (action.dstype === DATA_TYPE_GROUP) {
-				for (const groupID of action.dsIDs) {
-					const readingsForGroup = action.readings[groupID];
-					newState.byGroupID[groupID][timeInterval] = { isFetching: false, readings: readingsForGroup };
+			}
+			return newState;
+		}
+		case readingsActions.RECEIVE_METER_LINE_READINGS: {
+			const timeInterval = action.timeInterval;
+			const newState = {
+				...state,
+				byMeterID: {
+					...state.byMeterID,
 				}
+			};
+
+			for (const meterID of action.meterIDs) {
+				const readingsForMeter = action.readings[meterID];
+				newState.byMeterID[meterID][timeInterval] = { isFetching: false, readings: readingsForMeter };
+			}
+			return newState;
+		}
+		case readingsActions.RECEIVE_GROUP_LINE_READINGS: {
+			const timeInterval = action.timeInterval;
+			const newState = {
+				...state,
+				byGroupID: {
+					...state.byGroupID
+				}
+			};
+
+			for (const groupID of action.groupIDs) {
+				const readingsForGroup = action.readings[groupID];
+				newState.byGroupID[groupID][timeInterval] = { isFetching: false, readings: readingsForGroup };
 			}
 
 			return newState;


### PR DESCRIPTION
Remove the condition-heavy datasource abstract actions in favor of twice as many datasource specific ones.

Compare is broken on this commit.