### PR TITLE
Revert "Fixed wrong properties in validation"

### DIFF
--- a/src/server/routes/groups.js
+++ b/src/server/routes/groups.js
@@ -86,7 +86,7 @@ router.get('/deep/meters/:group_id', async (req, res) => {
 		maxProperties: 1,
 		required: ['group_id'],
 		properties: {
-			group_id: {
+			meter_id: {
 				type: 'number'
 			}
 		}

--- a/src/server/routes/meters.js
+++ b/src/server/routes/meters.js
@@ -40,7 +40,7 @@ router.get('/:meter_id', async (req, res) => {
 		maxProperties: 1,
 		required: ['meter_id'],
 		properties: {
-			meter_id: {
+			group_id: {
 				type: 'number'
 			}
 		}

--- a/src/server/routes/readings.js
+++ b/src/server/routes/readings.js
@@ -37,7 +37,7 @@ router.get('/line/meters/:meter_ids', async (req, res) => {
 		maxProperties: 1,
 		required: ['meter_ids'],
 		properties: {
-			meter_ids: {
+			group_id: {
 				type: 'number'
 			}
 		}
@@ -81,7 +81,7 @@ router.get('/line/groups/:group_ids', async (req, res) => {
 		maxProperties: 1,
 		required: ['group_ids'],
 		properties: {
-			group_ids: {
+			group_id: {
 				type: 'number'
 			}
 		}
@@ -126,7 +126,7 @@ router.get('/bar/meters/:meter_ids', async (req, res) => {
 		maxProperties: 1,
 		required: ['meter_ids'],
 		properties: {
-			meter_ids: {
+			group_id: {
 				type: 'number'
 			}
 		}
@@ -175,7 +175,7 @@ router.get('/bar/groups/:group_ids', async (req, res) => {
 		maxProperties: 1,
 		required: ['group_ids'],
 		properties: {
-			group_ids: {
+			group_id: {
 				type: 'number'
 			}
 		}

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -31,7 +31,7 @@ router.get('/:user_id', async (req, res) => {
 		maxProperties: 1,
 		required: ['user_id'],
 		properties: {
-			user_id: {
+			group_id: {
 				type: 'id'
 			}
 		}


### PR DESCRIPTION
Reverts OpenEnergyDashboard/OED#317

Some validation was wrong but hidden, and pr #317 makes it visible, causing routes to break.