### PR TITLE
Maps now work with groups

### DIFF
--- a/src/client/app/actions/barReadings.ts
+++ b/src/client/app/actions/barReadings.ts
@@ -44,7 +44,7 @@ export function shouldFetchMeterBarReadings(state: State, meterID: number, timeI
  * @returns {boolean} True if the readings for the given group, time, and duration are missing; false otherwise.
  */
 export function shouldFetchGroupBarReadings(state: State, groupID: number, timeInterval: TimeInterval, barDuration: moment.Duration): boolean {
-	const readingsForID = state.readings.bar.byMeterID[groupID];
+	const readingsForID = state.readings.bar.byGroupID[groupID];
 	if (readingsForID === undefined) {
 		return true;
 	}

--- a/src/client/app/actions/compareReadings.ts
+++ b/src/client/app/actions/compareReadings.ts
@@ -42,7 +42,7 @@ function shouldFetchMeterCompareReadings(state: State, meterID: number, timeInte
  * @returns {boolean} True if the readings for the given group, and time are missing; false otherwise.
  */
 function shouldFetchGroupCompareReadings(state: State, groupID: number, timeInterval: TimeInterval, compareShift: moment.Duration): boolean {
-	const readingsForID = state.readings.compare.byMeterID[groupID];
+	const readingsForID = state.readings.compare.byGroupID[groupID];
 	if (readingsForID === undefined) {
 		return true;
 	}

--- a/src/client/app/actions/groups.ts
+++ b/src/client/app/actions/groups.ts
@@ -282,7 +282,9 @@ export function submitGroupInEditingIfNeeded() {
 			const group = {
 				name: rawGroup.name,
 				childGroups: rawGroup.childGroups,
-				childMeters: rawGroup.childMeters
+				childMeters: rawGroup.childMeters,
+				gps: rawGroup.gps,
+				displayable: rawGroup.displayable
 			};
 			if (creatingNewGroup(getState())) {
 				return dispatch(submitNewGroup(group));

--- a/src/client/app/components/maps/MapCalibrationInitiateComponent.tsx
+++ b/src/client/app/components/maps/MapCalibrationInitiateComponent.tsx
@@ -90,7 +90,7 @@ class MapCalibrationInitiateComponent extends React.Component<MapInitiatePropsWi
 			};
 			await this.props.onSourceChange(source);
 		} catch (err) {
-			logToServer('error', `Error, map source image uploading: ${err}`);
+			logToServer('error', `Error, map source image uploading: ${err}`)();
 		}
 	}
 

--- a/src/client/app/containers/ChartDataSelectContainer.ts
+++ b/src/client/app/containers/ChartDataSelectContainer.ts
@@ -10,8 +10,9 @@ import { State } from '../types/redux/state';
 import { Dispatch } from '../types/redux/actions';
 import { ChartTypes } from '../types/redux/graph';
 import { SelectOption } from '../types/items';
-import { CartesianPoint, Dimensions, normalizeImageDimensions, calculateScaleFromEndpoints, meterDisplayableOnMap, meterMapInfoOk } from '../utils/calibration';
+import { CartesianPoint, Dimensions, normalizeImageDimensions, calculateScaleFromEndpoints, meterDisplayableOnMap, itemMapInfoOk } from '../utils/calibration';
 import { gpsToUserGrid } from './../utils/calibration';
+import { DataType } from '../types/Datasources';
 
 
 /* Passes the current redux state of the chart select container, and turns it into props for the React
@@ -68,7 +69,7 @@ function mapStateToProps(state: State) {
 				const scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
 				// Convert GPS of meter to grid on user map. See calibration.ts for more info on this.
 				const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
-				if (!(meterMapInfoOk({ gps, meterID: meter.value }, state.maps.byMapID[state.maps.selectedMap]) &&
+				if (!(itemMapInfoOk(meter.value, DataType.Meter, state.maps.byMapID[state.maps.selectedMap], gps) &&
 					meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid))) {
 					meter.disabled = true;
 					disableMeters.push(meter.value);

--- a/src/client/app/containers/ChartDataSelectContainer.ts
+++ b/src/client/app/containers/ChartDataSelectContainer.ts
@@ -10,7 +10,7 @@ import { State } from '../types/redux/state';
 import { Dispatch } from '../types/redux/actions';
 import { ChartTypes } from '../types/redux/graph';
 import { SelectOption } from '../types/items';
-import { CartesianPoint, Dimensions, normalizeImageDimensions, calculateScaleFromEndpoints, itemDisplayableOnMap, itemMapInfoOk, MapScale } from '../utils/calibration';
+import { CartesianPoint, Dimensions, normalizeImageDimensions, calculateScaleFromEndpoints, itemDisplayableOnMap, itemMapInfoOk } from '../utils/calibration';
 import { gpsToUserGrid } from './../utils/calibration';
 import { DataType } from '../types/Datasources';
 
@@ -59,17 +59,14 @@ function mapStateToProps(state: State) {
 		// causes TS to complain about the unknown case so not used.
 		const origin = state.maps.byMapID[state.maps.selectedMap].origin;
 		const opposite = state.maps.byMapID[state.maps.selectedMap].opposite;
-		var scaleOfMap: MapScale;
-		if (origin !== undefined && opposite !== undefined) {
-			// Get the GPS degrees per unit of Plotly grid for x and y. By knowing the two corners
-			// (or really any two distinct points) you can calculate this by the change in GPS over the
-			// change in x or y which is the map's width & height in this case.
-			scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
-		}
 		sortedMeters.forEach(meter => {
 			// This meter's GPS value.
 			const gps = state.meters.byMeterID[meter.value].gps;
 			if (origin !== undefined && opposite !== undefined && gps !== undefined && gps !== null) {
+				// Get the GPS degrees per unit of Plotly grid for x and y. By knowing the two corners
+				// (or really any two distinct points) you can calculate this by the change in GPS over the
+				// change in x or y which is the map's width & height in this case.
+				const scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
 				// Convert GPS of meter to grid on user map. See calibration.ts for more info on this.
 				const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
 				if (!(itemMapInfoOk(meter.value, DataType.Meter, state.maps.byMapID[state.maps.selectedMap], gps) &&
@@ -87,6 +84,7 @@ function mapStateToProps(state: State) {
 		sortedGroups.forEach(group => {
 			const gps = state.groups.byGroupID[group.value].gps;
 			if (origin !== undefined && opposite !== undefined && gps !== undefined && gps !== null) {
+				const scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
 				const groupGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
 				if (!(itemMapInfoOk(group.value, DataType.Group, state.maps.byMapID[state.maps.selectedMap], gps) &&
 					itemDisplayableOnMap(imageDimensionNormalized, groupGPSInUserGrid))) {

--- a/src/client/app/containers/ChartDataSelectContainer.ts
+++ b/src/client/app/containers/ChartDataSelectContainer.ts
@@ -81,7 +81,6 @@ function mapStateToProps(state: State) {
 			}
 		});
 		// filter groups - this is not yet done as groups do not show up on maps yet.
-		
 		sortedGroups.forEach(group => {
 			const gps = state.groups.byGroupID[group.value].gps;
 			const origin = state.maps.byMapID[state.maps.selectedMap].origin;

--- a/src/client/app/containers/ChartDataSelectContainer.ts
+++ b/src/client/app/containers/ChartDataSelectContainer.ts
@@ -31,6 +31,7 @@ function mapStateToProps(state: State) {
 	 */
 	// do extra check for display if using mapChart.
 	const disableMeters: number[] = [];
+	const disableGroups: number[] = [];
 	// Don't do this if there is no selected map.
 	if (state.graph.chartToRender === ChartTypes.map && state.maps.selectedMap !== 0) {
 		// filter meters;
@@ -79,15 +80,40 @@ function mapStateToProps(state: State) {
 			}
 		});
 		// filter groups - this is not yet done as groups do not show up on maps yet.
+		/*
+		sortedGroups.forEach(group => {
+			const gps = state.groups.byGroupID[group.value].gps;
+			const origin = state.maps.byMapID[state.maps.selectedMap].origin;
+			const opposite = state.maps.byMapID[state.maps.selectedMap].opposite;
+
+			if (origin !== undefined && opposite !== undefined && gps !== undefined && gps !== null) {
+				const scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
+				const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
+				if (!(meterMapInfoOk({ gps, meterID: group.value }, state.maps.byMapID[state.maps.selectedMap]) &&
+					meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid))) {
+					group.disabled = true;
+					disableGroups.push(group.value);
+				}
+			} else {
+				// Lack info on this map so skip. This is mostly done since TS complains about the undefined possibility.
+				group.disabled = true;
+				disableGroups.push(group.value);
+			}
+		});*/
 	}
 
-	const selectedGroups = state.graph.selectedGroups.map(groupID => (
-		{
-			label: state.groups.byGroupID[groupID] ? state.groups.byGroupID[groupID].name : '',
-			value: groupID,
-			disabled: false
-		} as SelectOption
-	));
+	const selectedGroups = state.graph.selectedGroups.map(groupID => {
+		if (disableGroups.includes(groupID)) {
+			return;
+		}
+		else {
+			return {
+				label: state.groups.byGroupID[groupID] ? state.groups.byGroupID[groupID].name : '',
+				value: groupID,
+				disabled: false
+			} as SelectOption
+		}
+	});
 	const selectedMeters = state.graph.selectedMeters.map(meterID => {
 		if (disableMeters.includes(meterID)) {
 			return;

--- a/src/client/app/containers/ChartDataSelectContainer.ts
+++ b/src/client/app/containers/ChartDataSelectContainer.ts
@@ -10,7 +10,7 @@ import { State } from '../types/redux/state';
 import { Dispatch } from '../types/redux/actions';
 import { ChartTypes } from '../types/redux/graph';
 import { SelectOption } from '../types/items';
-import { CartesianPoint, Dimensions, normalizeImageDimensions, calculateScaleFromEndpoints, meterDisplayableOnMap, itemMapInfoOk } from '../utils/calibration';
+import { CartesianPoint, Dimensions, normalizeImageDimensions, calculateScaleFromEndpoints, itemDisplayableOnMap, itemMapInfoOk, MapScale } from '../utils/calibration';
 import { gpsToUserGrid } from './../utils/calibration';
 import { DataType } from '../types/Datasources';
 
@@ -44,33 +44,36 @@ function mapStateToProps(state: State) {
 		};
 		// Determine the dimensions so within the Plotly coordinates on the user map.
 		const imageDimensionNormalized = normalizeImageDimensions(imageDimensions);
+		// The following is needed to get the map scale. Now that the system accepts maps that are not
+		// pointed north, it would be better to store the origin GPS and the scale factor instead of
+		// the origin and opposite GPS. For now, not going to change but could if redo DB and interface
+		// for maps.
+		// Convert the gps value to the equivalent Plotly grid coordinates on user map.
+		// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
+		// It must be on true north map since only there are the GPS axes parallel to the map axes.
+		// To start, calculate the user grid coordinates (Plotly) from the GPS value. This involves calculating
+		// it coordinates on the true north map and then rotating/shifting to the user map.
+		// This is the origin & opposite from the calibration. It is the lower, left
+		// and upper, right corners of the user map.
+		// The gps value can be null from the database. Note using gps !== null to check for both null and undefined
+		// causes TS to complain about the unknown case so not used.
+		const origin = state.maps.byMapID[state.maps.selectedMap].origin;
+		const opposite = state.maps.byMapID[state.maps.selectedMap].opposite;
+		var scaleOfMap: MapScale;
+		if (origin !== undefined && opposite !== undefined) {
+			// Get the GPS degrees per unit of Plotly grid for x and y. By knowing the two corners
+			// (or really any two distinct points) you can calculate this by the change in GPS over the
+			// change in x or y which is the map's width & height in this case.
+			scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
+		}
 		sortedMeters.forEach(meter => {
 			// This meter's GPS value.
 			const gps = state.meters.byMeterID[meter.value].gps;
-			// The following is needed to get the map scale. Now that the system accepts maps that are not
-			// pointed north, it would be better to store the origin GPS and the scale factor instead of
-			// the origin and opposite GPS. For now, not going to change but could if redo DB and interface
-			// for maps.
-			// Convert the gps value to the equivalent Plotly grid coordinates on user map.
-			// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
-			// It must be on true north map since only there are the GPS axes parallel to the map axes.
-			// To start, calculate the user grid coordinates (Plotly) from the GPS value. This involves calculating
-			// it coordinates on the true north map and then rotating/shifting to the user map.
-			// This is the origin & opposite from the calibration. It is the lower, left
-			// and upper, right corners of the user map.
-			const origin = state.maps.byMapID[state.maps.selectedMap].origin;
-			const opposite = state.maps.byMapID[state.maps.selectedMap].opposite;
-			// The gps value can be null from the database. Note using gps !== null to check for both null and undefined
-			// causes TS to complain about the unknown case so not used.
 			if (origin !== undefined && opposite !== undefined && gps !== undefined && gps !== null) {
-				// Get the GPS degrees per unit of Plotly grid for x and y. By knowing the two corners
-				// (or really any two distinct points) you can calculate this by the change in GPS over the
-				// change in x or y which is the map's width & height in this case.
-				const scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
 				// Convert GPS of meter to grid on user map. See calibration.ts for more info on this.
 				const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
 				if (!(itemMapInfoOk(meter.value, DataType.Meter, state.maps.byMapID[state.maps.selectedMap], gps) &&
-					meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid))) {
+					itemDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid))) {
 					meter.disabled = true;
 					disableMeters.push(meter.value);
 				}
@@ -80,27 +83,34 @@ function mapStateToProps(state: State) {
 				disableMeters.push(meter.value);
 			}
 		});
-		// filter groups - this is not yet done as groups do not show up on maps yet.
+		// The below code follows the logic for meters shown above. See comments above for clarification on the below code.
 		sortedGroups.forEach(group => {
 			const gps = state.groups.byGroupID[group.value].gps;
-			const origin = state.maps.byMapID[state.maps.selectedMap].origin;
-			const opposite = state.maps.byMapID[state.maps.selectedMap].opposite;
-
 			if (origin !== undefined && opposite !== undefined && gps !== undefined && gps !== null) {
-				const scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
-				const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
+				const groupGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
 				if (!(itemMapInfoOk(group.value, DataType.Group, state.maps.byMapID[state.maps.selectedMap], gps) &&
-					meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid))) {
+					itemDisplayableOnMap(imageDimensionNormalized, groupGPSInUserGrid))) {
 					group.disabled = true;
 					disableGroups.push(group.value);
 				}
 			} else {
-				// Lack info on this map so skip. This is mostly done since TS complains about the undefined possibility.
 				group.disabled = true;
 				disableGroups.push(group.value);
 			}
 		});
 	}
