### PR TITLE
fixed hovering precision on maps

### DIFF
--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -117,7 +117,7 @@ function mapStateToProps(state: State) {
 								size.push(averagedReading);
 							}
 							// The hover text.
-							texts.push(`<b> ${timeReading} </b> <br> ${label}: ${averagedReading} kWh/day`);
+							texts.push(`<b> ${timeReading} </b> <br> ${label}: ${averagedReading.toPrecision(6)} kWh/day`);
 						}
 					}
 				}


### PR DESCRIPTION
# Description

Limited the number of digits shown when hovering in maps

Fixes #567 


## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

