### PR TITLE
update install to avoid npm installs

### DIFF
--- a/src/scripts/installOED.sh
+++ b/src/scripts/installOED.sh
@@ -48,11 +48,21 @@ if [ -f ".env" ]; then
 	source .env
 fi
 
+# Skip the install if the node_modules were installed before the package files.
+# The two package files
+packageFile="package.json"
+packageLockFile="package-lock.json"
+# node hidden lock file that is changed each time npm install is run.
+nodeHiddenLockFile="node_modules/.package-lock.json"
+# See if hidden node lock file exists and is newer than the two package files.
+if [ -f "$nodeHiddenLockFile" ] && [ "$nodeHiddenLockFile" -nt "$packageFile" ] && [ "$nodeHiddenLockFile" -nt "$packageLockFile" ] ; then
+    # The node install happened after the package files were created so don't redo
+    keep_node_modules=yes
+fi
+
 # Install NPM dependencies
 if [ "$keep_node_modules" == "yes" ]; then
-	printf "%s\n" "skipping NPM install as requested"
-elif [ "$OED_PRODUCTION" == "yes" ] && [ -d "node_modules" ]; then
-	echo "node_modules/ exists, skipping NPM install in production environment."
+	printf "%s\n" "skipping NPM install as requested or because node_modules seems up to date"
 else
 	printf "%s\n" "NPM install..."
 	npm ci --loglevel=warn

--- a/src/scripts/updateOED.sh
+++ b/src/scripts/updateOED.sh
@@ -8,13 +8,17 @@
 echo "Upgrading OED"
 
 # Install NPM dependencies
-echo "NPM install..."
-npm install --loglevel=warn --progress=false
+echo "NPM ci to upgrade the packages..."
+npm ci --loglevel=warn --progress=false
 echo "NPM install finished."
 
 echo "Attempting to migrate database to latest version..."
 npm run migratedb -- highest
 
+echo "Doing docker compose up --no-start --build to capture any changes needed for images/containers without starting..."
+docker compose up --no-start --build
+
+echo "Doing webpack:build to update the application..."
 npm run webpack:build
 
 echo "OED upgrade completed"


### PR DESCRIPTION
# Description

This PR is another iteration to try to avoid npm installs when bringing up OED and it is not needed. The npm install is, in general, the most time consuming part of bringing up OED when it happens. Here is a little history and what these changes do:

1. At one time OED looked to see if the node_modules/ directory existed and skipped the install if it did. The problem was that this did not detect updates to the json package file and a developer had to manually remove node_modules to get an install to happen. Often developers missed this step.
2. OED was changed to do the install by default. A parameter was added (keep_node_modules) that allowed skipping the npm install. It required a somewhat convoluted syntax to docker to pass it into the script. This was better but required the developer to manually do this and some did not realize it existed. There was also a special case for a production install that dropped back to case 1 above to avoid reinstalls. That was safer since production software is rarely updated and there is a special migration process. OED also switched to npm ci so no updates would occur to the packages and would use the one specified in the OED repository.
3. The current update is an attempt to address the shortcomings of the previous attempts. It uses a feature of npm v7+ (see (https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#hidden-lockfiles)). This is now possible because we updated node and the package-lock.json to v2. These create a .package-lock.json file in node_modules/. It is used by npm install but we npm ci. Thus, the install script now checks if .package-lock.json exists and is newer than the package.json and package-lock.json files. (In the unlikely case that someone uses this script without an updated node/npm then there will be no lock file and the install will happen every time by default which is similar to the current behavior except in a production setting.) If so, then the npm ci occurred after the json package files were created so an install is not needed but still happens if this is not the case. Thus, most npm installs are skipped automatically in most cases without the person doing anything. The previous keep_node_modules parameter was left for backward compatibility and in the unusual case when it is needed. Also, the special case for production installs could be removed as it is the same as the general case.

The OED update script for production environments was modified in a couple of ways:

- It was still doing npm install so it was changed to npm ci.
- As discussed in PR #716, you need to do a build to get the images/containers to update. This step was added but using a slightly different mechanism since in this case we don't want OED to start.

I will soon update OED documentation to reflect this change.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known.
