### PR TITLE
Fix issue where groups editing and creating mixed.

### DIFF
--- a/src/client/app/components/groups/CreateGroupComponent.tsx
+++ b/src/client/app/components/groups/CreateGroupComponent.tsx
@@ -7,7 +7,7 @@ import { Input, Button } from 'reactstrap';
 import DatasourceBoxContainer from '../../containers/groups/DatasourceBoxContainer';
 import { SelectionType } from '../../containers/groups/DatasourceBoxContainer';
 import { NamedIDItem } from '../../types/items';
-import { CreateNewBlankGroupAction, EditGroupNameAction } from '../../types/redux/groups';
+import { CreateNewBlankGroupAction, EditGroupNameAction, ChangeDisplayModeAction } from '../../types/redux/groups';
 import HeaderContainer from '../../containers/HeaderContainer';
 import FooterComponent from '../FooterComponent';
 import { browserHistory } from '../../utils/history';
@@ -20,6 +20,7 @@ interface CreateGroupProps {
 	createNewBlankGroup(): CreateNewBlankGroupAction;
 	editGroupName(name: string): EditGroupNameAction;
 	submitGroupInEditingIfNeeded(): Promise<any>;
+	changeDisplayModeToView(): ChangeDisplayModeAction;
 }
 
 type CreateGroupPropsWithIntl = CreateGroupProps & InjectedIntlProps;
@@ -110,6 +111,7 @@ class CreateGroupComponent extends React.Component<CreateGroupPropsWithIntl, {}>
 	}
 
 	private handleReturnToView() {
+		this.props.changeDisplayModeToView();
 		browserHistory.push('/groups');
 	}
 }

--- a/src/client/app/components/groups/EditGroupsComponent.tsx
+++ b/src/client/app/components/groups/EditGroupsComponent.tsx
@@ -9,7 +9,7 @@ import { Input, Button } from 'reactstrap';
 import DatasourceBoxContainer from '../../containers/groups/DatasourceBoxContainer';
 import { NamedIDItem } from '../../types/items';
 import { SelectionType } from '../../containers/groups/DatasourceBoxContainer';
-import { EditGroupNameAction, ChangeChildMetersAction, ChangeChildGroupsAction } from '../../types/redux/groups';
+import { EditGroupNameAction, ChangeChildMetersAction, ChangeChildGroupsAction, ChangeDisplayModeAction } from '../../types/redux/groups';
 import FooterComponent from '../FooterComponent';
 import HeaderContainer from '../../containers/HeaderContainer';
 import {  browserHistory } from '../../utils/history';
@@ -26,6 +26,7 @@ interface EditGroupsProps {
 	editGroupName(name: string): EditGroupNameAction;
 	changeChildMeters(selected: number[]): ChangeChildMetersAction;
 	changeChildGroups(selected: number[]): ChangeChildGroupsAction;
+	changeDisplayModeToView(): ChangeDisplayModeAction;
 }
 
 type EditGroupsPropsWithIntl = EditGroupsProps & InjectedIntlProps;
@@ -254,6 +255,7 @@ class EditGroupsComponent extends React.Component<EditGroupsPropsWithIntl, EditG
 
 	private handleReturnToView() {
 		browserHistory.push('/groups');
+		this.props.changeDisplayModeToView();
 	}
 }
 

--- a/src/client/app/components/groups/GroupViewComponent.tsx
+++ b/src/client/app/components/groups/GroupViewComponent.tsx
@@ -8,6 +8,7 @@ import ListDisplayComponent from '../ListDisplayComponent';
 import { Link } from 'react-router';
 import { hasToken } from '../../utils/token';
 import { FormattedMessage } from 'react-intl';
