### PR TITLE
Rewrite DisplayComponent

### DIFF
--- a/src/client/app/components/ListDisplayComponent.jsx
+++ b/src/client/app/components/ListDisplayComponent.jsx
@@ -6,11 +6,29 @@
 import React from 'react';
 
 export default function ListDisplayComponent(props) {
+	const heightPx = (props.height || 8) * 18;
+	const listWrapperStyle = {
+		border: '1px solid #cccccc',
+		borderRadius: '2px',
+		minHeight: `${heightPx}px`,
+		maxHeight: `${heightPx}px`,
+		overflowY: 'scroll'
+	};
+
+	const listStyle = {
+		listStyleType: 'none',
+		paddingTop: '6px',
+		paddingBottom: '6px',
+		paddingLeft: '12px',
+		paddingRight: '12px',
+	};
 	return (
-		<select className="form-control" id="meterList" size={props.height || 8}>
-			{props.items.map((item, index) =>
-				<option key={index} disabled>{ item.toString() }</option>
-			)}
-		</select>
+		<div className="list-wrapper" style={listWrapperStyle} >
+			<ul id="meterList" style={listStyle} >
+				{props.items.map((item, index) =>
+					<li key={index} disabled>{ item.toString() }</li>
+				)}
+			</ul>
+		</div>
 	);
 }

--- a/src/client/app/components/ListDisplayComponent.jsx
+++ b/src/client/app/components/ListDisplayComponent.jsx
@@ -5,11 +5,11 @@
 
 import React from 'react';
 
-export default function DisplayComponent(props) {
+export default function ListDisplayComponent(props) {
 	return (
 		<select className="form-control" id="meterList" size={props.height || 8}>
 			{props.items.map((item, index) =>
-				<option key={index} disabled>{ item }</option>
+				<option key={index} disabled>{ item.toString() }</option>
 			)}
 		</select>
 	);

--- a/src/client/app/components/ListDisplayComponent.jsx
+++ b/src/client/app/components/ListDisplayComponent.jsx
@@ -6,7 +6,12 @@
 import React from 'react';
 
 export default function ListDisplayComponent(props) {
-	const heightPx = (props.height || 8) * 18;
+	const defaultHeightItems = 8;
+	const itemHeightPx = 18;
+	const heightPx = (props.height || defaultHeightItems) * itemHeightPx;
+
+	// The list wrapper is of a fixed height, with  grey border and a slight curve
+	// It imposes a scrollbar when there is too much content to display
 	const listWrapperStyle = {
 		border: '1px solid #cccccc',
 		borderRadius: '2px',
@@ -15,6 +20,7 @@ export default function ListDisplayComponent(props) {
 		overflowY: 'scroll'
 	};
 
+	// The list itself has no bullets and pads items as if they were in a <select>
 	const listStyle = {
 		listStyleType: 'none',
 		paddingTop: '6px',
@@ -22,12 +28,11 @@ export default function ListDisplayComponent(props) {
 		paddingLeft: '12px',
 		paddingRight: '12px',
 	};
+
 	return (
 		<div className="list-wrapper" style={listWrapperStyle} >
 			<ul id="meterList" style={listStyle} >
-				{props.items.map((item, index) =>
-					<li key={index} disabled>{ item.toString() }</li>
-				)}
+				{ props.items.map(item => <li>{ item.toString() }</li>) }
 			</ul>
 		</div>
 	);

--- a/src/client/app/components/groups/GroupViewComponent.jsx
+++ b/src/client/app/components/groups/GroupViewComponent.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { Button } from 'react-bootstrap';
-import DisplayComponent from '../DisplayComponent';
+import ListDisplayComponent from '../ListDisplayComponent';
 
 export default class GroupViewComponent extends React.Component {
 	constructor(props) {
@@ -38,11 +38,11 @@ export default class GroupViewComponent extends React.Component {
 				<div className="row">
 					<div className="col-xs-6">
 						<p style={boldStyle}>Child Meters:</p>
-						<DisplayComponent items={this.props.childMeters} />
+						<ListDisplayComponent items={this.props.childMeters} />
 					</div>
 					<div className="col-xs-6">
 						<p style={boldStyle}>Child Groups:</p>
-						<DisplayComponent items={this.props.childGroups} />
+						<ListDisplayComponent items={this.props.childGroups} />
 					</div>
 				</div>
 				<Button style={buttonPadding} bsStyle="default" onClick={this.handleEditGroup}>Edit group</Button>


### PR DESCRIPTION
First: `DisplayComponent` is a confusing name. It says nothing about _what_ is being displayed. The component is now `ListDisplayComponent`.

Second: Using a `<select>` is not worth it, and is actively bad in a lot of cases. I've re-written the component to just use a `<div>` wrapping a `<ul>` with some styling.