### PR TITLE
Add a .dockerignore file to exclude unneeded files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.idea
+.editorconfig
+.env
+.git
+postgres-data

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
+# *
+# * This Source Code Form is subject to the terms of the Mozilla Public
+# * License, v. 2.0. If a copy of the MPL was not distributed with this
+# * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# *
+
 .idea
 .editorconfig
 .env


### PR DESCRIPTION
We were including database files and other unneeded things in our docker
builds before. This stops that.