### PR TITLE
Add Nodemon; now `start:dev` watches and restarts

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -91,6 +91,7 @@ These can be run by executing `npm run <script>` in the `web` Docker-Compose ser
 
 App actions:
 * `start` starts the NodeJS webserver.
+* `start:dev` starts the NodeJS webserver with Nodemon, so it restarts automatically.
 * `webpack:dev` runs Webpack in development mode and dynamically rebuilding the client-side application when files change.
 * `webpack:build` runs Webpack once in production mode.
 * `webpack` runs Webpack once in development mode.
@@ -113,8 +114,8 @@ Administration:
 
 To upgrade the app:
 1. Stop the app (`systemctl stop oed.service`)
-1. Store your local config changes with `git stash` 
-1. Update with `git pull`. 
+1. Store your local config changes with `git stash`
+1. Update with `git pull`.
 1. Replace your local changes with `git stash pop`
 1. Re-build the app (`docker-compose run --rm web ./src/scripts/updateOED.sh`)
 1. Restart the app (`systemctl start oed.service`)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/OpenEnergyDashboard/OED",
   "scripts": {
     "start": "node ./src/bin/www",
+    "start:dev": "./node_modules/.bin/nodemon ./src/bin/www",
     "webpack:dev": "webpack -d --watch --color --progress",
     "webpack:build": "cross-env NODE_ENV=production webpack -p",
     "webpack": "webpack -d --color --progress",
@@ -21,6 +22,16 @@
     "createUser": "node ./src/server/services/user/createUser.js",
     "editUser": "node ./src/server/services/user/editUser.js",
     "sendLogEmail": "node ./src/server/services/sendLogEmail.js"
+  },
+  "nodemonConfig": {
+    "watch": [
+      "src/server/",
+      "src/bin/",
+      "src/common"
+    ],
+    "ignore": [
+      "src/client/"
+    ]
   },
   "dependencies": {
     "axios": "~0.16.2",
@@ -104,6 +115,7 @@
     "css-loader": "~0.28.7",
     "mocha": "~3.5.3",
     "mock-require": "~2.0.2",
+    "nodemon": "~1.18.4",
     "redux-devtools": "~3.4.0",
     "sinon": "~4.0.2",
     "source-map-loader": "~0.2.3",

--- a/src/scripts/devstart.sh
+++ b/src/scripts/devstart.sh
@@ -11,4 +11,4 @@
 # It starts the autorebuild in the background and then
 # runs the server.
 npm run webpack:dev &
-npm start
+npm run start:dev


### PR DESCRIPTION
Also changed in devstart.sh so the guide uses the best version for
development.