### PR TITLE
VSC dev container for OED

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,55 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "OED for VSCode",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "web",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspace",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": ["eamodio.gitlens", "streetsidesoftware.code-spell-checker", "ms-azuretools.vscode-docker", "github.vscode-pull-request-github"],
+
+	// From https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
+	// to get Docker-from-Docker so can run Docker inside constainer.
+	"features": {
+		"docker-from-docker": {
+			"version": "latest",
+			"moby": true
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// This runs the OED install script in the background. If you do:
+	// "postCreateCommand": "bash /workspace/src/scripts/installOED.sh"
+	// then you see all the output in the terminal that opens up but it shows
+	// "Configuring Dev Container" with a spinning wheel.
+	// When you use the command below then the output goes into nohup.out.
+	"postCreateCommand": "nohup bash -c '/workspace/src/scripts/installOED.sh &'"
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/docker-existing-docker-compose
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,3 +1,9 @@
+# *
+# * This Source Code Form is subject to the terms of the Mozilla Public
+# * License, v. 2.0. If a copy of the MPL was not distributed with this
+# * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# *
+
 version: '2.1'
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '2.1'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  web:
+    # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
+    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
+    # debugging) to execute as the user. Uncomment the next line if you want the entire 
+    # container to run as this user instead. Note that, on Linux, you may need to 
+    # ensure the UID and GID of the container user you create matches your local user. 
+    # See https://aka.ms/vscode-remote/containers/non-root for details.
+    #
+    # user: vscode
+
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - .:/workspace:cached
+
+      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
+      # - /var/run/docker.sock:/var/run/docker.sock 
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ postgres-data
 
 # Test data (normally for developers)
 src/server/test/db/data/automatedTests/*.csv
+
+# nohup.out is created when working inside the remote container with Visual Studio Code.
+nohup.out
+
+# Mac Finder files - do here so avoid in VSC container
+.DS_Store

--- a/src/scripts/installOED.sh
+++ b/src/scripts/installOED.sh
@@ -5,6 +5,8 @@
 # * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # *
 
+printf "\n\n%s\n\n" "***** Starting install of OED at $(date) *****"
+
 USAGE="Usage: $0 [--production] [--nostart] [--keep_node_modules] [--continue_on_db_error]"
 
 production=no

--- a/src/scripts/testData.sh
+++ b/src/scripts/testData.sh
@@ -7,9 +7,8 @@
 
 echo "This script assumes you have OED running."
 echo "This script is normally run for the main OED directory (where package.json is located)"
-echo "This script should not be run with a different container meaning don't user docker-compose."
 echo "Time estimates will vary depending on your machine and what it is doing."
-echo "The terminal where you started OED will show any errors and some of the activity going on"
+echo "The OED output will show any errors and some of the activity going on"
 echo "  but normally only once the loading of data into OED begins."
 echo "Comments inside this script tell you how to delete all current readings and meters from the"
 echo "  database if you already ran this before and need to remove that data. You will likley get "
@@ -22,8 +21,8 @@ echo "  if you rerun without doing this but the result is normally fine."
 # meters and readings already exist.
 # NOTE this removes the meters and readings. You may need to remove dependent groups
 # before doing this in the web groups page in OED.
-# Get into postgres in the terminal.
-# docker-compose exec database psql -U oed
+# Get into postgres terminal inside the database Docker container and then do:
+# psql -U oed
 # Remove all the readings. Normally gives "DELETE 575218"
 # > delete from readings where meter_id in (select id from meters where name in ('test4DaySin', 'test4HourSin', 'test23MinSin', 'test15MinSin', 'test23MinCos', 'testSqSin', 'testSqCos', 'testAmp1Sin', 'testAmp2Sin', 'testAmp3Sin', 'testAmp4Sin', 'testAmp5Sin', 'testAmp6Sin', 'testAmp7Sin'));
 # Remove all the meters. Normally gives "DELETE 14"
@@ -59,10 +58,10 @@ echo "  This normally takes less than a minute:"
 # This assumes you have a newer version (as of 2021) docker that has compose built in.
 # In the past it was docker-compose.
 # Don't use --rm since this seems to cause the newer docker to terminate any other running OED (which is needed for the CSV upload).
-docker compose run web npm run generateTestingData
+npm run generateTestingData
 echo -e "\nStart generating second set of test data (varying amplitudes)"
 echo "  This normally takes about a minute:"
-docker compose run web npm run generateVariableAmplitudeTestingData
+npm run generateVariableAmplitudeTestingData
 
 # Go to directory with test data
 cd $testdatadir


### PR DESCRIPTION
# Description

This is a basic container that works with the Visual Studio Code Remote - Containers.
The container has the following features:

- You can use Docker in it.
- It has the extensions gitlens, code-spell-checker, azuretools and vscode-pull-request-github.

You can still use it outside Visual Studio Code as was done previously.

This was tested by developers running MacOS X and Windows 10. It ran fine.

This also adds to the .gitignore to exclude the new nohup.out file and .DS_Store. The later is Mac specific but this avoids it getting into the repo.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

- This is a work in progress where some items are left commented out from what VSC created in case we want them later.
- The debugger is not working.
- The test data scripts and not yet changed. All scripts are planned to run inside the container rather than in the local machine shell. These changes are coming as the new developer documentation is completed.

