### PR TITLE
Rewrite logging functionality

### DIFF
--- a/src/bin/www
+++ b/src/bin/www
@@ -10,7 +10,7 @@
 
 const app = require('../server/app');
 const http = require('http');
-const log = require('../server/log');
+const { log } = require('../server/log');
 
 const serverPort = require('../server/config').serverPort;
 
@@ -66,11 +66,11 @@ function onError(error) {
     // handle specific listen errors with friendly messages
 	switch (error.code) {
 	case 'EACCES':
-		log(`${bind} requires elevated privileges`, 'error', true);
+		log.error(`${bind} requires elevated privileges`);
 		process.exit(1);
 		break;
 	case 'EADDRINUSE':
-		log(`${bind} is already in use`, 'error', true);
+		log.error(`${bind} is already in use`);
 		process.exit(1);
 		break;
 	default:
@@ -87,7 +87,7 @@ function onListening() {
 	const bind = typeof addr === 'string'
         ? `pipe ${addr}`
         : `port ${addr.port}`;
-	log(`Listening on ${bind}`);
+	log.info(`Listening on ${bind}`);
 }
 
 

--- a/src/server/log.js
+++ b/src/server/log.js
@@ -73,13 +73,11 @@ class Logger {
 			}
 		}
 		if (this.logToFile) {
-			if (this.logToFile) {
-				fs.appendFile(logFile, messageToLog, err => {
-					if (err) {
-						console.error(`Failed to write to log file: ${err}`); // eslint-disable-line no-console
-					}
-				});
-			}
+			fs.appendFile(logFile, messageToLog, err => {
+				if (err) {
+					console.error(`Failed to write to log file: ${err}`); // eslint-disable-line no-console
+				}
+			});
 		}
 	}
 

--- a/src/server/log.js
+++ b/src/server/log.js
@@ -4,24 +4,131 @@
 
 const fs = require('fs');
 const logFile = require('./config').logFile;
+
 /**
- *
- * @param {String} message Message to log
- * @param {String} level Level of message: 'standard' or 'error'
- * @param {Boolean} logToFile Log to a file in addition to std out/error
+ * Represents the importance of a message to be logged
  */
