### PR TITLE
Fix #723 by removing duplicate meter ids when generating compressed readings

### DIFF
--- a/src/server/sql/reading/create_compressed_reading_views.sql
+++ b/src/server/sql/reading/create_compressed_reading_views.sql
@@ -248,7 +248,7 @@ AS $$
 		meter_ids INTEGER[];
 	BEGIN
 		-- First get all the meter ids that will be included in one or more groups being queried
-		SELECT array_agg(gdm.meter_id) INTO meter_ids
+		SELECT array_agg(DISTINCT gdm.meter_id) INTO meter_ids
 		FROM groups_deep_meters gdm
 		INNER JOIN unnest(group_ids) gids(id) ON gdm.group_id = gids.id;
 


### PR DESCRIPTION
# Description

Fix #723 by removing duplicate meter ids when generating compressed readings. `array_agg` introduces duplicate meter ids in the `meter_ids` array. `compressed_readings_2` returns summed values when duplicate meter ids are provided.

Fixes #723 

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None.
