### PR TITLE
fix bar chart hover precision

### DIFF
--- a/src/client/app/containers/BarChartContainer.ts
+++ b/src/client/app/containers/BarChartContainer.ts
@@ -43,7 +43,7 @@ function mapStateToProps(state: State) {
 						`${moment(barReading.startTimestamp).utc().format('LL')} - ${moment(barReading.endTimestamp).utc().format('LL')}`;
 					xData.push(timeReading);
 					yData.push(barReading.reading);
-					hoverText.push(`<b> ${timeReading} </b> <br> ${label}: ${barReading.reading} kWh`);
+					hoverText.push(`<b> ${timeReading} </b> <br> ${label}: ${barReading.reading.toPrecision(6)} kWh`);
 				});
 
 				// This variable contains all the elements (x and y values, bar type, etc.) assigned to the data parameter of the Plotly object
@@ -82,7 +82,7 @@ function mapStateToProps(state: State) {
 						`${moment(barReading.startTimestamp).utc().format('LL')} - ${moment(barReading.endTimestamp).utc().format('LL')}`;
 					xData.push(timeReading);
 					yData.push(barReading.reading);
-					hoverText.push(`<b> ${timeReading} </b> <br> ${label}: ${barReading.reading} kWh`);
+					hoverText.push(`<b> ${timeReading} </b> <br> ${label}: ${barReading.reading.toPrecision(6)} kWh`);
 				});
 
 				// This variable contains all the elements (x and y values, bar chart, etc.) assigned to the data parameter of the Plotly object


### PR DESCRIPTION
# Description

All other graphics were changed to 6 digit precision but bar charts were overlooked. This fixes that.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known. The pictures in the help need to be updated for the next release.
