### PR TITLE
Fix chart links setting bar duration in seconds.

### DIFF
--- a/src/client/app/components/RouteComponent.tsx
+++ b/src/client/app/components/RouteComponent.tsx
@@ -117,7 +117,7 @@ export default class RouteComponent extends React.Component<RouteProps, {}> {
 							options.chartType = info as ChartTypes;
 							break;
 						case 'barDuration':
-							options.barDuration = moment.duration(parseInt(info));
+							options.barDuration = moment.duration(parseInt(info), 'days');
 							break;
 						case 'barStacking':
 							if (this.props.barStacking.toString() !== info) {


### PR DESCRIPTION
This lead to "week" setting 7 seconds, not 7 days, and similar for other
durations. This closes #418, while technically not fixing all of it,
the other portion is related to #403 which is out of scope.