### PR TITLE
Hide meters/groups that aren't displayable for groups page

### DIFF
--- a/src/client/app/components/ListDisplayComponent.tsx
+++ b/src/client/app/components/ListDisplayComponent.tsx
@@ -33,10 +33,23 @@ export default function ListDisplayComponent(props: ListDisplayProps) {
 		paddingRight: '12px'
 	};
 
+	const hiddenStyle: React.CSSProperties = {
+		opacity: 0.5
+	};
+
 	return (
 		<div className='list-wrapper' style={listWrapperStyle} >
 			<ul id='meterList' style={listStyle} >
-				{props.items.map((item: any) => <li key={item.toString()}>{item.toString()}</li>)}
+				{props.items.map((item: any, index: number) => {
+					// If the item, ie; meter/group had a name of length 0, this meant it was a hidden name.
+					if (item.toString().length !== 0) {
+						return <li key={item.toString()}>{item.toString()}</li>
+					}
+					else {
+						// Each list item needs a unique key, so we use index to differentiate hidden elements.
+						return <li style={hiddenStyle} key={`hidden${index.toString()}`}><i>(hidden)</i></li>
+					}
+				})}
 			</ul>
 		</div>
 	);

--- a/src/client/app/components/groups/GroupViewComponent.tsx
+++ b/src/client/app/components/groups/GroupViewComponent.tsx
@@ -48,7 +48,8 @@ export default class GroupViewComponent extends React.Component<GroupViewProps> 
 			paddingLeft: '5px'
 		};
 		const groupAllMeters: React.CSSProperties = {
-			fontWeight: 'bold'
+			fontWeight: 'bold',
+			marginBottom: 0
 		};
 		return (
 			<div>
@@ -76,9 +77,23 @@ export default class GroupViewComponent extends React.Component<GroupViewProps> 
 					<p style={groupAllMeters}>
 						<FormattedMessage id='group.all.meters' />:
 					</p>
-					{this.props.deepMeterNames.map ((item, index) => (
-						<span key={`d_${index}`}>{(index ? ', ': '') + item}</span>
-					))}
+					{this.props.deepMeterNames.map((item, index) => {
+						// If meter name is length 0, return nothing.
+						if (item.length !== 0) {
+							// Because we sort the names, the empty strings will always be first and so the comma will always apply.
+							if (index !== this.props.deepMeterNames.length - 1) {
+								return <span key={`d_${index}`}>{item + ', '}</span>
+							}
+							else {
+								return <span key={`d_${index}`}>{item}</span>
+							}
+						}
+						else return; // satisfy map always returning a value (in a function).
+					})}
+					{
+						this.props.childMeterNames.includes('') || this.props.childGroupNames.includes('') ?
+							<div><i>This group contains non-displayable meters/groups denoted as hidden.</i></div> : <></>
+					}
 				</div>
 			</div>
 		);

