### PR TITLE
remove many calls to dropConnection

### DIFF
--- a/src/server/routes/obvius.js
+++ b/src/server/routes/obvius.js
@@ -26,7 +26,7 @@ const streamBuffers = require('stream-buffers');
 const loadLogfileToReadings = require('../services/obvius/loadLogfileToReadings');
 const middleware = require('../middleware');
 const obvius = require('../util').obvius;
-const { getConnection, dropConnection } = require('../db');
+const { getConnection } = require('../db');
 const escapeHtml = require('core-js/fn/string/escape-html');
 
 const upload = multer({ storage: multer.memoryStorage() });

--- a/src/server/services/addMamacMeters.js
+++ b/src/server/services/addMamacMeters.js
@@ -5,7 +5,7 @@
 const path = require('path');
 const { log } = require('../log');
 const { insertMetersWrapper } = require('./readMamacMeters');
-const { getConnection, dropConnection } = require('../db');
+const { getConnection } = require('../db');
 
 // Script to add meters from a .xlsx file
 // The first two elements are 'node' and the name of the file. We only want arguments passed to it.
@@ -24,7 +24,6 @@ const { getConnection, dropConnection } = require('../db');
 				log.error(`Error inserting meters: ${err}`, err);
 			}
 		} finally {
-			dropConnection();
 			log.info('Done inserting meters');
 		}
 	}

--- a/src/server/services/createDB.js
+++ b/src/server/services/createDB.js
@@ -4,7 +4,7 @@
 
 const { createSchema } = require('../models/database');
 const { log } = require('../log');
-const { getConnection, dropConnection } = require('../db');
+const { getConnection } = require('../db');
 (async function createSchemaWrapper() {
 	const conn = getConnection();
 	try {
@@ -14,8 +14,6 @@ const { getConnection, dropConnection } = require('../db');
 	} catch (err) {
 		log.error(`Error creating schema: ${err}`, err, skipMail = true);
 		process.exitCode = 1;
-	} finally {
-		dropConnection();
 	}
 }());
 

--- a/src/server/services/migrateDB.js
+++ b/src/server/services/migrateDB.js
@@ -10,7 +10,7 @@ const { ask, terminateReadline } = require('./utils');
 const { findMaxSemanticVersion } = require('../util');
 const { showPossibleMigrations, migrateAll, getUniqueVersions } = require('../migrations/migrateDatabase');
 const migrationList = require('../migrations/registerMigration');
