### PR TITLE
Keep any data already in the database when inserting readings

### DIFF
--- a/src/server/models/Reading.js
+++ b/src/server/models/Reading.js
@@ -85,6 +85,19 @@ class Reading {
 	}
 
 	/**
+	 * Returns a promise to insert or ignore all of the given readings into the database (as a transaction)
+	 * @param {array<Reading>} readings the readings to insert or update
+	 * @param conn the connection to use. Defaults to the default database connection.
+	 * @returns {Promise<any>}
+	 */
+	static insertOrIgnoreAll(readings, conn = getDB) {
+		return conn().tx(t => t.sequence(function seq(i) {
+			const seqT = this;
+			return readings[i] && readings[i].insertOrIgnore(conn = () => seqT);
+		}));
+	}
+
+	/**
 	 * Returns a promise to get all of the readings for this meter from the database.
 	 * @param meterID The id of the meter to find readings for
 	 * @param conn the connection to use. Defaults to the default database connection.
@@ -130,6 +143,15 @@ class Reading {
 	 */
 	insertOrUpdate(conn = getDB) {
 		return conn().none(sqlFile('reading/insert_or_update_reading.sql'), this);
+	}
+
+	/**
+	 * Returns a promise to insert this reading into the database, or ignore it if it already exists.
+	 * @param conn the connection to use. Defaults to the default database connection.
+	 * @returns {Promise.<>}
+	 */
+	insertOrIgnore(conn = getDB) {
+		return conn().none(sqlFile('reading/insert_or_ignore_reading.sql'), this);
 	}
 
 	/**

--- a/src/server/routes/fileProcessing.js
+++ b/src/server/routes/fileProcessing.js
@@ -48,7 +48,7 @@ router.post('/readings/:meter_id', upload.single('csvFile'), async (req, res) =>
 					const endTimestamp = moment(row[1], 'MM/DD/YYYY HH:mm');
 					const startTimestamp = moment(row[1], 'MM/DD/YYYY HH:mm').subtract(60, 'minutes');
 					return new Reading(id, readRate, startTimestamp, endTimestamp);
-				}, (readings, tx) => Reading.insertOrUpdateAll(readings, tx));
+				}, (readings, tx) => Reading.insertOrIgnoreAll(readings, tx));
 				res.status(200).json({ success: true });
 			} catch (e) {
 				res.status(403).json({ success: false });

--- a/src/server/services/updateMeters.js
+++ b/src/server/services/updateMeters.js
@@ -34,7 +34,7 @@ async function updateAllMeters(dataReader, metersToUpdate) {
 
 		// Flatten the batches (an array of arrays) into a single array.
 		const allReadingsToInsert = [].concat(...readingInsertBatches);
-		await Reading.insertOrUpdateAll(allReadingsToInsert);
+		await Reading.insertOrIgnoreAll(allReadingsToInsert);
 		log.info('Update finished');
 	} catch (err) {
 		log.error(`Error updating all meters: ${err}`, err);

--- a/src/server/sql/reading/insert_or_ignore_reading.sql
+++ b/src/server/sql/reading/insert_or_ignore_reading.sql
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+INSERT INTO readings (meter_id, reading, start_timestamp, end_timestamp)
+VALUES (${meterID}, ${reading}, ${startTimestamp}, ${endTimestamp})
+ON CONFLICT DO NOTHING;

--- a/src/server/test/db/loadFromCsvStreamTests.js
+++ b/src/server/test/db/loadFromCsvStreamTests.js
@@ -49,7 +49,7 @@ mocha.describe('Read mamc log from a file: ', () => {
 				const startTimestamp = moment(row[1], 'MM/DD/YYYY HH:mm').subtract(60, 'minutes');
 				return new Reading(meter.id, readRate, startTimestamp, endTimestamp);
 			},
-			(readings, tx) => Reading.insertOrUpdateAll(readings, tx));
+			(readings, tx) => Reading.insertOrIgnoreAll(readings, tx));
 		const { count } = await getDB().one('SELECT COUNT(*) as count FROM readings');
 		expect(parseInt(count)).to.equal(20);
 	});
@@ -70,7 +70,7 @@ mocha.describe('Read mamc log from a file: ', () => {
 				const endTimestamp = moment(row[1], 'MM/DD/YYYY HH:mm');
 				const startTimestamp = moment(row[1], 'MM/DD/YYYY HH:mm').subtract(60, 'minutes');
 				return new Reading(meter.id, readRate, startTimestamp, endTimestamp);
-			}, (readings, tx) => Reading.insertOrUpdateAll(readings, tx))
+			}, (readings, tx) => Reading.insertOrIgnoreAll(readings, tx))
 		).to.eventually.be.rejected;
 	});
 
@@ -90,7 +90,7 @@ mocha.describe('Read mamc log from a file: ', () => {
 				const endTimestamp = moment(row[1], 'MM/DD/YYYY HH:mm');
 				const startTimestamp = moment(row[1], 'MM/DD/YYYY HH:mm').subtract(60, 'minutes');
 				return new Reading(meter.id, readRate, startTimestamp, endTimestamp);
-			}, (readings, tx) => Reading.insertOrUpdateAll(readings, tx));
+			}, (readings, tx) => Reading.insertOrIgnoreAll(readings, tx));
 		} catch (e) {
 			const { count } = await getDB().one('SELECT COUNT(*) as count FROM readings');
 			expect(parseInt(count)).to.equal(0);

--- a/src/server/test/db/readingTests.js
+++ b/src/server/test/db/readingTests.js
@@ -60,4 +60,18 @@ mocha.describe('Readings', () => {
 		const retrievedReadings = await Reading.getAllByMeterID(meter.id);
 		expect(retrievedReadings).to.have.length(2);
 	});
+	mocha.it('can keep any data already in the DB', async () => {
+		const startTimestamp = moment('2018-01-01');
+		const endTimestamp = moment(startTimestamp).add(1, 'hour');
+		const reading = new Reading(meter.id, 1, startTimestamp, endTimestamp);
+		await reading.insert();
+		const newReading = new Reading(meter.id, 2, startTimestamp, endTimestamp);
+		await Reading.insertOrIgnoreAll([newReading]);
+		const retrievedReadings = await Reading.getAllByMeterID(meter.id);
+		expect(retrievedReadings).to.have.length(1);
+		const retrievedReading = retrievedReadings[0];
+		expect(retrievedReading.startTimestamp.isSame(startTimestamp)).to.equal(true);
+		expect(retrievedReading.endTimestamp.isSame(endTimestamp)).to.equal(true);
+		expect(retrievedReading.reading).to.equal(1);
+	});
 });


### PR DESCRIPTION
Changed to ignore a new reading when the database already has data for the same timestamp.