-module.exports = (message, level = 'standard', logToFile = true) => {
-	const messageToLog = `[${level}@${new Date(Date.now()).toISOString()}] ${message}\n`;
-	if (level === 'error') {
-		console.error(messageToLog); // eslint-disable-line no-console
-	} else {
-		console.log(messageToLog); // eslint-disable-line no-console
+class LogLevel {
+	/**
+	 * Create a new LogLevel
+	 * @param name the name of this LogLevel
+	 * @param priority the priority of this LogLevel. Lower numbers are more important.
+	 */
+	constructor(name, priority) {
+		this.name = name;
+		this.priority = priority;
 	}
-	if (logToFile) {
-		fs.appendFile(logFile, messageToLog, err => {
-			if (err) {
-				console.error(`Failed to write to log file: ${err}`); // eslint-disable-line no-console
+}
+
+LogLevel.DEBUG = new LogLevel('DEBUG', 40);
+LogLevel.INFO = new LogLevel('INFO', 30);
+LogLevel.WARN = new LogLevel('WARN', 20);
+LogLevel.ERROR = new LogLevel('ERROR', 10);
+LogLevel.SILENT = new LogLevel('SILENT', Number.NEGATIVE_INFINITY);
+
+
+class Logger {
+
+	constructor(logFile) {
+		this.level = LogLevel.INFO;
+		this.logToFile = true;
+		this.logToConsole = true;
+		this.logFile = logFile;
+	}
+
+	/**
+	 * Log using a custom LogLevel.
+	 *
+	 * A convenience method such as info() or error() is likely to be more convenient than this.
+	 * @param {LogLevel} level the level to log at
+	 * @param {String} message the message to log
+	 * @param {Error?} error An optional error object to provide a stacktrace
+	 */
+	log(level, message, error = null) {
+		// Only log if given a high enough priority level.
+		if (level.priority > this.level.priority) {
+			return;
+		}
+		let messageToLog = `[${level.name}@${new Date(Date.now()).toISOString()}] ${message}\n`;
+
+		// Add a stacktrace to the message if one was provided
+		if (error !== null) {
+			if (error.stack) {
+				messageToLog += 'Stacktrace: \n' + error.stack + '\n'
+			} else {
+				// It's possible someone passed in an error that isn't actually an Error object
+				// because javascript lets you throw anything. In that case, the error won't have
+				// a stack.
+
+				// So we just try to convert whatever we got to a string and include it. It's better
+				// than nothing.
+				messageToLog += 'An error was included, but it was not an Error object:\n' + error
 			}
-		});
+		}
+		if (this.logToConsole) {
+			if (level.priority >= LogLevel.WARN.priority) {
+				console.error(messageToLog);
+			} else {
+				console.log(messageToLog);
+			}
+		}
+		if (this.logToFile) {
+			if (this.logToFile) {
+				fs.appendFile(logFile, messageToLog, err => {
+					if (err) {
+						console.error(`Failed to write to log file: ${err}`); // eslint-disable-line no-console
+					}
+				});
+			}
+		}
 	}
-};
+
+	/**
+	 * Log the given message at the DEBUG level
+	 * @param {String} message the message to log
+	 * @param {Error?} error An optional error object to include information about
+	 */
+	debug(message, error = null) {
+		this.log(LogLevel.DEBUG, message)
+	}
+
+	/**
+	 * Log the given message at the INFO level
+	 * @param {String} message the message to log
+	 * @param {Error?} error An optional error object to include information about
+	 */
+	info(message, error = null) {
+		this.log(LogLevel.INFO, message, error)
+	}
+
+	/**
+	 * Log the given message at the WARN level
+	 * @param {String} message the message to log
+	 * @param {Error?} error An optional error object to include information about
+	 */
+	warn(message, error = null) {
+		this.log(LogLevel.WARN, message, error)
+	}
+
+	/**
+	 * Log the given message at the ERROR level
+	 * @param {String} message the message to log
+	 * @param {Error?} error An optional error object to include information about
+	 */
+	error(message, error) {
+		this.log(LogLevel.ERROR, message, error)
+	}
+
+}
+
+
+const defaultLogger = new Logger(logFile);
+
+defaultLogger.logToFile = true;
+defaultLogger.logToConsole = true;
+defaultLogger.level = LogLevel.DEBUG;
+
+/**
+ * @type {{log: Logger, LogLevel: LogLevel}}
+ */
+module.exports = { log: defaultLogger, LogLevel };

--- a/src/server/routes/groups.js
+++ b/src/server/routes/groups.js
@@ -9,7 +9,7 @@ const validate = require('jsonschema').validate;
 const Group = require('../models/Group');
 const db = require('../models/database').db;
 const authenticator = require('./authenticator');
-const log = require('../log');
+const { log } = require('../log');
 
 const router = express.Router();
 
@@ -32,7 +32,7 @@ router.get('/', async (req, res) => {
 		const rows = await Group.getAll();
 		res.json(rows.map(formatToOnlyNameAndID));
 	} catch (err) {
-		log(`Error while preforming GET all groups query: ${err}`, 'error');
+		log.error(`Error while preforming GET all groups query: ${err}`, err);
 	}
 });
 
@@ -52,7 +52,7 @@ router.get('/children/:group_id', async (req, res) => {
 		]);
 		res.json({ meters, groups });
 	} catch (err) {
-		log(`Error while preforming GET on all immediate children (meters and groups) of specific group: ${err}`, 'error');
+		log.error(`Error while preforming GET on all immediate children (meters and groups) of specific group: ${err}`, err);
 	}
 });
 
@@ -61,7 +61,7 @@ router.get('/deep/groups/:group_id', async (req, res) => {
 		const [deepGroups] = await Group.getDeepGroupsByGroupID(req.params.group_id);
 		res.json({ deepGroups });
 	} catch (err) {
-		log(`Error while preforming GET on all deep child groups of specific group: ${err}`, 'error');
+		log.error(`Error while preforming GET on all deep child groups of specific group: ${err}`, err);
 	}
 });
 
@@ -70,7 +70,7 @@ router.get('/deep/meters/:group_id', async (req, res) => {
 		const [deepMeters] = await Group.getDeepMetersByGroupID(req.params.group_id);
 		res.json({ deepMeters });
 	} catch (err) {
-		log(`Error while preforming GET on all deep child meters of specific group: ${err}`, 'error');
+		log.error(`Error while preforming GET on all deep child meters of specific group: ${err}`, err);
 	}
 });
 
@@ -117,7 +117,7 @@ router.post('/create', async (req, res) => {
 			});
 			res.sendStatus(200);
 		} catch (err) {
-			log(`Error while inserting new group ${err}`, 'error');
+			log.error(`Error while inserting new group ${err}`, err);
 			res.sendStatus(500);
 		}
 	}
@@ -183,7 +183,7 @@ router.put('/edit', async (req, res) => {
 			});
 			res.sendStatus(200);
 		} catch (err) {
-			log(`Error while editing existing group: ${err}`, 'error');
+			log.error(`Error while editing existing group: ${err}`, err);
 			res.sendStatus(500);
 		}
 	}
