### PR TITLE
Set reading to float

### DIFF
--- a/src/server/migrations/0.8.0-1.0.0/index.js
+++ b/src/server/migrations/0.8.0-1.0.0/index.js
@@ -26,6 +26,8 @@ module.exports = {
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/cik/create_cik_table.sql'));
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/drop_old_views.sql'));
 		// Note that old views should be dropped before the reading's type is changed to float.
+		// It is also important that the creation of new views below is done after this because
+		// you cannot alter a type that is used in a view.
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/set_reading_to_float.sql'));
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/set_function_get_compare_readings_to_float.sql'));
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/create_reading_views.sql'));

--- a/src/server/migrations/0.8.0-1.0.0/index.js
+++ b/src/server/migrations/0.8.0-1.0.0/index.js
@@ -24,8 +24,11 @@ module.exports = {
 		// Note that default units and conversions must be inserted before calling this file.
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/group/update_default_graphic_unit.sql'));
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/cik/create_cik_table.sql'));
+		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/drop_old_views.sql'));
+		// Note that old views should be dropped before the reading's type is changed to float.
+		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/set_reading_to_float.sql'));
+		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/set_function_get_compare_readings_to_float.sql'));
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/create_reading_views.sql'));
 		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/drop_old_functions.sql'));
-		await db.none(sqlFile('../migrations/0.8.0-1.0.0/sql/readings/drop_old_views.sql'));
 	}
 };

