### PR TITLE
add eslint extention to VSC container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,34 +3,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/docker-existing-docker-compose
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
 	"name": "OED for VSCode",
-
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
 		"../docker-compose.yml",
 		"docker-compose.yml"
 	],
-
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "web",
-
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
 	"workspaceFolder": "/workspace",
-
 	// Set *default* container specific settings.json values on container create.
 	"settings": {},
-
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": ["eamodio.gitlens", "streetsidesoftware.code-spell-checker", "ms-azuretools.vscode-docker", "github.vscode-pull-request-github"],
-
+	"extensions": [
+		"eamodio.gitlens",
+		"streetsidesoftware.code-spell-checker",
+		"ms-azuretools.vscode-docker",
+		"github.vscode-pull-request-github",
+		"dbaeumer.vscode-eslint"
+	],
 	// From https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 	// to get Docker-from-Docker so can run Docker inside constainer.
 	"features": {
@@ -39,23 +38,18 @@
 			"moby": true
 		}
 	},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Uncomment the next line if you want start specific services in your Docker Compose config.
 	// "runServices": [],
-
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
-
 	// This runs the OED install script in the background. If you do:
 	// "postCreateCommand": "bash /workspace/src/scripts/installOED.sh"
 	// then you see all the output in the terminal that opens up but it shows
 	// "Configuring Dev Container" with a spinning wheel.
 	// When you use the command below then the output goes into nohup.out.
 	"postCreateCommand": "nohup bash -c '/workspace/src/scripts/installOED.sh &'"
-
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
 }


### PR DESCRIPTION
# Description

A quick change to enable eslint extension in the VSC container so warning are seen while coding. This is now possible because OED has ESLint enabled.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known. Tested and seems to work fine.