+
+	const selectedMeters = state.graph.selectedMeters.map(meterID => {
+		if (disableMeters.includes(meterID)) {
+			return;
+		} else {
+			return {
+				label: state.meters.byMeterID[meterID] ? state.meters.byMeterID[meterID].name : '',
+				value: meterID,
+				disabled: false
+			} as SelectOption
+		}
+	});
 
 	const selectedGroups = state.graph.selectedGroups.map(groupID => {
 		if (disableGroups.includes(groupID)) {
@@ -110,17 +120,6 @@ function mapStateToProps(state: State) {
 			return {
 				label: state.groups.byGroupID[groupID] ? state.groups.byGroupID[groupID].name : '',
 				value: groupID,
-				disabled: false
-			} as SelectOption
-		}
-	});
-	const selectedMeters = state.graph.selectedMeters.map(meterID => {
-		if (disableMeters.includes(meterID)) {
-			return;
-		} else {
-			return {
-				label: state.meters.byMeterID[meterID] ? state.meters.byMeterID[meterID].name : '',
-				value: meterID,
 				disabled: false
 			} as SelectOption
 		}

--- a/src/client/app/containers/ChartDataSelectContainer.ts
+++ b/src/client/app/containers/ChartDataSelectContainer.ts
@@ -81,7 +81,7 @@ function mapStateToProps(state: State) {
 			}
 		});
 		// filter groups - this is not yet done as groups do not show up on maps yet.
-		/*
+		
 		sortedGroups.forEach(group => {
 			const gps = state.groups.byGroupID[group.value].gps;
 			const origin = state.maps.byMapID[state.maps.selectedMap].origin;
@@ -90,7 +90,7 @@ function mapStateToProps(state: State) {
 			if (origin !== undefined && opposite !== undefined && gps !== undefined && gps !== null) {
 				const scaleOfMap = calculateScaleFromEndpoints(origin, opposite, imageDimensionNormalized);
 				const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
-				if (!(meterMapInfoOk({ gps, meterID: group.value }, state.maps.byMapID[state.maps.selectedMap]) &&
+				if (!(itemMapInfoOk(group.value, DataType.Group, state.maps.byMapID[state.maps.selectedMap], gps) &&
 					meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid))) {
 					group.disabled = true;
 					disableGroups.push(group.value);
@@ -100,7 +100,7 @@ function mapStateToProps(state: State) {
 				group.disabled = true;
 				disableGroups.push(group.value);
 			}
-		});*/
+		});
 	}
 
 	const selectedGroups = state.graph.selectedGroups.map(groupID => {

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -8,7 +8,7 @@ import PlotlyChart, { IPlotlyChartProps } from 'react-plotlyjs-ts';
 import { State } from '../types/redux/state';
 import {
 	calculateScaleFromEndpoints, meterDisplayableOnMap, Dimensions,
-	CartesianPoint, normalizeImageDimensions, meterMapInfoOk, gpsToUserGrid
+	CartesianPoint, normalizeImageDimensions, itemMapInfoOk, gpsToUserGrid
 } from '../utils/calibration';
 import * as _ from 'lodash';
 import getGraphColor from '../utils/getGraphColor';
@@ -80,7 +80,7 @@ function mapStateToProps(state: State) {
 					// it coordinates on the true north map and then rotating/shifting to the user map.
 					const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
 					// Only display items within valid info and within map.
-					if (meterMapInfoOk({ gps, meterID }, map) && meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
+					if (itemMapInfoOk(meterID, DataType.Meter, map, gps) && meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
 						// The x, y value for Plotly to use that are on the user map.
 						x.push(meterGPSInUserGrid.x);
 						y.push(meterGPSInUserGrid.y);
@@ -122,7 +122,60 @@ function mapStateToProps(state: State) {
 					}
 				}
 			}
-			
+
+			for (const groupID of state.graph.selectedGroups) {
+				const byGroupID = state.readings.bar.byGroupID[groupID];
+				const gps = state.groups.byGroupID[groupID].gps;
+				if (gps !== undefined && gps !== null) {
+					// Convert the gps value to the equivalent Plotly grid coordinates on user map.
+					// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
+					// It must be on true north map since only there are the GPS axis parallel to the map axis.
+					// To start, calculate the user grid coordinates (Plotly) from the GPS value. This involves calculating
+					// it coordinates on the true north map and then rotating/shifting to the user map.
+					const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
+					// Only display items within valid info and within map.
+					if (itemMapInfoOk(groupID, DataType.Group, map, gps) && meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
+						// The x, y value for Plotly to use that are on the user map.
+						x.push(meterGPSInUserGrid.x);
+						y.push(meterGPSInUserGrid.y);
+						// Get the bar data to use for the map circle.
+						const readingsData = byGroupID[timeInterval.toString()][barDuration.toISOString()];
+						if (readingsData !== undefined && !readingsData.isFetching) {
+							// Meter name to include in hover on graph.
+							const label = state.groups.byGroupID[groupID].name;
+							// The usual color for this meter.
+							colors.push(getGraphColor(groupID, DataType.Group));
+							if (readingsData.readings === undefined) {
+								throw new Error('Unacceptable condition: readingsData.readings is undefined.');
+							}
+							// Use the most recent time reading for the circle on the map.
+							// This has the limitations of the bar value where the last one can include ranges without
+							// data (GitHub issue on this).
+							// TODO: It might be better to do this similarly to compare. (See GitHub issue)
+							const readings = _.orderBy(readingsData.readings, ['startTimestamp'], ['desc']);
+							const mapReading = readings[0];
+							let timeReading: string;
+							let averagedReading = 0;
+							if (readings.length === 0) {
+								// No data. The next lines causes an issue so set specially.
+								// There may be a better overall fix for no data.
+								timeReading = 'no data to display';
+								size.push(0);
+							} else {
+								// Shift to UTC since want database time not local/browser time which is what moment does.
+								timeReading =
+								`${moment(mapReading.startTimestamp).utc().format('LL')} - ${moment(mapReading.endTimestamp).utc().format('LL')}`;
+								// The value for the circle is the average daily usage.
+								averagedReading = mapReading.reading / barDuration.asDays();
+								// The size is the reading value. It will be scaled later.
+								size.push(averagedReading);
+							}
+							// The hover text.
+							texts.push(`<b> ${timeReading} </b> <br> ${label}: ${averagedReading.toPrecision(6)} kWh/day`);
+						}
+					}	
+				}
+			}
 			// TODO Using the following seems to have no impact on the code. It has been noticed that this function is called
 			// many times for each change. Someone should look at why that is happening and why some have no items in the arrays.
 			// if (size.length > 0) {
@@ -168,84 +221,6 @@ function mapStateToProps(state: State) {
 				showlegend: false
 			};
 			data.push(traceOne);
-
-			
-			const x2: number[] = [];
-			const y2: number[] = [];
-			const colors2: string[] = [];
-			const size2: number[] = [];
-			const texts2: string[] = [];
-			for (const groupID of state.graph.selectedGroups) {
-				const byGroupID = state.readings.bar.byGroupID[groupID];
-				const gps = state.groups.byGroupID[groupID].gps;
-				if (gps !== undefined && gps !== null) {
-					// Convert the gps value to the equivalent Plotly grid coordinates on user map.
-					// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
-					// It must be on true north map since only there are the GPS axis parallel to the map axis.
-					// To start, calculate the user grid coordinates (Plotly) from the GPS value. This involves calculating
-					// it coordinates on the true north map and then rotating/shifting to the user map.
-					const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
-					// Only display items within valid info and within map.
-					if (meterMapInfoOk({ gps, meterID: groupID }, map) && meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
-						// The x, y value for Plotly to use that are on the user map.
-						x2.push(meterGPSInUserGrid.x);
-						y2.push(meterGPSInUserGrid.y);
-						// Get the bar data to use for the map circle.
-						const readingsData = byGroupID[timeInterval.toString()][barDuration.toISOString()];
-						if (readingsData !== undefined && !readingsData.isFetching) {
-							// Meter name to include in hover on graph.
-							const label = state.groups.byGroupID[groupID].name;
-							// The usual color for this meter.
-							colors2.push(getGraphColor(groupID, DataType.Group));
-							if (readingsData.readings === undefined) {
-								throw new Error('Unacceptable condition: readingsData.readings is undefined.');
-							}
-							// Use the most recent time reading for the circle on the map.
-							// This has the limitations of the bar value where the last one can include ranges without
-							// data (GitHub issue on this).
-							// TODO: It might be better to do this similarly to compare. (See GitHub issue)
-							const readings = _.orderBy(readingsData.readings, ['startTimestamp'], ['desc']);
-							const mapReading = readings[0];
-							let timeReading: string;
-							let averagedReading = 0;
-							if (readings.length === 0) {
-								// No data. The next lines causes an issue so set specially.
-								// There may be a better overall fix for no data.
-								timeReading = 'no data to display';
-								size2.push(0);
-							} else {
-								// Shift to UTC since want database time not local/browser time which is what moment does.
-								timeReading =
-								`${moment(mapReading.startTimestamp).utc().format('LL')} - ${moment(mapReading.endTimestamp).utc().format('LL')}`;
-								// The value for the circle is the average daily usage.
-								averagedReading = mapReading.reading / barDuration.asDays();
-								// The size is the reading value. It will be scaled later.
-								size2.push(averagedReading);
-							}
-							// The hover text.
-							texts2.push(`<b> ${timeReading} </b> <br> ${label}: ${averagedReading.toPrecision(6)} kWh/day`);
-						}
-					}	
-				}
-			}
-			const traceTwo = {
-				x: x2,
-				y: y2,
-				type: 'scatter',
-				mode: 'markers',
-				marker: {
-					color: colors2,
-					opacity: 0.5,
-					size: size2,
-					sizemin: 6,
-					sizeref: scaling,
-					sizemode: 'area'
-				},
-				text: texts2,
-				opacity: 1,
-				showlegend: false
-			};
-			data.push(traceTwo);
 		}
 	}
 

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import PlotlyChart, { IPlotlyChartProps } from 'react-plotlyjs-ts';
 import { State } from '../types/redux/state';
 import {
-	calculateScaleFromEndpoints, meterDisplayableOnMap, Dimensions,
+	calculateScaleFromEndpoints, itemDisplayableOnMap, Dimensions,
 	CartesianPoint, normalizeImageDimensions, itemMapInfoOk, gpsToUserGrid
 } from '../utils/calibration';
 import * as _ from 'lodash';
@@ -80,7 +80,7 @@ function mapStateToProps(state: State) {
 					// it coordinates on the true north map and then rotating/shifting to the user map.
 					const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
 					// Only display items within valid info and within map.
-					if (itemMapInfoOk(meterID, DataType.Meter, map, gps) && meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
+					if (itemMapInfoOk(meterID, DataType.Meter, map, gps) && itemDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
 						// The x, y value for Plotly to use that are on the user map.
 						x.push(meterGPSInUserGrid.x);
 						y.push(meterGPSInUserGrid.y);
@@ -124,26 +124,29 @@ function mapStateToProps(state: State) {
 			}
 
 			for (const groupID of state.graph.selectedGroups) {
+				// Get group id number.
 				const byGroupID = state.readings.bar.byGroupID[groupID];
+				// Get group GPS value.
 				const gps = state.groups.byGroupID[groupID].gps;
+				// Filter groups with actual gps coordinates.
 				if (gps !== undefined && gps !== null) {
 					// Convert the gps value to the equivalent Plotly grid coordinates on user map.
 					// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
 					// It must be on true north map since only there are the GPS axis parallel to the map axis.
 					// To start, calculate the user grid coordinates (Plotly) from the GPS value. This involves calculating
 					// it coordinates on the true north map and then rotating/shifting to the user map.
-					const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
+					const groupGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap);
 					// Only display items within valid info and within map.
-					if (itemMapInfoOk(groupID, DataType.Group, map, gps) && meterDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
+					if (itemMapInfoOk(groupID, DataType.Group, map, gps) && itemDisplayableOnMap(imageDimensionNormalized, groupGPSInUserGrid)) {
 						// The x, y value for Plotly to use that are on the user map.
-						x.push(meterGPSInUserGrid.x);
-						y.push(meterGPSInUserGrid.y);
+						x.push(groupGPSInUserGrid.x);
+						y.push(groupGPSInUserGrid.y);
 						// Get the bar data to use for the map circle.
 						const readingsData = byGroupID[timeInterval.toString()][barDuration.toISOString()];
 						if (readingsData !== undefined && !readingsData.isFetching) {
-							// Meter name to include in hover on graph.
+							// Group name to include in hover on graph.
 							const label = state.groups.byGroupID[groupID].name;
-							// The usual color for this meter.
+							// The usual color for this group.
 							colors.push(getGraphColor(groupID, DataType.Group));
 							if (readingsData.readings === undefined) {
 								throw new Error('Unacceptable condition: readingsData.readings is undefined.');

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -173,7 +173,7 @@ function mapStateToProps(state: State) {
 							// The hover text.
 							texts.push(`<b> ${timeReading} </b> <br> ${label}: ${averagedReading.toPrecision(6)} kWh/day`);
 						}
-					}	
+					}
 				}
 			}
 			// TODO Using the following seems to have no impact on the code. It has been noticed that this function is called
@@ -264,7 +264,7 @@ function mapStateToProps(state: State) {
 	 *               onClick={({points, event}) => console.log(points, event)}>
 	 */
 	const props: IPlotlyChartProps = {
-		data: data,
+		data,
 		layout,
 		config: {
 			locales: Locales // makes locales available for use

--- a/src/client/app/types/redux/groups.ts
+++ b/src/client/app/types/redux/groups.ts
@@ -123,16 +123,16 @@ export interface MarkOneGroupOutdatedAction {
 export interface GroupMetadata {
 	isFetching: boolean;
 	outdated: boolean;
-	displayable: boolean;
 	selectedGroups: number[];
 	selectedMeters: number[];
-	gps?: GPSPoint;
 }
 
 export interface GroupData {
 	name: string;
 	childMeters: number[];
 	childGroups: number[];
+	gps?: GPSPoint;
+	displayable: boolean;
 }
 
 export interface GroupID {

--- a/src/client/app/types/redux/groups.ts
+++ b/src/client/app/types/redux/groups.ts
@@ -4,6 +4,7 @@
 
 import { ActionType } from './actions';
 import { NamedIDItem } from '../items';
+import { GPSPoint } from 'utils/calibration';
 
 export enum DisplayMode { View = 'view', Edit = 'edit', Create = 'create' }
 
@@ -122,8 +123,10 @@ export interface MarkOneGroupOutdatedAction {
 export interface GroupMetadata {
 	isFetching: boolean;
 	outdated: boolean;
+	displayable: boolean;
 	selectedGroups: number[];
 	selectedMeters: number[];
+	gps?: GPSPoint;
 }
 
 export interface GroupData {

--- a/src/client/app/utils/calibration.ts
+++ b/src/client/app/utils/calibration.ts
@@ -4,6 +4,7 @@
 
 import { MapMetadata } from '../types/redux/map';
 import { logToServer } from '../actions/logs';
+import { DataType } from '../types/Datasources';
 
 /**
  * Defines a Cartesian Point with x & y
@@ -65,16 +66,18 @@ export interface Dimensions {
 }
 
 /**
- * Returns true if meter and map and reasonably defined and false otherwise.
- * @param meterInfo meter info to check
+ * Returns true if item (meter or group) and map and reasonably defined and false otherwise.
+ * @param itemID ID to be used for logging errors
+ * @param type DataType to distinguish between meter and group
  * @param map map info to check
+ * @param gps GPS Point to check
  * @returns True if map is defined with origin & opposite and meter with valid GPS
  */
-export function meterMapInfoOk(meterInfo: { gps?: GPSPoint, meterID: number }, map: MapMetadata): boolean {
+export function itemMapInfoOk(itemID: number, type: DataType, map: MapMetadata, gps?: GPSPoint): boolean {
 	if (map === undefined) { return false; }
-	if ((meterInfo.gps === null || meterInfo.gps === undefined) || map.origin === undefined || map.opposite === undefined) { return false; }
-	if (!isValidGPSInput(`${meterInfo.gps.latitude},${meterInfo.gps.longitude}`)) {
-		logToServer('error', `Found invalid meter gps stored in database, id = ${meterInfo.meterID}`);
+	if ((gps === null || gps === undefined) || map.origin === undefined || map.opposite === undefined) { return false; }
+	if (!isValidGPSInput(`${gps.latitude},${gps.longitude}`)) {
+		logToServer('error', `Found invalid ${type === DataType.Meter ? "meter" : "group"} gps stored in database, id = ${itemID}`);
 		return false;
 	}
 	return true;

--- a/src/client/app/utils/calibration.ts
+++ b/src/client/app/utils/calibration.ts
@@ -77,7 +77,7 @@ export function itemMapInfoOk(itemID: number, type: DataType, map: MapMetadata, 
 	if (map === undefined) { return false; }
 	if ((gps === null || gps === undefined) || map.origin === undefined || map.opposite === undefined) { return false; }
 	if (!isValidGPSInput(`${gps.latitude},${gps.longitude}`)) {
-		logToServer('error', `Found invalid ${type === DataType.Meter ? "meter" : "group"} gps stored in database, id = ${itemID}`);
+		logToServer('error', `Found invalid ${type === DataType.Meter ? 'meter' : 'group'} gps stored in database, id = ${itemID}`);
 		return false;
 	}
 	return true;

--- a/src/client/app/utils/calibration.ts
+++ b/src/client/app/utils/calibration.ts
@@ -77,7 +77,7 @@ export function itemMapInfoOk(itemID: number, type: DataType, map: MapMetadata, 
 	if (map === undefined) { return false; }
 	if ((gps === null || gps === undefined) || map.origin === undefined || map.opposite === undefined) { return false; }
 	if (!isValidGPSInput(`${gps.latitude},${gps.longitude}`)) {
-		logToServer('error', `Found invalid ${type === DataType.Meter ? 'meter' : 'group'} gps stored in database, id = ${itemID}`);
+		logToServer('error', `Found invalid ${type === DataType.Meter ? 'meter' : 'group'} gps stored in database, id = ${itemID}`)();
 		return false;
 	}
 	return true;
@@ -89,7 +89,7 @@ export function itemMapInfoOk(itemID: number, type: DataType, map: MapMetadata, 
  * @param point The point being considered for display in user map grid coordinates.
  * @returns true if within map and false otherwise.
  */
-export function meterDisplayableOnMap(size: Dimensions, point: CartesianPoint): boolean {
+export function itemDisplayableOnMap(size: Dimensions, point: CartesianPoint): boolean {
 	// The user map is a rectangle that is parallel to the Plotly grid. Thus, the point
 	// must be above origin (bottom, left) and below the opposite (top, right) corner.
 	// The Plotly grid was set up so

--- a/src/server/routes/groups.js
+++ b/src/server/routes/groups.js
@@ -17,10 +17,10 @@ const router = express.Router();
  * Given a meter or group, return only the name and ID of that meter or group.
  * This exists to control what data we send to the client.
  * @param item group or meter
- * @returns {{id, name}}
+ * @returns {{id, name, gps}}
  */
 function formatToOnlyNameAndID(item) {
-	return { id: item.id, name: item.name };
+	return { id: item.id, name: item.name, gps: item.gps };
 }
 
 /**

--- a/src/server/routes/groups.js
+++ b/src/server/routes/groups.js
@@ -14,13 +14,24 @@ const { log } = require('../log');
 const router = express.Router();
 
 /**
+ * Given a meter or group, return only the name, ID, and gps of that meter or group.
+ * This exists to control what data we send to the client.
+ * @param item group or meter
+ * @param gps GPS Point
+ * @returns {{id, name, gps}}
+ */
+function formatToOnlyNameIDAndGPS(item) {
+	return { id: item.id, name: item.name, gps: item.gps };
+}
+
+/**
  * Given a meter or group, return only the name and ID of that meter or group.
  * This exists to control what data we send to the client.
  * @param item group or meter
- * @returns {{id, name, gps}}
+ * @returns {{id, name}}
  */
-function formatToOnlyNameAndID(item) {
-	return { id: item.id, name: item.name, gps: item.gps };
+function formatToOnlyNameID(item) {
+	return { id: item.id, name: item.name };
 }
 
 /**
@@ -30,9 +41,19 @@ router.get('/', async (req, res) => {
 	const conn = getConnection();
 	try {
 		const rows = await Group.getAll(conn);
-		res.json(rows.map(formatToOnlyNameAndID));
+		res.json(rows.map(formatToOnlyNameIDAndGPS));
 	} catch (err) {
 		log.error(`Error while preforming GET all groups query: ${err}`, err);
+	}
+});
+
+router.get('/idname', async (req, res) => {
+	const conn = getConnection();
+	try {
+		const rows = await Group.getAll(conn);
+		res.json(rows.map(formatToOnlyNameID));
+	} catch (err) {
+		log.error(`Error while performing GET all groups query: ${err}`, err);
 	}
 });
 

--- a/src/server/test/web/groups.js
+++ b/src/server/test/web/groups.js
@@ -51,14 +51,14 @@ mocha.describe('groups API', () => {
 	});
 	mocha.describe('retrieval', () => {
 		mocha.it('returns the list of existing groups', async () => {
-			const res = await chai.request(app).get('/api/groups');
+			const res = await chai.request(app).get('/api/groups/idname');
 			expect(res).to.have.status(200);
 			expect(res).to.be.json;
 			expect(res.body).to.be.a('array').with.a.lengthOf(3);
 			// This route only returns the id and name. Since we have other properties, we need to remove them
 			// before doing the compare. All the groups are put into an array first and then a new array is created
 			// with only the two desired properties.
-			const groupArray = [groupA, groupB, groupC].map(({displayable, gps, note, area , ...keepAttrs}) => keepAttrs);
+			const groupArray = [groupA, groupB, groupC].map(({displayable, gps, note, area, ...keepAttrs}) => keepAttrs);
 			expect(res.body).to.deep.include.members(groupArray);
 		});
 		mocha.it('returns the immediate children of a group', async () => {


### PR DESCRIPTION
# Description
Fixes #569 
So previously, displaying a map would only work with meters, and now maps can work with groups as well, as long as you put GPS coordinates into the database directly. 
Fixes #579 , I fixed this bug by changing it to accurately pull using groupID instead of meterID
## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations
As mentioned above, this implementation can only be seen visually by inserting gps values directly into the database; ie; updating gps point values in the groups table. In the future, we will need to implement UI for the admin to be able to edit GPS values in the database for the groups from the website.