@@ -206,7 +206,7 @@ router.post('/delete', async (req, res) => {
 			await Group.delete(req.body.id);
 			res.sendStatus(200);
 		} catch (err) {
-			log(`Error while deleting group ${err}`, 'error');
+			log.error(`Error while deleting group ${err}`, err);
 			res.sendStatus(500);
 		}
 	}

--- a/src/server/routes/meters.js
+++ b/src/server/routes/meters.js
@@ -4,7 +4,7 @@
 
 const express = require('express');
 const Meter = require('../models/Meter');
-const log = require('../log');
+const { log } = require('../log');
 
 const router = express.Router();
 
@@ -25,7 +25,7 @@ router.get('/', async (req, res) => {
 		const rows = await Meter.getAll();
 		res.json(rows.map(formatMeterForResponse));
 	} catch (err) {
-		log(`Error while performing GET all meters query: ${err}`, 'error');
+		log.error(`Error while performing GET all meters query: ${err}`, err);
 	}
 });
 
@@ -38,7 +38,7 @@ router.get('/:meter_id', async (req, res) => {
 		const meter = await Meter.getByID(req.params.meter_id);
 		res.json(formatMeterForResponse(meter));
 	} catch (err) {
-		log(`Error while performing GET specific meter by id query: ${err}`, 'error');
+		log.error(`Error while performing GET specific meter by id query: ${err}`, err);
 	}
 });
 

--- a/src/server/routes/preferences.js
+++ b/src/server/routes/preferences.js
@@ -4,7 +4,7 @@
 
 const express = require('express');
 const Preferences = require('../models/Preferences');
-const log = require('../log');
+const { log } = require('../log');
 const authentication = require('./authenticator');
 
 const router = express.Router();
@@ -17,7 +17,7 @@ router.get('/', async (req, res) => {
 		const rows = await Preferences.get();
 		res.json(rows);
 	} catch (err) {
-		log(`Error while performing GET all preferences query: ${err}`, 'error');
+		log.error(`Error while performing GET all preferences query: ${err}`, err);
 	}
 });
 
@@ -32,7 +32,7 @@ router.post('/', async (req, res) => {
 		const rows = await Preferences.update(req.body.preferences);
 		res.json(rows);
 	} catch (err) {
-		log(`Error while performing POST update preferences: ${err}`, 'error');
+		log.error(`Error while performing POST update preferences: ${err}`, err);
 	}
 });
 

--- a/src/server/routes/readings.js
+++ b/src/server/routes/readings.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 const moment = require('moment');
 const Reading = require('../models/Reading');
 const TimeInterval = require('../../common/TimeInterval');
-const log = require('../log');
+const { log } = require('../log');
 
 const router = express.Router();
 
@@ -39,7 +39,7 @@ router.get('/line/meters/:meter_ids', async (req, res) => {
 		const formattedCompressedReadings = _.mapValues(rawCompressedReadings, formatLineReadings);
 		res.json(formattedCompressedReadings);
 	} catch (err) {
-		log(`Error while performing GET readings for line with meters ${meterIDs} with time interval ${timeInterval}: ${err}`, 'error');
+		log.error(`Error while performing GET readings for line with meters ${meterIDs} with time interval ${timeInterval}: ${err}`, err);
 	}
 });
 
@@ -58,7 +58,7 @@ router.get('/line/groups/:group_ids', async (req, res) => {
 		const formattedCompressedReadings = _.mapValues(rawCompressedReadings, formatLineReadings);
 		res.json(formattedCompressedReadings);
 	} catch (err) {
-		log(`Error while performing GET readings for line with groups ${groupIDs} with time interval ${timeInterval}: ${err}`, 'error');
+		log.error(`Error while performing GET readings for line with groups ${groupIDs} with time interval ${timeInterval}: ${err}`, err);
 	}
 });
 
@@ -79,7 +79,7 @@ router.get('/bar/meters/:meter_ids', async (req, res) => {
 		const formattedBarchartReadings = _.mapValues(barchartReadings, formatBarReadings);
 		res.json(formattedBarchartReadings);
 	} catch (err) {
-		log(`Error while performing GET readings for bar with meters ${meterIDs} with time interval ${timeInterval}: ${err}`, 'error');
+		log.error(`Error while performing GET readings for bar with meters ${meterIDs} with time interval ${timeInterval}: ${err}`);
 	}
 });
 
