### PR TITLE
Linux Compatibility

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -43,6 +43,14 @@ If you want to install OED so you can contribute code, see the "Development" sec
 you are setting up OED in order to gather data from power meters and display it, see the
 "Production" section.
 
+### On Linux ###
+
+In order to run OED with Docker on Linux, your operating system must be `docker-compose`
+compatible.  A good standard of whether or not your distro will work is if it supports the
+x86-64 instruction set; if it does, you're probably in the clear.  It is recommended that
+you check [this list](https://github.com/semicolon-madness/RCOS/blob/main/64bitLinuxOSs.md) 
+to be sure.
+
 ## Notes ##
 
 ### On The Terminal ###


### PR DESCRIPTION
- Added a warning about use on 64-bit Linux operating systems
- Added documentation on supported Linux distros

# Description

This is a documentation addition; you should not see any conflicts with the original documents, and there are
no dependencies that need to be changed or fixed.

This did not fix any documented issue, but it does fix one I have found in my research as a student in RCOS:

I have been trying to install `docker-compose` on RHEL 7.8, so I might be able to build and test whether or not
OED is compatible with the s390x architecture.  I discovered that `docker-compose` is only compatible with 
64 bit operating systems, which is important information to know before trying to build OED.  I also included a
link to Linux distros that support `docker-compose`.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [ ] I have removed text in ( ) from the issue request

## Limitations

The list is not definitive, but it does include enough information to augment your current documentation.
