### PR TITLE
Obvius user and moment parsing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,6 @@ services:
             - OED_MAIL_FROM=mydomain@example.com # The email address that the email will come from
             - OED_MAIL_TO=someone@example.com  # Set the destination address here for where to send emails
             - OED_MAIL_ORG=My Organization Name # Org name for mail that is included in the subject
-            - OED_OBVIUS_PASSWORD=pleaseChange # The password used when Obvius pushes data to OED and should be changed for security if going to use
             # If in a subdirectory, set it here
             # - OED_SUBDIR=/subdir/
         # Set the correct build environment.

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -47,7 +47,4 @@ config.serverPort = process.env.OED_SERVER_PORT;
 config.logFile = process.env.OED_LOG_FILE || 'log.txt';
 config.subdir = process.env.OED_SUBDIR || '';
 
-config.obvius = {
-	password: process.env.OED_OBVIUS_PASSWORD || 'password'
-};
 module.exports = config;

--- a/src/server/routes/obvius.js
+++ b/src/server/routes/obvius.js
@@ -119,9 +119,6 @@ function verifyObviusUser(req, res, next){
 	} else if (!req.param('email')){
 		failure(req, res, 'email parameter is required.');
 		return;
-	} else if (req.param('password') !== config.obvius.password) {
-		failure(req, res, 'password was not correct.');
-		return;
 	} else { // Authenticate Obvius user.
 		req.body.email = req.param('email');
 		req.body.password = req.param('password');

--- a/src/server/services/obvius/loadLogfileToReadings.js
+++ b/src/server/services/obvius/loadLogfileToReadings.js
@@ -44,8 +44,10 @@ async function loadLogfileToReadings(serialNumber, ipAddress, logfile, conn) {
 			// Switching to assume one reading is end time and can use default moment parsing of date/timestamp.
 			// It is believed that the format from Obvius will always be this way so specify.
 			// Strict mode is used so it will give Invalid date if not correct and should be caught in pipeline.
-			const endTimestamp = moment(rawReading[0], 'YYYY-MM-DD HH:mm:ss', true);
-			// const reading = new Reading(meter.id, rawReading[1], startTimestamp, endTimestamp);
+			// const endTimestamp = moment(rawReading[0], 'YYYY-MM-DD HH:mm:ss', true);
+			// TODO For reasons I do not understand, strict mode causes Invalid date even though debugging seems
+			// to indicate it is correct. I thought it worked before but it does not. Thus, removing strict mode for now.
+			const endTimestamp = moment(rawReading[0], 'YYYY-MM-DD HH:mm:ss');
 			reading[index] = [rawReading[1], endTimestamp];
 			index++;
 		}


### PR DESCRIPTION
# Description

This eliminates the environment variable for the Obvius push password
and uses the Obvius user instead.

It also gets the parsing of data to be correct by removing strict mode.
TODO left in code because unsure why needed.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

Testing has not be performed on a live system. This is consistent with
issue #564.