### PR TITLE
Migration script for 0.4.0

### DIFF
--- a/src/server/migrations/0.3.0-0.4.0/index.js
+++ b/src/server/migrations/0.3.0-0.4.0/index.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const database = require('../../models/database');
+
+const sqlFile = database.sqlFile;
+
+module.exports = {
+	fromVersion: '0.3.0',
+	toVersion: '0.4.0',
+	up: async db => {
+		// migration here
+		await db.none(sqlFile('preferences/create_language_types_enum.sql'));
+		await db.none(sqlFile('preferences/add_language_column.sql'));
+	}
+};

--- a/src/server/migrations/0.3.0-0.4.0/index.js
+++ b/src/server/migrations/0.3.0-0.4.0/index.js
@@ -3,15 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const database = require('../../models/database');
-
+const { log } = require('../../log');
 const sqlFile = database.sqlFile;
 
 module.exports = {
 	fromVersion: '0.3.0',
 	toVersion: '0.4.0',
 	up: async db => {
-		// migration here
-		await db.none(sqlFile('preferences/create_language_types_enum.sql'));
-		await db.none(sqlFile('preferences/add_language_column.sql'));
+		try {
+			// await db.none(sqlFile('../migrations/0.3.0-0.4.0/sql/preferences/create_language_types_enum.sql'));
+			await db.none(sqlFile('../migrations/0.3.0-0.4.0/sql/preferences/add_lansguage_column.sql'));
+		} catch (err) {
+			throw new Error('Cannot migrate');
+		}
 	}
 };

--- a/src/server/migrations/0.3.0-0.4.0/index.js
+++ b/src/server/migrations/0.3.0-0.4.0/index.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const database = require('../../models/database');
-const { log } = require('../../log');
 const sqlFile = database.sqlFile;
 
 module.exports = {
@@ -11,10 +10,11 @@ module.exports = {
 	toVersion: '0.4.0',
 	up: async db => {
 		try {
-			// await db.none(sqlFile('../migrations/0.3.0-0.4.0/sql/preferences/create_language_types_enum.sql'));
-			await db.none(sqlFile('../migrations/0.3.0-0.4.0/sql/preferences/add_lansguage_column.sql'));
+			await db.none(sqlFile('../migrations/0.3.0-0.4.0/sql/preferences/create_language_types_enum.sql'));
+			await db.none(sqlFile('../migrations/0.3.0-0.4.0/sql/preferences/add_language_column.sql'));
+			await db.none(sqlFile('../migrations/0.3.0-0.4.0/sql/logemail/create_log_table.sql'));
 		} catch (err) {
-			throw new Error('Cannot migrate');
+			throw new Error('Error while migrating each sql file');
 		}
 	}
 };

--- a/src/server/migrations/0.3.0-0.4.0/sql/logemail/create_log_table.sql
+++ b/src/server/migrations/0.3.0-0.4.0/sql/logemail/create_log_table.sql
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CREATE TABLE IF NOT EXISTS logemail (
+	id SERIAL PRIMARY KEY,
+	error_message TEXT NOT NULL
+);

--- a/src/server/migrations/0.3.0-0.4.0/sql/preferences/add_language_column.sql
+++ b/src/server/migrations/0.3.0-0.4.0/sql/preferences/add_language_column.sql
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ALTER TABLE preferences
+	ADD COLUMN default_language language_type NOT NULL DEFAULT 'en';

--- a/src/server/migrations/0.3.0-0.4.0/sql/preferences/create_language_types_enum.sql
+++ b/src/server/migrations/0.3.0-0.4.0/sql/preferences/create_language_types_enum.sql
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+CREATE TYPE language_type AS ENUM('en', 'fr');

--- a/src/server/migrations/registerMigration.js
+++ b/src/server/migrations/registerMigration.js
@@ -7,7 +7,8 @@
  */
 const migrations = [
 	/* eslint-disable global-require */
-	require('./0.2.0-0.3.0-Template/indexTemplate')
+	// require('./0.2.0-0.3.0-Template/indexTemplate'),
+	require('./0.3.0-0.4.0')
 	/* eslint-disable global-require */
 ];
 

--- a/src/server/services/migrateDB.js
+++ b/src/server/services/migrateDB.js
@@ -48,8 +48,12 @@ function findMaxVersion(list) {
 		if (currentVersion === toVersion) {
 			terminateReadline(`Cannot migrate. You already have the highest version ${currentVersion}`);
 		} else {
-			await migrateAll(toVersion, migrationList);
-			terminateReadline('Migration successful');
+			const result = await migrateAll(toVersion, migrationList);
+			if (result !== undefined) {
+				terminateReadline('Migration successful');
+			} else {
+				terminateReadline('Migration failed');
+			}
 		}
 	} catch (err) {
 		log.error('Error while migrating database: ', err);


### PR DESCRIPTION
We have to execute the create migration table and insert default migration first.

The specific steps are: 
1. Run `docker-compose exec database psql -U oed`

2. Then run
`
CREATE TABLE IF NOT EXISTS migrations (
	id SERIAL PRIMARY KEY,
	from_version VARCHAR(20),
	to_version VARCHAR(20) NOT NULL,
	update_timestamp TIMESTAMP DEFAULT NOW() NOT NULL
);
`

3. Then run
`
INSERT INTO migrations (from_version, to_version, update_timestamp)
VALUES (NULL, '0.3.0', NOW())
RETURNING id;
`

Migration script from 0.3.0 to 0.4.0