### PR TITLE
Add check to prevent error on error message after failed meter update

### DIFF
--- a/src/server/services/updateMeters.js
+++ b/src/server/services/updateMeters.js
@@ -24,7 +24,8 @@ async function updateAllMeters() {
 			metersToUpdate
 				.map(readMamacData)
 				.map(p => p.catch(err => {
-					log(`ERROR ON REQUEST TO ${err.options.uri}, ${err.message}`, 'error');
+					const uri = err.options !== undefined ? err.options.uri : '[NO URI AVAILABLE]';
+					log(`ERROR ON REQUEST TO ${uri}, ${err.message}`, 'error');
 					return null;
 				}))
 		), elem => elem !== null);

--- a/src/server/services/updateMeters.js
+++ b/src/server/services/updateMeters.js
@@ -24,7 +24,10 @@ async function updateAllMeters() {
 			metersToUpdate
 				.map(readMamacData)
 				.map(p => p.catch(err => {
-					const uri = err.options !== undefined ? err.options.uri : '[NO URI AVAILABLE]';
+					let uri = '[NO URI AVAILABLE]';
+					if (err.options !== undefined && err.options.uri !== undefined) {
+						uri = err.options.uri;
+					}
 					log(`ERROR ON REQUEST TO ${uri}, ${err.message}`, 'error');
 					return null;
 				}))


### PR DESCRIPTION
Check that `err.options` exists before attempting to print `err.options.uri`.
If `err.options` exists, but `err.options.uri` does not, it will show up as `undefined`. 