--- a/src/server/migrations/0.8.0-1.0.0/sql/readings/set_function_get_compare_readings_to_float.sql
+++ b/src/server/migrations/0.8.0-1.0.0/sql/readings/set_function_get_compare_readings_to_float.sql
@@ -2,6 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*
+The following function returns data for plotting bacompare graphs. It works on meters.
+It should not be used on raw readings.
+It is the new version of compare_readings that works with units. It takes these parameters:
+meter_ids: A array of meter ids to query.
+graphic_unit_id: The unit id of the unit to use for the graph.
+curr_start: When the current/this time period begins for the compare.
+curr_end: When the current/this time period ends for the compare.
+shift: How far back in time to shift the curr_start and curr_end date/time to get the previous
+	times to compare.
+ */
 CREATE OR REPLACE FUNCTION meter_compare_readings_unit (
 	meter_ids INTEGER[],
 	graphic_unit_id INTEGER,

--- a/src/server/migrations/0.8.0-1.0.0/sql/readings/set_function_get_compare_readings_to_float.sql
+++ b/src/server/migrations/0.8.0-1.0.0/sql/readings/set_function_get_compare_readings_to_float.sql
@@ -2,43 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/*
-This shouldn't ever be looking at more than a few weeks of data, so we don't need to deal with compression.
- */
-
-/*
-TODO This functioin can probably be improved for two reasons:
-1) While it was noted that you don't look at too many days, it does limit its usage to modest time lengths.
-There has been thought to allowing comparisons, for example, or a whole year. It also assumes that the
-frequency of readings is not too high so the number of readings looked at could be large even over
-modest time frames.
-2) Readings are only included if they are within the current time period. This means that if you have
-a reading that crosses the timeframe they are excluded. This can be viewed as either a good thing or
-a bad thing. However, if the frequency of readings is high, then large segements of time can be excluded.
-For example, monthly readings would not be includes in either day, week or four week comparisons that
-OED currently does. Also note that the daily and hourly views do include readings that span a time frame
-so including them would be consistent.
-
-We need to think about how best to deal with this but one option is to use the daily and hourly tables
-to get the reading values as in done with bar graphs. This needs to be a little different since partial
-days can be invovled. However, getting the full days from the daily table and then the hours from the
-hourly table to be combined would solve this. (One could get the subhour from the raw readings but it is
-unclear users would want that.) Another consider is that the current system, as is the case for bar graphs,
-does not take into account missing times in readings which can lead to lower than expected values. The
-daily and hourly readings would help fix this.
-*/
-
-/*
-The following function returns data for plotting bacompare graphs. It works on meters.
-It should not be used on raw readings.
-It is the new version of compare_readings that works with units. It takes these parameters:
-meter_ids: A array of meter ids to query.
-graphic_unit_id: The unit id of the unit to use for the graph.
-curr_start: When the current/this time period begins for the compare.
-curr_end: When the current/this time period ends for the compare.
-shift: How far back in time to shift the curr_start and curr_end date/time to get the previous
-	times to compare.
- */
 CREATE OR REPLACE FUNCTION meter_compare_readings_unit (
 	meter_ids INTEGER[],
 	graphic_unit_id INTEGER,

--- a/src/server/migrations/0.8.0-1.0.0/sql/readings/set_function_get_compare_readings_to_float.sql
+++ b/src/server/migrations/0.8.0-1.0.0/sql/readings/set_function_get_compare_readings_to_float.sql
@@ -13,6 +13,11 @@ curr_end: When the current/this time period ends for the compare.
 shift: How far back in time to shift the curr_start and curr_end date/time to get the previous
 	times to compare.
  */
+
+-- This changes the signature of the function. It did not exist before version 1.0 but if
+-- someone has it then you have to drop before replace so doing to be safe.
+DROP FUNCTION meter_compare_readings_unit;
+ 
 CREATE OR REPLACE FUNCTION meter_compare_readings_unit (
 	meter_ids INTEGER[],
 	graphic_unit_id INTEGER,
@@ -92,6 +97,11 @@ curr_end: When the current/this time period ends for the compare.
 shift: How far back in time to shift the curr_start and curr_end date/time to get the previous
 	times to compare.
  */
+
+-- This changes the signature of the function. It did not exist before version 1.0 but if
+-- someone has it then you have to drop before replace so doing to be safe.
+DROP FUNCTION group_compare_readings_unit;
+
 CREATE OR REPLACE FUNCTION group_compare_readings_unit (
 	group_ids INTEGER[],
 	graphic_unit_id INTEGER,

--- a/src/server/migrations/0.8.0-1.0.0/sql/readings/set_reading_to_float.sql
+++ b/src/server/migrations/0.8.0-1.0.0/sql/readings/set_reading_to_float.sql
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+-- Set the reading's type to float. 
+-- Since daily_readings and hourly_readings views use reading values, this must happen after dropping these views.
+ALTER TABLE readings ALTER COLUMN reading TYPE FLOAT;

--- a/src/server/migrations/0.8.0-1.0.0/sql/readings/set_reading_to_float.sql
+++ b/src/server/migrations/0.8.0-1.0.0/sql/readings/set_reading_to_float.sql
@@ -4,4 +4,14 @@
 
 -- Set the reading's type to float. 
 -- Since daily_readings and hourly_readings views use reading values, this must happen after dropping these views.
+
+-- These comments are only really needed if doing the migrations manually.
+-- Note that if you already have the old views then do the steps in
+-- src/server/migrations/0.8.0-1.0.0/sql/readings/drop_old_views.sql
+-- If you already have the new views then you will need to do:
+-- DROP MATERIALIZED VIEW daily_readings_unit;
+-- DROP MATERIALIZED VIEW hourly_readings_unit;
+-- You can check if a view exists with:
+-- \d hourly_readings_unit or any name of a view.
+-- Once this is done you need to refresh the reading views so you can graph again.
 ALTER TABLE readings ALTER COLUMN reading TYPE FLOAT;

--- a/src/server/sql/reading/create_readings_table.sql
+++ b/src/server/sql/reading/create_readings_table.sql
@@ -5,7 +5,7 @@
 -- create readings table
 CREATE TABLE IF NOT EXISTS readings (
   meter_id INT NOT NULL REFERENCES meters(id),
-  reading REAL NOT NULL,
+  reading FLOAT NOT NULL,
   start_timestamp TIMESTAMP NOT NULL,
 	end_timestamp TIMESTAMP NOT NULL,
 	CHECK (start_timestamp < readings.end_timestamp),


### PR DESCRIPTION
# Description

Testing found that the space and access time are acceptable when changing the reading type from real (32-bits) to float (64-bit). This PR makes this change for the reading table and functions using these values. DB migration is also created. I have done a full migration and it works as expected on my machine.

Fixes #650 

## Type of change

- [ ] Note merging this changes the node modules
- [x] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations
