### PR TITLE
fix unit state syntax issue

### DIFF
--- a/src/client/app/types/redux/units.ts
+++ b/src/client/app/types/redux/units.ts
@@ -54,5 +54,5 @@ export interface UnitDataById {
 
 export interface UnitsState {
 	isFetching: boolean;
-	units: UnitDataById[];
+	units: UnitDataById;
 }


### PR DESCRIPTION
# Description

While doing coding that needed the new unit state, I had an issue. I tracked it down to the proposed change. I think I am the first one to use this part of the state. It seems to work fine after I do this so you can do:
state.units.units[state.graph.selectedUnit].identifier
otherwise it gives an error.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known