@@ -101,7 +101,7 @@ router.get('/bar/groups/:group_ids', async (req, res) => {
 		const formattedBarchartReadings = _.mapValues(barchartReadings, formatBarReadings);
 		res.json(formattedBarchartReadings);
 	} catch (err) {
-		log(`Error while performing GET readings for bar with groups ${groupIDs} with time interval ${timeInterval}: ${err}`, 'error');
+		log.error(`Error while performing GET readings for bar with groups ${groupIDs} with time interval ${timeInterval}: ${err}`, err);
 	}
 });
 

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -4,7 +4,7 @@
 
 const express = require('express');
 const User = require('../models/User');
-const log = require('../log');
+const { log } = require('../log');
 
 const router = express.Router();
 
@@ -16,7 +16,7 @@ router.get('/', async (req, res) => {
 		const rows = await User.getAll();
 		res.json(rows);
 	} catch (err) {
-		log(`Error while performing GET all users query: ${err}`, 'error');
+		log.error(`Error while performing GET all users query: ${err}`, err);
 	}
 });
 
@@ -29,7 +29,7 @@ router.get('/:user_id', async (req, res) => {
 		const rows = await User.getByID(req.params.user_id);
 		res.json(rows);
 	} catch (err) {
-		log(`Error while performing GET specific user by id query: ${err}`, 'error');
+		log.error(`Error while performing GET specific user by id query: ${err}`, err);
 	}
 });
 

--- a/src/server/services/addMamacMeters.js
+++ b/src/server/services/addMamacMeters.js
@@ -12,7 +12,7 @@ const parseString = require('xml2js').parseString;
 const Meter = require('../models/Meter');
 const _ = require('lodash');
 const stopDB = require('../models/database').stopDB;
-const log = require('../log');
+const { log } = require('../log');
 
 const parseXMLPromisified = promisify(parseString);
 
