### PR TITLE
fix pg-promise connect usage

### DIFF
--- a/src/server/models/database.js
+++ b/src/server/models/database.js
@@ -4,9 +4,9 @@
 
 const pgp = require('pg-promise')({
 	// This sets the style of returned durations so that Moment can parse them
-	connect: (client, dc, fresh) => {
+	connect(client, dc, useCount) {
 		// Only set the style on fresh connections
-		if (fresh === true || fresh === undefined) {
+		if (useCount === 0) {
 			client.query('SET intervalStyle = iso_8601');
 		}
 	}


### PR DESCRIPTION
Fix incorrect usage of connect after upgrade of pg-promise.
Many thanks to @vitaly-t for pointing this out.
This replaces PR #528.