### PR TITLE
Fixes compare flicker

### DIFF
--- a/src/client/app/components/MultiCompareChartComponent.jsx
+++ b/src/client/app/components/MultiCompareChartComponent.jsx
@@ -6,17 +6,20 @@ import React from 'react';
 import CompareChartContainer from '../containers/CompareChartContainer';
 
 export default function MultiCompareChartComponent(props) {
-	// Compute how much space should be used in the bootstrap grid system
-	let size;
-	if (props.selectedMeters.length + props.selectedGroups.length === 1) {
-		size = 12;
-	} else {
-		size = 6;
-	}
-
 	const centeredStyle = {
 		marginTop: '20%',
 		textAlign: 'center'
+	};
+
+	const flexContainerStyle = {
+		display: 'flex',
+		flexFlow: 'row wrap',
+		flexShrink: '3'
+	};
+
+	const flexChildStyle = {
+		width: '30%',
+		flexGrow: '1'
 	};
 
 	// Display a message if no meters are selected
@@ -31,14 +34,14 @@ export default function MultiCompareChartComponent(props) {
 	}
 
 	return (
-		<div className="row">
+		<div style={flexContainerStyle}>
 			{props.selectedMeters.map(meterID =>
-				<div className={`col-xs-${size}`} key={meterID}>
+				<div style={flexChildStyle} key={meterID}>
 					<CompareChartContainer key={meterID} id={meterID} isGroup={false} />
 				</div>
 			)}
 			{props.selectedGroups.map(groupID =>
-				<div className={`col-xs-${size}`} key={groupID}>
+				<div style={flexChildStyle} key={groupID}>
 					<CompareChartContainer key={groupID} id={groupID} isGroup />
 				</div>
 			)}

--- a/src/client/app/components/MultiCompareChartComponent.jsx
+++ b/src/client/app/components/MultiCompareChartComponent.jsx
@@ -10,10 +10,8 @@ export default function MultiCompareChartComponent(props) {
 	let size;
 	if (props.selectedMeters.length + props.selectedGroups.length === 1) {
 		size = 12;
-	} else if (props.selectedMeters.length + props.selectedGroups.length === 2) {
-		size = 6;
 	} else {
-		size = 4;
+		size = 6;
 	}
 
 	const centeredStyle = {

--- a/src/client/app/components/MultiCompareChartComponent.jsx
+++ b/src/client/app/components/MultiCompareChartComponent.jsx
@@ -6,6 +6,11 @@ import React from 'react';
 import CompareChartContainer from '../containers/CompareChartContainer';
 
 export default function MultiCompareChartComponent(props) {
+	let size = 0;
+	if (props.selectedMeters.length + props.selectedGroups.length < 3) {
+		size = 1;
+	}
+
 	const centeredStyle = {
 		marginTop: '20%',
 		textAlign: 'center'
@@ -14,12 +19,11 @@ export default function MultiCompareChartComponent(props) {
 	const flexContainerStyle = {
 		display: 'flex',
 		flexFlow: 'row wrap',
-		flexShrink: '3'
 	};
 
 	const flexChildStyle = {
 		width: '30%',
-		flexGrow: '1'
+		flexGrow: size
 	};
 
 	// Display a message if no meters are selected


### PR DESCRIPTION
Only displaying 2 graphs per line seems to fix the flickering. I will continue to look into fixing the flickering using a footer but for the sake of a timely feature rollout this should do the trick. 