### PR TITLE
Rewrite export naming logic.

### DIFF
--- a/src/client/app/components/ExportComponent.jsx
+++ b/src/client/app/components/ExportComponent.jsx
@@ -17,9 +17,9 @@ const ExportComponent = props => {
 
 		// Determine and format the first time in the dataset
 		let startTime = moment(compressedData[0].exportVals[0].x);
-		for (const i in compressedData) {
-			if (i.isInteger()) {
-				const startTimeOfDataset = moment(compressedData[i].exportVals[0].x);
+		for (const reading of compressedData) {
+			if (reading !== undefined) {
+				const startTimeOfDataset = moment(reading.exportVals[0].x);
 				if (startTime.isAfter(startTimeOfDataset)) {
 					startTime = startTimeOfDataset;
 				}
@@ -29,9 +29,9 @@ const ExportComponent = props => {
 
 		// Determine and format the last time in the dataset
 		let endTime = moment(compressedData[0].exportVals[compressedData[0].exportVals.length - 1].x);
-		for (const i in compressedData) {
-			if (i.isInteger()) {
-				const endTimeOfDataset = moment(compressedData[i].exportVals[compressedData[0].exportVals.length - 1].x);
+		for (const reading of compressedData) {
+			if (reading !== undefined) {
+				const endTimeOfDataset = moment(reading.exportVals[reading.exportVals.length - 1].x);
 				if (endTimeOfDataset.isAfter(endTime)) {
 					endTime = endTimeOfDataset;
 				}

--- a/src/client/app/components/ExportComponent.jsx
+++ b/src/client/app/components/ExportComponent.jsx
@@ -14,10 +14,33 @@ const ExportComponent = props => {
 	 */
 	const exportReading = () => {
 		const compressedData = props.exportVals.datasets;
-		let time = compressedData[0].exportVals[0].x;
-		const chart = compressedData[0].currentChart;
-		time = moment(time).format('ddddMMMDDYYYY');
-		const name = `oedExport${time}${chart}.csv`;
+
+		// Determine and format the first time in the dataset
+		let startTime = moment(compressedData[0].exportVals[0].x);
+		for (const i in compressedData) {
+			if (i.isInteger()) {
+				const startTimeOfDataset = moment(compressedData[i].exportVals[0].x);
+				if (startTime.isAfter(startTimeOfDataset)) {
+					startTime = startTimeOfDataset;
+				}
+			}
+		}
+		const startTimeString = startTime.format('YYYY-MMM-DD-dddd');
+
+		// Determine and format the last time in the dataset
+		let endTime = moment(compressedData[0].exportVals[compressedData[0].exportVals.length - 1].x);
+		for (const i in compressedData) {
+			if (i.isInteger()) {
+				const endTimeOfDataset = moment(compressedData[i].exportVals[compressedData[0].exportVals.length - 1].x);
+				if (endTimeOfDataset.isAfter(endTime)) {
+					endTime = endTimeOfDataset;
+				}
+			}
+		}
+		const endTimeString = endTime.format('YYYY-MMM-DD-dddd');
+
+		const chartName = compressedData[0].currentChart;
+		const name = `oedExport_${chartName}_${startTimeString}_to_${endTimeString}.csv`;
 		graphExport(compressedData,	name);
 	};
 	return (


### PR DESCRIPTION
This fixes the issue where export could use the wrong start date if the
first dataset did not start earliest.

Also fixes not including end date/time in export filenames.

Also fixes exported files not sorting well. Uses a
year-month-day-dayname format (e.g. 2017-11-21-Tuesday)

Full format is like `oedExport_line_2017-11-20-Monday_to_2017-11-21-Tuesday.csv`