-const { getConnection, dropConnection } = require('../db');
+const { getConnection } = require('../db');
 
 function findMaxVersion(list) {
 	return findMaxSemanticVersion(getUniqueVersions(list));

--- a/src/server/services/obvius/purgeConfigfiles.js
+++ b/src/server/services/obvius/purgeConfigfiles.js
@@ -4,7 +4,7 @@
 
 const Configfile = require('../../models/obvius/Configfile');
 const { log } = require('../../log');
-const { getConnection, dropConnection } = require('../../db');
+const { getConnection } = require('../../db');
 
 async function purgeConfigfiles() {
 	log.info('Purging Obvius config logs.');
@@ -13,8 +13,6 @@ async function purgeConfigfiles() {
 		Configfile.purgeAll(conn);
 	} catch (err) {
 		log.error(`Error purging Obvius config logs: ${err}`, err);
-	} finally {
-		dropConnection();
 	}
 }
 

--- a/src/server/services/obvius/showConfigfiles.js
+++ b/src/server/services/obvius/showConfigfiles.js
@@ -4,7 +4,7 @@
 
 const Configfile = require('../../models/obvius/Configfile');
 const { log } = require('../../log');
-const { getConnection, dropConnection } = require('../../db');
+const { getConnection } = require('../../db');
 
 async function showConfigfiles() {
 	try {
@@ -20,8 +20,6 @@ async function showConfigfiles() {
 		}
 	} catch (err) {
 		log.error(`Error listing Obvius config logs: ${err}`, err);
-	} finally {
-		dropConnection();
 	}
 }
 

--- a/src/server/services/refreshReadingViews.js
+++ b/src/server/services/refreshReadingViews.js
@@ -6,7 +6,7 @@
 
 const { log } = require('../log');
 
-const { getConnection, dropConnection } = require('../db');
+const { getConnection } = require('../db');
 const Reading = require('../models/Reading');
 /* tslint:disable no-console */
 async function refreshReadingViews() {
@@ -15,7 +15,6 @@ async function refreshReadingViews() {
 	log.info('Refreshing Reading Views');
 	await Reading.refreshCompressedReadings(conn);
 	log.info('Views Refreshed');
-	dropConnection();
 }
 
 refreshReadingViews();

--- a/src/server/services/sendLogEmail.js
+++ b/src/server/services/sendLogEmail.js
@@ -4,7 +4,7 @@
 
 const { logMailer } = require('../logMailer');
 const { log } = require('../log');
-const { getConnection, dropConnection } = require('../db');
+const { getConnection } = require('../db');
 
 (async function sendLoggingEmail() {
 	let conn = getConnection();
@@ -12,8 +12,6 @@ const { getConnection, dropConnection } = require('../db');
 		await logMailer(conn);
 	} catch (err) {
 		log.error(`Error while sending email: ${err}`, err, true);
-	} finally {
-		dropConnection();
 	}
 }());
 

--- a/src/server/services/updateMamacMeters.js
+++ b/src/server/services/updateMamacMeters.js
@@ -8,7 +8,7 @@ const Meter = require('../models/Meter');
 const readMamacData = require('./readMamacData');
 const updateMeters = require('./updateMeters');
 const { log } = require('../log');
-const { getConnection, dropConnection } = require('../db');
+const { getConnection } = require('../db');
 
 async function updateMamacMeters() {
 	const conn = getConnection();
@@ -19,8 +19,6 @@ async function updateMamacMeters() {
 		await updateMeters(readMamacData, metersToUpdate, conn);
 	} catch (err) {
 		log.error(`Error fetching Mamac meter data: ${err}`, err);
-	} finally {
-		dropConnection();
 	}
 }
 

--- a/src/server/services/user/createUser.js
+++ b/src/server/services/user/createUser.js
@@ -6,7 +6,7 @@ const bcrypt = require('bcryptjs');
 const User = require('../../models/User');
 const { validateEmail } = require('./utils');
 const { ask, terminateReadline } = require('../utils');
-const { getConnection, dropConnection } = require('../../db');
+const { getConnection } = require('../../db');
 
 (async () => {
 	let email;
@@ -51,7 +51,5 @@ const { getConnection, dropConnection } = require('../../db');
 		// Something went wrong with insertion so return error code.
 		// This assumes the err has a message. This could be done better.
 		terminateReadline('Creation of user failed with err: ' + err.message, 11);
-	} finally {
-		dropConnection();
 	}
 })();

--- a/src/server/services/user/editUser.js
+++ b/src/server/services/user/editUser.js
@@ -5,7 +5,7 @@
 const bcrypt = require('bcryptjs');
 const User = require('../../models/User');
 const { ask, terminateReadline } = require('../utils');
-const { getConnection, dropConnection } = require('../../db');
+const { getConnection } = require('../../db');
 
 
 (async () => {
@@ -26,7 +26,6 @@ const { getConnection, dropConnection } = require('../../db');
 	try {
 		await User.getByEmail(email, conn);
 	} catch (err) {
-		dropConnection();
 		terminateReadline('No user with that email exists');
 	}
 
@@ -36,7 +35,5 @@ const { getConnection, dropConnection } = require('../../db');
 		terminateReadline('User\'s password updated');
 	} catch (err) {
 		terminateReadline('Failed to update user\'s password');
-	} finally {
-		dropConnection();
 	}
 })();


### PR DESCRIPTION
# Description

The new version of pgp does not require us to drop connections. OED recovers by doing a new connection but that is slower. Previously, many of these calls were removed but some remained. This removes most of the remaining ones except during testing where we want to reset the DB each time.

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known. I tried to test manually all the functions that were impacted and found no problems.
