### PR TITLE
update node to latest LTS

### DIFF
--- a/containers/web/Dockerfile
+++ b/containers/web/Dockerfile
@@ -5,7 +5,7 @@
 # *
 
 # Dockerfile for NodeJS application portion
-FROM node:14
+FROM node:16.13.2
 
 # Create the directory for the app
 RUN mkdir -p "/usr/src/app"


### PR DESCRIPTION
# Description

Node is updated to the latest LTS version of 16.13.2.

Fixes #682. It is unclear why this version of node no longer fails. The two most likely reasons are that node was changed and/or the recent package updates. Whatever the reason, testing indicates that this version of node does not have install or run issues.

As part of doing this work, it was determined that you need to add --build when you bring up OED when a From in a Dockerfile is changed. The web pages have already been updated to include this information.

Node recommends that production code use an LTS version so this is done with this change.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [X] This change requires a documentation update (done)

## Checklist

- [X] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [X] I have removed text in ( ) from the issue request

## Limitations

Developers and sites will need to use the --build option to get the new version in their image/container. The web pages describe this.

We will need to manually update node in the future. Note that using the latest tag had issues so that is no longer done. It does not update as hoped.
