### PR TITLE
Add robust meter diagnosis tools

### DIFF
--- a/src/scripts/checkMeters.sh
+++ b/src/scripts/checkMeters.sh
@@ -13,11 +13,11 @@ read line
 while read line
 do
 	echo "$line:"
-	curl -s -m 1 "http://$line" > /dev/null
+	curl -s -m 5 "http://$line" > /dev/null
 	success=$?
 	if [ "$success" == "0" ]; then
-		echo "	GOOD"
+		echo "	Request succeeds."
 	else
-		echo "	NO GOOD $success"
+		echo "	Request fails with code $success."
 	fi
 done

--- a/src/scripts/checkMeters.sh
+++ b/src/scripts/checkMeters.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# *
+# * This Source Code Form is subject to the terms of the Mozilla Public
+# * License, v. 2.0. If a copy of the MPL was not distributed with this
+# * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# *
+
+USAGE="Usage: checkMeters.sh Takes a CSV file of meter IP addresses on standard in. Use as cat ips.csv | checkMeters.sh or checkMeters.sh < ips.csv"
+
+# Throw out header
+read line
+
+while read line
+do
+	echo "$line:"
+	curl -s -m 1 "http://$line" > /dev/null
+	success=$?
+	if [ "$success" == "0" ]; then
+		echo "	GOOD"
+	else
+		echo "	NO GOOD $success"
+	fi
+done

--- a/src/server/services/readMamacData.js
+++ b/src/server/services/readMamacData.js
@@ -42,13 +42,25 @@ async function readMamacData(meter) {
 	return parsedReadings.map(raw => {
 		const reading = Math.round(Number(raw[0]));
 		if (isNaN(reading)) {
-			throw new Error(`Meter reading ${reading} parses to NaN for meter named ${meter.name} with id ${meter.id}`);
+			const e = Error(`Meter reading ${reading} parses to NaN for meter named ${meter.name} with id ${meter.id}`);
+			e.options = {ipAddress: meter.ipAddress};
+			throw e;
+		}
+		let startTs;
+		let endTs;
+		try {
+			startTs = parseTimestamp(raw[1]).subtract(1, 'hours').toDate();
+			endTs = parseTimestamp(raw[1]).toDate();
+		} catch (re) {
+			const e = Error(re.message);
+			e.options = {ipAddress: meter.ipAddress};
+			throw e;
 		}
 		return new Reading(
 				meter.id,
 				reading,
-				parseTimestamp(raw[1]).subtract(1, 'hours').toDate(),
-				parseTimestamp(raw[1]).toDate()
+				startTs,
+				endTs
 		);
 	});
 }

--- a/src/server/services/updateMeters.js
+++ b/src/server/services/updateMeters.js
@@ -21,15 +21,15 @@ async function updateAllMeters(dataReader, metersToUpdate) {
 		// Do all the network requests in parallel, then throw out any requests that fail after logging the errors.
 		const readingInsertBatches = _.filter(await Promise.all(
 			metersToUpdate
-				.map(dataReader)
-				.map(p => p.catch(err => {
-					let uri = '[NO URI AVAILABLE]';
-					if (err.options !== undefined && err.options.uri !== undefined) {
-						uri = err.options.uri;
-					}
-					log.error(`ERROR ON REQUEST TO ${uri}, ${err.message}`, err);
-					return null;
-				}))
+			.map(dataReader)
+			.map(p => p.catch(err => {
+				let ipAddress = '[NO IP ADDRESS AVAILABLE]';
+				if (err.options !== undefined && err.options.ipAddress !== undefined) {
+					ipAddress = err.options.ipAddress;
+				}
+				log.error(`ERROR ON REQUEST TO METER ${ipAddress}, ${err.message}`, err);
+				return null;
+			}))
 		), elem => elem !== null);
 
 		// Flatten the batches (an array of arrays) into a single array.


### PR DESCRIPTION
These commits fix the updateMamacMeters error messages and add a script to check if meters are up, based on a CSV file of IPs (like ips.csv that we use for addMamacMeters).