### PR TITLE
Egauge refresh, line kWh label & VSC setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ nohup.out
 
 # Mac Finder files - do here so avoid in VSC container
 .DS_Store
+
+# Visual Studio Code settings file
+.vscode/settings.json

--- a/src/client/app/containers/LineChartContainer.ts
+++ b/src/client/app/containers/LineChartContainer.ts
@@ -32,7 +32,7 @@ function mapStateToProps(state: State) {
 			// Quantity and flow units have different unit labels.
 			// Look up the type of unit if it is for quantity/flow/raw and decide what to do.
 			// Bar graphics are always quantities.
-			if (selectUnitState.identifier === 'kWh' || selectUnitState.identifier === 'kW' || selectUnitState.unitRepresent == UnitRepresentType.raw) {
+			if (selectUnitState.identifier === 'kWh' || selectUnitState.identifier === 'kW') {
 				// This is a special case. kWh has a general meaning and the flow equivalent is kW.
 				// A kW is a Joule/sec. While it is possible to convert to another rate, OED is not
 				// going to allow that. If you want that then the site should add Joule as a unit.
@@ -40,7 +40,10 @@ function mapStateToProps(state: State) {
 				// Thus, OED will show kW and not allow other rates. To make it consistent, kWh cannot
 				// be shown in another rate. Thus, there is no need to scale.
 				// TODO This isn't a general solution. For example, Wh or W would not be fixed.
-				// A flow unit also just uses the identifier.
+				// The y-axis label is the kW.
+				unitLabel = 'kW';
+			} else if (selectUnitState.unitRepresent == UnitRepresentType.raw) {
+				// A raw unit just uses the identifier.
 				// The y-axis label is the same as the identifier.
 				unitLabel = selectUnitState.identifier;
 			} else if (selectUnitState.unitRepresent === UnitRepresentType.quantity || selectUnitState.unitRepresent === UnitRepresentType.flow) {

--- a/src/server/services/eGauge/updateEgaugeMeters.js
+++ b/src/server/services/eGauge/updateEgaugeMeters.js
@@ -9,7 +9,7 @@ const updateMeters = require('../updateMeters');
 const { log } = require('../../log');
 const { getConnection } = require('../../db');
 const readEgaugeData = require('./readEgaugeData');
-const { refreshCompressedReadings, refreshCompressedHourlyReadings } = require('../../models/Reading');
+const { refreshDailyReadings, refreshHourlyReadings } = require('../../models/Reading');
 
 /**
  * For every enabled eGauge meter, update the readings in the database.
@@ -29,8 +29,8 @@ async function updateEgaugeMeters() {
 		// We refresh the readings so they can be graphed to see the new ones.
 		// TODO If the system is getting other types of meters this may cause the refresh
 		// to happen multiple times. Might want to work on this in the future.
-		await refreshCompressedReadings(conn);
-		await refreshCompressedHourlyReadings(conn);
+		await refreshDailyReadings(conn);
+		await refreshHourlyReadings(conn);
 	} catch (err) {
 		log.error(`Error fetching eGauge meter data: ${err}`, err);
 	}


### PR DESCRIPTION
# Description

This PR has three unrelated items:
1. The function names used to refresh readings after an eGauge update were changed to be correct.
2. Line graphs with a unit of kWh was incorrectly using kWh and now uses kW.
3. git ignore now stops Visual Studio code settings from being saved.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known
