### PR TITLE
add refresh of reading views to update script

### DIFF
--- a/src/scripts/updateOED.sh
+++ b/src/scripts/updateOED.sh
@@ -21,4 +21,11 @@ docker compose up --no-start --build
 echo "Doing webpack:build to update the application..."
 npm run webpack:build
 
+# Though generally not needed, it is possible that you need to refresh the reading views after a migration.
+# This is definitely needed for the migration to 1.0.0 because it deletes the old views and creates new ones.
+# It is quite possible this could be commented out in the future but it probably does not do any harm except
+# taking a little time.
+echo "Doing docker compose run web npm run refreshAllReadingViews to refresh the reading views for doing graphics..."
+docker compose run web npm run refreshAllReadingViews
+
 echo "OED upgrade completed"


### PR DESCRIPTION
# Description

It was noticed that the v1.0.0 migration needs to refresh the reading views because it drops and then recreates new views.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

As noted in a comment in the script, this may not be needed in general but adding for all since easier.