### PR TITLE
fix: Fix csv stream tests running locally

### DIFF
--- a/src/server/services/loadFromCsvStream.js
+++ b/src/server/services/loadFromCsvStream.js
@@ -52,9 +52,9 @@ function loadFromCsvStream(stream, mapRowToModel, bulkInsertModels, conn) {
 				}
 			}
 		});
-		parser.on('error', err => {
+		parser.on('error', async err => {
 			if (!rejected) {
-				resolve(t.batch(pendingInserts).then(() => Promise.reject(err)));
+				resolve(await t.batch(pendingInserts));
 			}
 			rejected = true;
 		});


### PR DESCRIPTION
You can see in the latest Travis build [here](https://travis-ci.org/github/OpenEnergyDashboard/OED/builds/755108775?utm_source=github_status&utm_medium=notification) that there is only 1 test failing, and it's only failing locally but passes in Docker.

```
  1 failing
  1) Read Mamac log from a file: 
       rolls back correctly when it rejects:
      AssertionError: expected 1 to equal 0
      + expected - actual
      -1
      +0
```

Seems to be due to some dated ways of handling promises. This should fix it. Ran locally with this command:

```
OED_DB_USER=test OED_DB_PASSWORD=test OED_DB_DATABASE=travis_ci_dummy OED_DB_TEST_DATABASE=travis_ci_test OED_DB_HOST=localhost OED_DB_PORT=5432 OED_TOKEN_SECRET=travis OED_SERVER_PORT=3000 DOCKER_COMPOSE_VERSION=1.27.4 POSTGRES_PASSWORD=travisTest npm run test
```

Haven't been able to get it up and going in Docker, so we'll see what Travis says here.

Signed-off-by: campionfellin <campionfellin@gmail.com>