--- a/src/client/app/containers/groups/GroupViewContainer.ts
+++ b/src/client/app/containers/groups/GroupViewContainer.ts
@@ -11,9 +11,31 @@ import { DisplayMode } from '../../types/redux/groups';
 import { isRoleAdmin } from '../../utils/hasPermissions';
 function mapStateToProps(state: State, ownProps: {id: number}) {
 	const id = ownProps.id;
-	const childMeterNames = state.groups.byGroupID[id].childMeters.map((meterID: number) => state.meters.byMeterID[meterID].name.trim()).sort();
-	const childGroupNames = state.groups.byGroupID[id].childGroups.map((groupID: number) => state.groups.byGroupID[groupID].name.trim()).sort();
-	const deepMeterNames = state.groups.byGroupID[id].deepMeters.map((meterID: number) => state.meters.byMeterID[meterID].name.trim()).sort();
+	const childMeterNames = state.groups.byGroupID[id].childMeters.map((meterID: number) => {
+		if (state.meters.byMeterID[meterID] !== undefined) {
+			return state.meters.byMeterID[meterID].name.trim();
+		}
+		else {
+			// No meter/group can have name with length of 0, so empty strings indicate a hidden meter/group.
+			return '';
+		}
+	}).sort();
+	const childGroupNames = state.groups.byGroupID[id].childGroups.map((groupID: number) => {
+		if (state.groups.byGroupID[groupID] !== undefined) {
+			return state.groups.byGroupID[groupID].name.trim();
+		}
+		else {
+			return '';
+		}
+	}).sort();
+	const deepMeterNames = state.groups.byGroupID[id].deepMeters.map((meterID: number) => {
+		if (state.meters.byMeterID[meterID] !== undefined) {
+			return state.meters.byMeterID[meterID].name.trim();
+		}
+		else {
+			return '';
+		}
+	}).sort();
 	const currentUser = state.currentUser.profile;
 	let loggedInAsAdmin = false;
 	if(currentUser !== null){

--- a/src/server/models/Group.js
+++ b/src/server/models/Group.js
@@ -84,10 +84,20 @@ class Group {
 	/**
 	 * returns a promise to retrieve all groups in the database
 	 * @param conn the connection to be used.
-	 * @returns {Promise.<void>}
+	 * @returns {Promise.<array.<Group>>}
 	 */
 	static async getAll(conn) {
 		const rows = await conn.any(sqlFile('group/get_all_groups.sql'));
+		return rows.map(Group.mapRow);
+	}
+
+	/**
+	 * Returns a promise to get all of the displayable groups from the database
+	 * @param conn the connection to use. Defaults to the default database connection.
+	 * @returns {Promise.<array.<Group>>}
+	 */
+	static async getDisplayable(conn) {
+		const rows = await conn.any(sqlFile('group/get_displayable_groups.sql'));
 		return rows.map(Group.mapRow);
 	}
 

--- a/src/server/routes/groups.js
+++ b/src/server/routes/groups.js
@@ -5,14 +5,17 @@
 const express = require('express');
 const _ = require('lodash');
 const validate = require('jsonschema').validate;
-
+const User = require('../models/User');
+const { isTokenAuthorized } = require('../util/userRoles');
 const { getConnection } = require('../db');
 const Group = require('../models/Group');
 const adminAuthenticator = require('./authenticator').adminAuthMiddleware;
+const optionalAuthenticator = require('./authenticator').optionalAuthMiddleware;
 const { log } = require('../log');
 const Point = require('../models/Point');
 
 const router = express.Router();
+router.use(optionalAuthenticator);
 
 /**
  * Given a meter or group, return id, name, displayable, gps, note, area.
@@ -45,7 +48,16 @@ function formatToOnlyNameID(item) {
 router.get('/', async (req, res) => {
 	const conn = getConnection();
 	try {
-		const rows = await Group.getAll(conn);
+		let query;
+		const token = req.headers.token || req.body.token || req.query.token;
+		const loggedInAsAdmin = req.hasValidAuthToken && (await isTokenAuthorized(token, User.role.ADMIN));
+		if (loggedInAsAdmin) {
+			query = Group.getAll;
+		}
+		else {
+			query = Group.getDisplayable;
+		}
+		const rows = await query(conn);
 		res.json(rows.map(formatGroupForResponse));
 	} catch (err) {
 		log.error(`Error while preforming GET all groups query: ${err}`, err);

--- a/src/server/sql/group/get_displayable_groups.sql
+++ b/src/server/sql/group/get_displayable_groups.sql
@@ -2,4 +2,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-SELECT * FROM groups;
+SELECT * FROM groups WHERE displayable = true;

--- a/src/server/test/web/groups.js
+++ b/src/server/test/web/groups.js
@@ -141,7 +141,7 @@ mocha.describe('groups API', () => {
 				expect(res).to.have.status(200);
 
 				// Get the results of the API call.
-				const res2 = await chai.request(app).get('/api/groups');
+				const res2 = await chai.request(app).get('/api/groups').set('token', token);
 				expect(res2).to.have.status(200);
 				expect(res2).to.be.json;
 				expect(res2.body).to.have.lengthOf(4);


### PR DESCRIPTION
# Description

Fixes #699, Fixes #414 

Hides meters/groups that aren't displayable to avoid blank page error. Uses the returned meter/group names in mapStateToProps to distinguish hidden vs displayable meters/groups. All groups/meters must have at least 1 character in their
name to be created, so I used an empty string for those that were hidden. 
I then noticed groups were not hidden even when displayable was set to false, and saw issue #414 which addresses this. Changes were then made to allow for this functionality, where it follows meters being displayable or not. In general, this change is minimal and does not hinder the resource generalization work, as it doesn't touch the front-end code for displaying. 

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations
n/a
