### PR TITLE
add code to enable React traces

### DIFF
--- a/src/client/app/index.tsx
+++ b/src/client/app/index.tsx
@@ -14,8 +14,22 @@ import './styles/index.css';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import initScript from './initScript';
 
-// Creates and applies thunk middleware to the Redux store, which is defined from the Redux reducers
+// Creates and applies thunk middleware to the Redux store, which is defined from the Redux reducers.
+// For now we are enabling Redux debug tools on production builds. If had a good way to only do this
+// when not in production mode then maybe we should remove this but it does allow for debugging.
+// Comment this out if enabling traces below.
 const store = createStore(reducers, composeWithDevTools(applyMiddleware(thunkMiddleware)));
+
+// Creates and applies thunk middleware to the Redux store, which is defined from the Redux reducers.
+// It would be nice to enable this automatically if not in production mode. Unfortunately, the client
+// side does not see the docker environment variables so it would require more work to do this. Doing
+// in the initScript with a proper route would likely fix this up.
+// For now,
+// the developer needs to comment out the line above and uncomment the two lines below to get traces.
+// The webpack rebuild should make the change while OED is running.
+// Allow tracing of code.
+// const composeEnhancers = composeWithDevTools({trace: true});
+// const store = createStore(reducers, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
 // Store information that would rarely change throughout using OED into the Redux store when the application first mounts.
 store.dispatch(initScript());


### PR DESCRIPTION
# Description

This allows code to be commented/uncommented to enable React traces. Note the developer details on the website for version 0.8.0 are already updated for this change.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

As the code comments indicate, it would be nice to route the needed information so it is enabled whenever OED is not in production mode. That can be done in the future.
