### PR TITLE
License.txt is no longer ignored by .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ postgres-data
 
 # Text files
 *.txt
+!License.txt


### PR DESCRIPTION
We had the `License.txt` file ignored by the `*.txt` rule. This adds an exception for it.