+import { ChangeDisplayModeAction } from '../../types/redux/groups';
 
 interface GroupViewProps {
 	name: string;
@@ -16,6 +17,7 @@ interface GroupViewProps {
 	childGroupNames: string[];
 	fetchGroupChildren(id: number): Promise<any>;
 	beginEditingIfPossible(id: number): Promise<any>;
+	changeDisplayModeToEdit(): ChangeDisplayModeAction;
 }
 
 export default class GroupViewComponent extends React.Component<GroupViewProps, {}> {

--- a/src/client/app/containers/groups/CreateGroupContainer.ts
+++ b/src/client/app/containers/groups/CreateGroupContainer.ts
@@ -5,10 +5,11 @@
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import CreateGroupComponent from '../../components/groups/CreateGroupComponent';
-import { createNewBlankGroup, editGroupName, submitGroupInEditingIfNeeded } from '../../actions/groups';
+import { createNewBlankGroup, editGroupName, submitGroupInEditingIfNeeded, changeDisplayMode } from '../../actions/groups';
 import { Dispatch } from '../../types/redux/actions';
 import { State } from '../../types/redux/state';
 import { NamedIDItem } from '../../types/items';
+import { DisplayMode } from '../../types/redux/groups';
 
 function mapStateToProps(state: State) {
 	const sortedMeters: NamedIDItem[] = _.sortBy(_.values(state.meters.byMeterID).map(
@@ -25,7 +26,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
 	return {
 		createNewBlankGroup: () => dispatch(createNewBlankGroup()),
 		submitGroupInEditingIfNeeded: () => dispatch(submitGroupInEditingIfNeeded()),
-		editGroupName: (name: string) => dispatch(editGroupName(name))
+		editGroupName: (name: string) => dispatch(editGroupName(name)),
+		changeDisplayModeToView: () => dispatch(changeDisplayMode(DisplayMode.View))
 	};
 }
 

--- a/src/client/app/containers/groups/EditGroupsContainer.ts
+++ b/src/client/app/containers/groups/EditGroupsContainer.ts
@@ -10,9 +10,10 @@ import {
 	editGroupName,
 	changeChildMeters,
 	changeChildGroups,
+	changeDisplayMode,
 	deleteGroup
 } from '../../actions/groups';
-import { GroupDefinition } from '../../types/redux/groups';
+import { GroupDefinition, DisplayMode } from '../../types/redux/groups';
 import { Dispatch } from '../../types/redux/actions';
 import { State } from '../../types/redux/state';
 import {  browserHistory } from '../../utils/history';
@@ -58,6 +59,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
 		submitGroupInEditingIfNeeded: () => dispatch(submitGroupInEditingIfNeeded()),
 		deleteGroup: () => dispatch(deleteGroup()),
 		editGroupName: (name: string) => dispatch(editGroupName(name)),
+		changeDisplayModeToView: () => dispatch(changeDisplayMode(DisplayMode.View)),
 		changeChildMeters: (meterIDs: number[]) => dispatch(changeChildMeters(meterIDs)),
 		changeChildGroups: (groupIDs: number[]) => dispatch(changeChildGroups(groupIDs))
 	};

--- a/src/client/app/containers/groups/GroupViewContainer.ts
+++ b/src/client/app/containers/groups/GroupViewContainer.ts
@@ -4,9 +4,10 @@
 
 import { connect } from 'react-redux';
 import GroupViewComponent from '../../components/groups/GroupViewComponent';
-import { fetchGroupChildrenIfNeeded, beginEditingIfPossible } from '../../actions/groups';
+import { fetchGroupChildrenIfNeeded, beginEditingIfPossible, changeDisplayMode } from '../../actions/groups';
 import { Dispatch } from '../../types/redux/actions';
 import { State } from '../../types/redux/state';
+import { DisplayMode } from '../../types/redux/groups';
 
 function mapStateToProps(state: State, ownProps: {id: number}) {
 	const id = ownProps.id;
@@ -23,6 +24,7 @@ function mapStateToProps(state: State, ownProps: {id: number}) {
 function mapDispatchToProps(dispatch: Dispatch) {
 	return {
 		fetchGroupChildren: (id: number) => dispatch(fetchGroupChildrenIfNeeded(id)),
+		changeDisplayModeToEdit: () => dispatch(changeDisplayMode(DisplayMode.Edit)),
 		beginEditingIfPossible: (id: number) => dispatch(beginEditingIfPossible(id))
 	};
 }

--- a/src/client/app/reducers/groups.ts
+++ b/src/client/app/reducers/groups.ts
@@ -128,6 +128,9 @@ export default function groups(state = defaultState, action: GroupsAction) {
 				return {
 					...state,
 					displayMode: action.newMode,
+					groupInEditing: {
+						dirty: false
+					},
 					selectedGroups: [] // zero out selected groups when we switch screens
 				};
 			}


### PR DESCRIPTION
This closes #415. Specifically, when transitioning between states in the
groups editing UI, state was not being kept track of. When a user
pressed "edit", a group was placed into editing, but it was not removed
when that action was cancelled, so that group remained "in editing"
if/when a new group was edited or created.

This meant that edits would go to the wrong group, and creating a new
group would actually over-write the old one.

This was corrected by calling the right state transitions in the right
places and resetting the group in editing state during a cancellation
transition.