@@ -63,9 +63,9 @@ async function insertMetersWrapper(filename) {
 	try {
 		const ips = await parseCSV(filename);
 		await insertMeters(ips);
-		log('Done inserting meters');
+		log.info('Done inserting meters');
 	} catch (err) {
-		log(`Error inserting meters: ${err}`, 'error');
+		log.error(`Error inserting meters: ${err}`, err);
 	} finally {
 		stopDB();
 	}
@@ -74,10 +74,10 @@ async function insertMetersWrapper(filename) {
 // The first two elements are 'node' and the name of the file. We only want arguments passed to it.
 const args = process.argv.slice(2);
 if (args.length !== 1) {
-	log(`Expected one argument (path to csv file of meter ips), but got ${args.length} instead`, 'error');
+	log.error(`Expected one argument (path to csv file of meter ips), but got ${args.length} instead`, 'error');
 } else {
 	const absolutePath = path.resolve(args[0]);
-	log(`Importing meters from ${absolutePath}`);
+	log.info(`Importing meters from ${absolutePath}`);
 	insertMetersWrapper(absolutePath);
 }
 

--- a/src/server/services/createDB.js
+++ b/src/server/services/createDB.js
@@ -3,14 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const { createSchema, pgp } = require('../models/database');
-const log = require('../log');
+const { log } = require('../log');
 
 (async function createSchemaWrapper() {
 	try {
 		await createSchema();
-		log('Schema created');
+		log.info('Schema created');
 	} catch (err) {
-		log(`Error creating schema: ${err}`, 'error');
+		log.error(`Error creating schema: ${err}`, err);
 	} finally {
 		pgp.end();
 	}

--- a/src/server/services/createUser.js
+++ b/src/server/services/createUser.js
@@ -7,7 +7,7 @@
 const readline = require('readline');
 const bcrypt = require('bcryptjs');
 const User = require('../models/User');
-const log = require('../log');
+const { log } = require('../log');
 
 const rl = readline.createInterface({
 	input: process.stdin,
@@ -39,7 +39,7 @@ function askPassword(email) {
 }
 
 function terminateReadline(message) {
-	if (message) log(message);
+	if (message) log.info(message);
 	rl.close();
 	process.exit(0);
 }

--- a/src/server/services/updateMamacMeters.js
+++ b/src/server/services/updateMamacMeters.js
@@ -8,16 +8,16 @@ const Meter = require('../models/Meter');
 const readMamacData = require('./readMamacData');
 const updateMeters = require('./updateMeters');
 const stopDB = require('../models/database').stopDB;
-const log = require('../log');
+const { log } = require('../log');
 
 async function updateMamacMeters() {
-	log('Fetching new Mamac meter data');
+	log.info('Fetching new Mamac meter data');
 	try {
 		const allMeters = await Meter.getAll();
 		const metersToUpdate = allMeters.filter(m => m.enabled && m.type === Meter.type.MAMAC);
 		await updateMeters(readMamacData, metersToUpdate);
 	} catch (err) {
-		log(`Error fetching Mamac meter data: ${err}`, 'error');
+		log.error(`Error fetching Mamac meter data: ${err}`, err);
 	} finally {
 		stopDB();
 	}

--- a/src/server/services/updateMeters.js
+++ b/src/server/services/updateMeters.js
@@ -5,7 +5,7 @@
 const _ = require('lodash');
 const Reading = require('../models/Reading');
 
-const log = require('../log');
+const { log } = require('../log');
 
 /**
  * Uses the provided dataReader function to poll the provided meters for new readings,
@@ -16,7 +16,7 @@ const log = require('../log');
  */
 async function updateAllMeters(dataReader, metersToUpdate) {
 	const time = new Date();
-	log(`Getting meter data ${time.toISOString()}`);
+	log.info(`Getting meter data ${time.toISOString()}`);
 	try {
 		// Do all the network requests in parallel, then throw out any requests that fail after logging the errors.
 		const readingInsertBatches = _.filter(await Promise.all(
@@ -27,7 +27,7 @@ async function updateAllMeters(dataReader, metersToUpdate) {
 					if (err.options !== undefined && err.options.uri !== undefined) {
 						uri = err.options.uri;
 					}
-					log(`ERROR ON REQUEST TO ${uri}, ${err.message}`, 'error');
+					log.error(`ERROR ON REQUEST TO ${uri}, ${err.message}`, err);
 					return null;
 				}))
 		), elem => elem !== null);
@@ -35,9 +35,9 @@ async function updateAllMeters(dataReader, metersToUpdate) {
 		// Flatten the batches (an array of arrays) into a single array.
 		const allReadingsToInsert = [].concat(...readingInsertBatches);
 		await Reading.insertOrUpdateAll(allReadingsToInsert);
-		log('Update finished');
+		log.info('Update finished');
 	} catch (err) {
-		log(`Error updating all meters: ${err}`, 'error');
+		log.error(`Error updating all meters: ${err}`, err);
 	}
 }
 

--- a/src/server/test/db/common.js
+++ b/src/server/test/db/common.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const config = require('../../config');
+const { log, LogLevel } = require('../../log');
 
 // This swaps us to the test database for running test.
 // TODO: Fix up configuration between different environments. Maybe use the config npm package.
@@ -14,6 +15,10 @@ config.database = {
 	host: process.env.OED_DB_TEST_HOST || process.env.OED_DB_HOST,
 	port: process.env.OED_DB_TEST_PORT || process.env.OED_DB_PORT
 };
+
+// Disable logging during tests.
+// TODO: Move logging disabling to a better place.
+log.level = LogLevel.SILENT;
 
 const { db, createSchema } = require('../../models/database');
 

--- a/src/server/version.js
+++ b/src/server/version.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const pkgJson = require('../../package.json');
-const log = require('./log');
+const { log } = require('./log');
 
 /**
  * Creates a new OEDVersion object, which contains a major, minor, and patch release level.
@@ -12,7 +12,7 @@ const log = require('./log');
 function OEDVersion() {
 	const versionParts = pkgJson.version.split('.');
 	if (versionParts.length !== 3) {
-		log(`package.json version string "${pkgJson.version}" is not in semver x.y.z format`, 'error', true);
+		log.error(`package.json version string "${pkgJson.version}" is not in semver x.y.z format`);
 	}
 	this.major = versionParts[0];
 	this.minor = versionParts[1];


### PR DESCRIPTION
Rewrites our logging implementation to be a bit more robust and to support multiple log levels.

The api changes are as follows: 
 - Instead of `const log = require('path/to/log');`, you will need to use `const { log } = require('path/to/log');`. This is because `log.js` now exports both a logger instance and a `LogLevel` class representing logging levels.
- Instead of calling `log(message)`, you call one of `log.debug()`, `log.info()`, `log.warn()`, or `log.error()` with your message. You can also include an `Error` object if you want to log a stacktrace.
- All logging calls do not necessarily get logged. The logger can have its level set, and it ignores log messages from lower priority levels. It's currently set to log all messages, except during testing, where it logs nothing.
- To configure the logger, set fields on it. It has two boolean fields: `logToFile` and `logToConsole`, which do what you'd expect, and one `LogLevel` field, `level`, that indicates the weakest log level that the logger will actually log, instead of discarding. You can get the `LogLevel` instances that the logger knows about by default as static fields on the `LogLevel` classs. There's one for each of `DEBUG, INFO, WARN, ERROR, SILENT`. `SILENT` should be used to suppress all logging.