### PR TITLE
allow running limited tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:types": "./node_modules/.bin/tsc -p . --noEmit",
     "check:lint": "./node_modules/.bin/tslint src/{server,bin,scripts,common}/**/*.{ts,tsx,js,jsx} src/client/app/**/*.{ts,tsx,js,jsx}",
     "test": "./node_modules/.bin/mocha --timeout 15000 \"src/server/test/**/*.js\"",
+    "testsome": "./node_modules/.bin/mocha --timeout 15000",
     "createdb": "node ./src/server/services/createDB.js",
     "migratedb": "node ./src/server/services/migrateDB.js",
     "addMamacMeters": "node ./src/server/services/addMamacMeters.js",


### PR DESCRIPTION
# Description

Developers wanted to be able to easily run one or more tests of interest
without having to run the full suite of tests. With this change you
can do:
`docker-compose run --rm web npm run testsome -- src/server/test/web/groups.js src/server/test/db/baselineTests.js`
to run both the groups and baselineTests. It is fine to do only one
test or list as many as you want.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] Remove text in ( ) from the issue request

## Limitations

None.
