### PR TITLE
convert outline arguments from boolean to string

### DIFF
--- a/src/client/app/components/ChartSelectComponent.tsx
+++ b/src/client/app/components/ChartSelectComponent.tsx
@@ -56,25 +56,25 @@ export default class ChartSelectComponent extends React.Component<ChartSelectPro
 					</DropdownToggle>
 					<DropdownMenu>
 						<DropdownItem
-							outline={this.props.selectedChart !== ChartTypes.line}
+							outline={(this.props.selectedChart !== ChartTypes.line).toString()}
 							onClick={() => this.handleChangeChartType(ChartTypes.line)}
 						>
 							<FormattedMessage id='line' />
 						</DropdownItem>
 						<DropdownItem
-							outline={this.props.selectedChart !== ChartTypes.bar}
+							outline={(this.props.selectedChart !== ChartTypes.bar).toString()}
 							onClick={() => this.handleChangeChartType(ChartTypes.bar)}
 						>
 							<FormattedMessage id='bar' />
 						</DropdownItem>
 						<DropdownItem
-							outline={this.props.selectedChart !== ChartTypes.compare}
+							outline={(this.props.selectedChart !== ChartTypes.compare).toString()}
 							onClick={() => this.handleChangeChartType(ChartTypes.compare)}
 						>
 							<FormattedMessage id='compare' />
 						</DropdownItem>
 						<DropdownItem
-							outline={this.props.selectedChart !== ChartTypes.map}
+							outline={(this.props.selectedChart !== ChartTypes.map).toString()}
 							onClick={() => this.handleChangeChartType(ChartTypes.map)}
 						>
 							<FormattedMessage id='map' />

--- a/src/client/app/components/LanguageSelectorComponent.tsx
+++ b/src/client/app/components/LanguageSelectorComponent.tsx
@@ -60,19 +60,19 @@ export default class LanguageSelectorComponent extends React.Component<LanguageS
 					</DropdownToggle>
 					<DropdownMenu>
 						<DropdownItem
-							outline={this.props.selectedLanguage !== LanguageTypes.en}
+							outline={(this.props.selectedLanguage !== LanguageTypes.en).toString()}
 							onClick={() => this.handleChangeLanguage(LanguageTypes.en)}
 						>
 							English
 						</DropdownItem>
 						<DropdownItem
-							outline={this.props.selectedLanguage !== LanguageTypes.fr}
+							outline={(this.props.selectedLanguage !== LanguageTypes.fr).toString()}
 							onClick={() => this.handleChangeLanguage(LanguageTypes.fr)}
 						>
 							Français
 						</DropdownItem>
 						<DropdownItem
-							outline={this.props.selectedLanguage !== LanguageTypes.es}
+							outline={(this.props.selectedLanguage !== LanguageTypes.es).toString()}
 							onClick={() => this.handleChangeLanguage(LanguageTypes.es)}
 						>
 							Español


### PR DESCRIPTION
# Description

Fix 1 warning: change the argument type in a div tag from boolean to string

Partly addresses #471 

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

Some React libraries packages might need updating to remove all warnings