### PR TITLE
Fix chart hotlinking, prevents admin preferences from taking precedence

### DIFF
--- a/src/client/app/actions/admin.js
+++ b/src/client/app/actions/admin.js
@@ -45,18 +45,20 @@ function markPreferencesNotSubmitted() {
 }
 
 function fetchPreferences() {
-	return dispatch => {
+	return (dispatch, getState) => {
 		dispatch(requestPreferences());
 		return axios.get('/api/preferences')
 			.then(response => {
 				dispatch(receivePreferences(response.data));
-				dispatch((dispatch2, getState) => {
-					const state = getState();
-					dispatch2(changeChartToRender(state.admin.defaultChartToRender));
-					if (response.data.defaultBarStacking !== state.graph.barStacking) {
-						dispatch2(changeBarStacking());
-					}
-				});
+				if (!getState().graph.hotlinked) {
+					dispatch((dispatch2, getState2) => {
+						const state = getState2();
+						dispatch2(changeChartToRender(state.admin.defaultChartToRender));
+						if (response.data.defaultBarStacking !== state.graph.barStacking) {
+							dispatch2(changeBarStacking());
+						}
+					});
+				}
 			});
 	};
 }
@@ -86,7 +88,7 @@ function submitPreferences() {
 }
 
 function shouldFetchPreferenceData(state) {
-	return !state.admin.isFetching && !state.graph.hotlinked;
+	return !state.admin.isFetching;
 }
 
 function shouldSubmitPreferenceData(state) {

--- a/src/client/app/actions/admin.js
+++ b/src/client/app/actions/admin.js
@@ -86,7 +86,7 @@ function submitPreferences() {
 }
 
 function shouldFetchPreferenceData(state) {
-	return !state.admin.isFetching;
+	return !state.admin.isFetching && !state.graph.hotlinked;
 }
 
 function shouldSubmitPreferenceData(state) {

--- a/src/client/app/actions/graph.js
+++ b/src/client/app/actions/graph.js
@@ -17,7 +17,12 @@ export const CHANGE_BAR_STACKING = 'CHANGE_BAR_STACKING';
 export const CHANGE_GRAPH_ZOOM = 'CHANGE_GRAPH_ZOOM';
 export const UPDATE_COMPARE_INTERVAL = 'UPDATE_COMPARE_INTERVAL';
 export const UPDATE_COMPARE_DURATION = 'UPDATE_COMPARE_DURATION';
+export const TOGGLE_HOTLINKED = 'TOGGLE_HOTLINKED';
 
+
+function toggleHotlinked() {
+	return { type: 'TOGGLE_HOTLINKED' };
+}
 
 /**
  * @param {string} chartType is one of chartTypes
@@ -124,7 +129,7 @@ export function changeGraphZoomIfNeeded(timeInterval) {
  * @returns {function(*)}
  */
 export function changeOptionsFromLink(options) {
-	const dispatchFirst = [];
+	const dispatchFirst = [toggleHotlinked()];
 	const dispatchSecond = [];
 	if (options.meterIDs) {
 		dispatchFirst.push(fetchMetersDetailsIfNeeded());

--- a/src/client/app/components/DashboardComponent.jsx
+++ b/src/client/app/components/DashboardComponent.jsx
@@ -15,26 +15,32 @@ defaults.global.plugins.datalabels.display = false;
 /**
  * React component that controls the dashboard
  */
-export default function DashboardComponent(props) {
-	let ChartToRender = '';
-	if (props.chartToRender === chartTypes.line) {
-		ChartToRender = LineChartContainer;
-	} else if (props.chartToRender === chartTypes.compare) {
-		ChartToRender = MultiCompareChartContainer;
-	} else {
-		ChartToRender = BarChartContainer;
+export default class DashboardComponent extends React.Component {
+	componentWillMount() {
+		this.props.fetchPreferencesIfNeeded();
 	}
 
-	return (
-		<div className="container-fluid">
-			<div className="row">
-				<div className="col-2 d-none d-lg-block">
-					<UIOptionsContainer />
-				</div>
-				<div className="col-12 col-lg-10">
-					<ChartToRender />
+	render() {
+		let ChartToRender = '';
+		if (this.props.chartToRender === chartTypes.line) {
+			ChartToRender = LineChartContainer;
+		} else if (this.props.chartToRender === chartTypes.compare) {
+			ChartToRender = MultiCompareChartContainer;
+		} else {
+			ChartToRender = BarChartContainer;
+		}
+
+		return (
+			<div className="container-fluid">
+				<div className="row">
+					<div className="col-2 d-none d-lg-block">
+						<UIOptionsContainer />
+					</div>
+					<div className="col-12 col-lg-10">
+						<ChartToRender />
+					</div>
 				</div>
 			</div>
-		</div>
-	);
+		);
+	}
 }

--- a/src/client/app/components/InitializationComponent.jsx
+++ b/src/client/app/components/InitializationComponent.jsx
@@ -9,7 +9,6 @@ import NotificationSystem from 'react-notification-system';
 export default class InitializationComponent extends React.Component {
 	componentWillMount() {
 		this.props.fetchMetersDetailsIfNeeded();
-		this.props.fetchPreferencesIfNeeded();
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -17,11 +16,6 @@ export default class InitializationComponent extends React.Component {
 			this.notificationSystem.addNotification(nextProps.notification);
 			this.props.clearNotifications();
 		}
-	}
-
-	shouldComponentUpdate() {
-		// To ignore warning: [react-router] You cannot change 'Router routes'; it will be ignored
-		return false;
 	}
 
 	render() {

--- a/src/client/app/components/RouteComponent.jsx
+++ b/src/client/app/components/RouteComponent.jsx
@@ -22,6 +22,11 @@ export default class RouteComponent extends React.Component {
 		this.linkToGraph = this.linkToGraph.bind(this);
 	}
 
+	shouldComponentUpdate() {
+		// To ignore warning: [react-router] You cannot change 'Router routes'; it will be ignored
+		return false;
+	}
+
 	/**
 	 * Middleware function that requires proper authentication for a page route
 	 * @param nextState The next state of the router
@@ -82,7 +87,9 @@ export default class RouteComponent extends React.Component {
 							throw new Error('Unknown query parameter');
 					}
 				}
-				this.props.changeOptionsFromLink(options);
+				if (Object.keys(options).length > 0) {
+					this.props.changeOptionsFromLink(options);
+				}
 			} catch (err) {
 				showErrorNotification('Failed to link to graph');
 			}

--- a/src/client/app/containers/ChartDataSelectContainer.js
+++ b/src/client/app/containers/ChartDataSelectContainer.js
@@ -21,13 +21,13 @@ function mapStateToProps(state) {
 	// Map information about the currently selected meters into a format the component can display.
 	const selectedGroups = state.graph.selectedGroups.map(groupID => (
 		{
-			label: state.groups.byGroupID[groupID].name,
+			label: state.groups.byGroupID[groupID] ? state.groups.byGroupID[groupID].name : '',
 			value: groupID
 		}
 	));
 	const selectedMeters = state.graph.selectedMeters.map(meterID => (
 		{
-			label: state.meters.byMeterID[meterID].name,
+			label: state.meters.byMeterID[meterID] ? state.meters.byMeterID[meterID].name : '',
 			value: meterID
 		}
 	));

--- a/src/client/app/containers/CompareChartContainer.js
+++ b/src/client/app/containers/CompareChartContainer.js
@@ -73,7 +73,7 @@ function mapStateToProps(state, ownProps) {
 	if (readingsData !== undefined && !readingsData.isFetching) {
 		if (readingsData.readings.length < 7) {
 			soFar = moment().hour();
-		} else if (readingsData.readings.length < 14) {
+		} else if (readingsData.readings.length <= 14) {
 			soFar = moment().diff(moment().startOf('week'), 'days');
 		} else {
 			// 21 to differentiate from week case, week case never larger than 14

--- a/src/client/app/containers/InitializationContainer.js
+++ b/src/client/app/containers/InitializationContainer.js
@@ -8,9 +8,6 @@ import { connect } from 'react-redux';
 import InitializationComponent from '../components/InitializationComponent';
 import { clearNotifications } from '../actions/notifications';
 import { fetchMetersDetailsIfNeeded } from '../actions/meters';
-import { changeOptionsFromLink } from '../actions/graph';
-import { fetchPreferencesIfNeeded } from '../actions/admin';
-
 
 function mapStateToProps(state) {
 	return {
@@ -21,9 +18,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
 	return {
 		clearNotifications: () => dispatch(clearNotifications()),
-		fetchMetersDetailsIfNeeded: () => dispatch(fetchMetersDetailsIfNeeded()),
-		fetchPreferencesIfNeeded: () => dispatch(fetchPreferencesIfNeeded()),
-		changeOptionsFromLink: options => dispatch(changeOptionsFromLink(options))
+		fetchMetersDetailsIfNeeded: () => dispatch(fetchMetersDetailsIfNeeded())
 	};
 }
 

--- a/src/client/app/containers/RouteContainer.js
+++ b/src/client/app/containers/RouteContainer.js
@@ -3,19 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { connect } from 'react-redux';
-import DashboardComponent from '../components/DashboardComponent';
-import { fetchPreferencesIfNeeded } from '../actions/admin';
+import RouteComponent from '../components/RouteComponent';
+import { changeOptionsFromLink } from '../actions/graph';
 
 function mapStateToProps(state) {
 	return {
-		chartToRender: state.graph.chartToRender,
+		barStacking: state.graph.barStacking
 	};
 }
+
 
 function mapDispatchToProps(dispatch) {
 	return {
-		fetchPreferencesIfNeeded: () => dispatch(fetchPreferencesIfNeeded())
+		changeOptionsFromLink: options => dispatch(changeOptionsFromLink(options))
 	};
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DashboardComponent);
+export default connect(mapStateToProps, mapDispatchToProps)(RouteComponent);

--- a/src/client/app/containers/UIOptionsContainer.js
+++ b/src/client/app/containers/UIOptionsContainer.js
@@ -22,7 +22,7 @@ function mapStateToProps(state) {
 		meters: sortedMeters,
 		selectedMeters: state.graph.selectedMeters.map(meterID => (
 			{
-				label: state.meters.byMeterID[meterID].name,
+				label: state.meters.byMeterID[meterID] ? state.meters.byMeterID[meterID].name : '',
 				value: meterID
 			}
 		)),

--- a/src/client/app/index.jsx
+++ b/src/client/app/index.jsx
@@ -8,7 +8,7 @@ import { render } from 'react-dom';
 import { createStore, applyMiddleware, compose } from 'redux';
 import { Provider } from 'react-redux';
 import 'bootstrap/dist/css/bootstrap.css';
-import RouteComponent from './components/RouteComponent';
+import RouteContainer from './containers/RouteContainer';
 import reducers from './reducers';
 import './styles/index.css';
 
@@ -25,7 +25,7 @@ const store = createStore(reducers, composeEnhancers(applyMiddleware(thunkMiddle
 // Provides the Redux store to all child components
 render(
 	<Provider store={store}>
-		<RouteComponent />
+		<RouteContainer />
 	</Provider>,
 	document.getElementById('root')
 );

--- a/src/client/app/reducers/graph.js
+++ b/src/client/app/reducers/graph.js
@@ -25,7 +25,8 @@ const defaultState = {
 	compareTimeInterval: new TimeInterval(moment().startOf('week').subtract(7, 'days'), moment()).toString(),
 	compareDuration: moment.duration(1, 'days'),
 	chartToRender: chartTypes.line,
-	barStacking: false
+	barStacking: false,
+	hotlinked: false
 };
 
 /**
@@ -35,6 +36,11 @@ const defaultState = {
  */
 export default function graph(state = defaultState, action) {
 	switch (action.type) {
+		case graphActions.TOGGLE_HOTLINKED:
+			return {
+				...state,
+				hotlinked: !state.hotlinked
+			};
 		case graphActions.UPDATE_SELECTED_METERS:
 			return {
 				...state,


### PR DESCRIPTION
This PR adds back the RouteContainer, which was accidentally removed a few PRs ago. This also adds a redux boolean in state.graph called hotlinked that tracks if a graph was hotlinked. This prevents admin preferences from overriding a linked graph.