### PR TITLE
shorten dates on graphics

### DIFF
--- a/src/client/app/containers/BarChartContainer.ts
+++ b/src/client/app/containers/BarChartContainer.ts
@@ -41,7 +41,7 @@ function mapStateToProps(state: State) {
 				readings.forEach(barReading => {
 					// subtracting one extra day caused by day ending at midnight of the next day
 					const timeReading: string =
-						`${moment(barReading.startTimestamp).utc().format('LL')} - ${moment(barReading.endTimestamp).subtract(1, 'days').utc().format('LL')}`;
+						`${moment(barReading.startTimestamp).utc().format('ll')} - ${moment(barReading.endTimestamp).subtract(1, 'days').utc().format('ll')}`;
 					xData.push(timeReading);
 					yData.push(barReading.reading);
 					hoverText.push(`<b> ${timeReading} </b> <br> ${label}: ${barReading.reading.toPrecision(6)} kWh`);
@@ -60,7 +60,6 @@ function mapStateToProps(state: State) {
 			}
 		}
 	}
-
 
 	for (const groupID of state.graph.selectedGroups) {
 		const byGroupID = state.readings.bar.byGroupID[groupID];
@@ -81,7 +80,7 @@ function mapStateToProps(state: State) {
 				readings.forEach(barReading => {
 					// subtracting one extra day caused by day ending at midnight of the next day
 					const timeReading: string =
-						`${moment(barReading.startTimestamp).utc().format('LL')} - ${moment(barReading.endTimestamp).subtract(1, 'days').utc().format('LL')}`;
+						`${moment(barReading.startTimestamp).utc().format('ll')} - ${moment(barReading.endTimestamp).subtract(1, 'days').utc().format('ll')}`;
 					xData.push(timeReading);
 					yData.push(barReading.reading);
 					hoverText.push(`<b> ${timeReading} </b> <br> ${label}: ${barReading.reading.toPrecision(6)} kWh`);

--- a/src/client/app/containers/LineChartContainer.ts
+++ b/src/client/app/containers/LineChartContainer.ts
@@ -39,7 +39,7 @@ function mapStateToProps(state: State) {
 					const timeReading = st.add(moment(reading.endTimestamp).diff(st) / 2);
 					xData.push(timeReading.utc().format('YYYY-MM-DD HH:mm:ss'));
 					yData.push(reading.reading);
-					hoverText.push(`<b> ${timeReading.format('dddd, LL LTS')} </b> <br> ${label}: ${reading.reading.toPrecision(6)} kW`);
+					hoverText.push(`<b> ${timeReading.format('ddd, ll LTS')} </b> <br> ${label}: ${reading.reading.toPrecision(6)} kW`);
 				});
 
 				// Save the timestamp range of the plot
@@ -99,7 +99,7 @@ function mapStateToProps(state: State) {
 					const timeReading = st.add(moment(reading.endTimestamp).diff(st) / 2);
 					xData.push(timeReading.utc().format('YYYY-MM-DD HH:mm:ss'));
 					yData.push(reading.reading);
-					hoverText.push(`<b> ${timeReading.format('dddd, LL LTS'	)} </b> <br> ${label}: ${reading.reading.toPrecision(6)} kW`);
+					hoverText.push(`<b> ${timeReading.format('ddd, ll LTS'	)} </b> <br> ${label}: ${reading.reading.toPrecision(6)} kW`);
 				});
 
 				// This variable contains all the elements (x and y values, line type, etc.) assigned to the data parameter of the Plotly object

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -108,7 +108,7 @@ function mapStateToProps(state: State) {
 							} else {
 								// Shift to UTC since want database time not local/browser time which is what moment does.
 								timeReading =
-								`${moment(mapReading.startTimestamp).utc().format('LL')} - ${moment(mapReading.endTimestamp).subtract(1, 'days').utc().format('LL')}`;
+								`${moment(mapReading.startTimestamp).utc().format('ll')} - ${moment(mapReading.endTimestamp).subtract(1, 'days').utc().format('ll')}`;
 								// The value for the circle is the average daily usage.
 								averagedReading = mapReading.reading / barDuration.asDays();
 								// The size is the reading value. It will be scaled later.
@@ -165,7 +165,7 @@ function mapStateToProps(state: State) {
 							} else {
 								// Shift to UTC since want database time not local/browser time which is what moment does.
 								timeReading =
-								`${moment(mapReading.startTimestamp).utc().format('LL')} - ${moment(mapReading.endTimestamp).subtract(1, 'days').utc().format('LL')}`;
+								`${moment(mapReading.startTimestamp).utc().format('ll')} - ${moment(mapReading.endTimestamp).subtract(1, 'days').utc().format('ll')}`;
 								// The value for the circle is the average daily usage.
 								averagedReading = mapReading.reading / barDuration.asDays();
 								// The size is the reading value. It will be scaled later.


### PR DESCRIPTION
# Description

The moment format was changed so it uses fewer characters. This is a small change but will help make hover and x-axis labels be shorter so they take up less space.

Note that compare is not done since its labels are being changed. It is assume that work will do the same changes as this.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

Compare left to do.

Note the documentation change is that the images with graphics have changed slightly and should be redone.
