### PR TITLE
migration for user table

### DIFF
--- a/src/server/migrations/0.6.0-0.7.0/sql/user/add_user_role.sql
+++ b/src/server/migrations/0.6.0-0.7.0/sql/user/add_user_role.sql
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+DO $$ BEGIN
+    CREATE TYPE user_type AS ENUM('admin', 'csv', 'obvius', 'export');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+-- Users prior to this version were admin. This sets them to admin and then removes that default.
+ALTER TABLE users
+	ADD COLUMN IF NOT EXISTS role user_type NOT NULL DEFAULT 'admin';
+ALTER TABLE users ALTER COLUMN role DROP DEFAULT;


### PR DESCRIPTION
# Description

There was no migration for the user table for the new role. This should fix that.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x ] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [ x] I have removed text in ( ) from the issue request

## Limitations

None known.
