### PR TITLE
Bar Chart date x-axis and single-day mouseover

### DIFF
--- a/src/client/app/containers/BarChartContainer.ts
+++ b/src/client/app/containers/BarChartContainer.ts
@@ -68,13 +68,19 @@ function mapStateToProps(state: State) {
 				const hoverText: string[] = [];
 				const readings = _.orderBy(readingsData.readings, ['startTimestamp'], ['asc']);
 				readings.forEach(barReading => {
-					// subtracting one extra day caused by day ending at midnight of the next day.
-					// Going from DB unit timestamp that is UTC so force UTC with moment, as usual.
-					const timeReading: string =
-						`${moment.utc(barReading.startTimestamp).format('ll')} - ${moment.utc(barReading.endTimestamp).subtract(1, 'days').format('ll')}`;
-					xData.push(timeReading);
+					const st = moment.utc(barReading.startTimestamp);
+					// Time reading is in the middle of the start and end timestamp (may change this depending on how it looks on the bar graph)\
+					const timeReading = st.add(moment.utc(barReading.endTimestamp).diff(st) / 2);
+					xData.push(timeReading.utc().format('YYYY-MM-DD HH:mm:ss'));
 					yData.push(barReading.reading);
-					hoverText.push(`<b> ${timeReading} </b> <br> ${label}: ${barReading.reading.toPrecision(6)} ${unitLabel}`);
+					// only display a range of dates for the hover text if there is more than one day in the range
+					let timeRange: string = `${moment.utc(barReading.startTimestamp).format('ll')}`;
+					if(barDuration.asDays() != 1) {
+						// subtracting one extra day caused by day ending at midnight of the next day.
+						// Going from DB unit timestamp that is UTC so force UTC with moment, as usual.
+						timeRange += ` - ${moment.utc(barReading.endTimestamp).subtract(1, 'days').format('ll')}`;
+					}
+					hoverText.push(`<b> ${timeRange} </b> <br> ${label}: ${barReading.reading.toPrecision(6)} ${unitLabel}`);
 				});
 				// This variable contains all the elements (x and y values, bar type, etc.) assigned to the data parameter of the Plotly object
 				datasets.push({
@@ -108,13 +114,19 @@ function mapStateToProps(state: State) {
 				const hoverText: string[] = [];
 				const readings = _.orderBy(readingsData.readings, ['startTimestamp'], ['asc']);
 				readings.forEach(barReading => {
-					// subtracting one extra day caused by day ending at midnight of the next day.
-					// Going from DB unit timestamp that is UTC so force UTC with moment, as usual.
-					const timeReading: string =
-						`${moment.utc(barReading.startTimestamp).format('ll')} - ${moment.utc(barReading.endTimestamp).subtract(1, 'days').format('ll')}`;
-					xData.push(timeReading);
+					const st = moment.utc(barReading.startTimestamp);
+					// Time reading is in the middle of the start and end timestamp (may change this depending on how it looks on the bar graph)\
+					const timeReading = st.add(moment.utc(barReading.endTimestamp).diff(st) / 2);
+					xData.push(timeReading.utc().format('YYYY-MM-DD HH:mm:ss'));
 					yData.push(barReading.reading);
-					hoverText.push(`<b> ${timeReading} </b> <br> ${label}: ${barReading.reading.toPrecision(6)} ${unitLabel}`);
+					// only display a range of dates for the hover text if there is more than one day in the range
+					let timeRange: string = `${moment.utc(barReading.startTimestamp).format('ll')}`;
+					if(barDuration.asDays() != 1) {
+						// subtracting one extra day caused by day ending at midnight of the next day.
+						// Going from DB unit timestamp that is UTC so force UTC with moment, as usual.
+						timeRange += ` - ${moment.utc(barReading.endTimestamp).subtract(1, 'days').format('ll')}`;
+					}
+					hoverText.push(`<b> ${timeRange} </b> <br> ${label}: ${barReading.reading.toPrecision(6)} ${unitLabel}`);
 				});
 
 				// This variable contains all the elements (x and y values, bar chart, etc.) assigned to the data parameter of the Plotly object

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -140,6 +140,7 @@ function mapStateToProps(state: State) {
 									size.push(0);
 								} else {
 									// only display a range of dates for the hover text if there is more than one day in the range
+									// Shift to UTC since want database time not local/browser time which is what moment does.
 									timeReading = `${moment.utc(mapReading.startTimestamp).format('ll')}`;
 									if(barDuration.asDays() != 1) {
 										// subtracting one extra day caused by day ending at midnight of the next day.

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -139,10 +139,13 @@ function mapStateToProps(state: State) {
 									timeReading = 'no data to display';
 									size.push(0);
 								} else {
-									// Shift to UTC since want database time not local/browser time which is what moment does.
-									// We need to subtract one day from the end since it is midnight of the next day.
-									timeReading =
-										`${moment.utc(mapReading.startTimestamp).format('ll')} - ${moment.utc(mapReading.endTimestamp).subtract(1, 'days').format('ll')}`;
+									// only display a range of dates for the hover text if there is more than one day in the range
+									timeReading = `${moment.utc(mapReading.startTimestamp).format('ll')}`;
+									if(barDuration.asDays() != 1) {
+										// subtracting one extra day caused by day ending at midnight of the next day.
+										// Going from DB unit timestamp that is UTC so force UTC with moment, as usual.
+										timeReading += ` - ${moment.utc(mapReading.endTimestamp).subtract(1, 'days').format('ll')}`;
+									}
 									// The value for the circle is the average daily usage.
 									averagedReading = mapReading.reading / barDuration.asDays();
 									// The size is the reading value. It will be scaled later.
@@ -202,10 +205,13 @@ function mapStateToProps(state: State) {
 									timeReading = 'no data to display';
 									size.push(0);
 								} else {
-									// Shift to UTC since want database time not local/browser time which is what moment does.
-									// We need to subtract one day from the end since it is midnight of the next day.
-									timeReading =
-										`${moment.utc(mapReading.startTimestamp).format('ll')} - ${moment.utc(mapReading.endTimestamp).subtract(1, 'days').format('ll')}`;
+									// only display a range of dates for the hover text if there is more than one day in the range
+									timeReading = `${moment.utc(mapReading.startTimestamp).format('ll')}`;
+									if(barDuration.asDays() != 1) {
+										// subtracting one extra day caused by day ending at midnight of the next day.
+										// Going from DB unit timestamp that is UTC so force UTC with moment, as usual.
+										timeReading += ` - ${moment.utc(mapReading.endTimestamp).subtract(1, 'days').format('ll')}`;
+									}
 									// The value for the circle is the average daily usage.
 									averagedReading = mapReading.reading / barDuration.asDays();
 									// The size is the reading value. It will be scaled later.


### PR DESCRIPTION
# Description
This changes the bar graph's x-axis to display using dates instead of string ranges, which is how the line graph currently displays data. 
Issue #688 was caused by displaying the date ranges as strings, which plotly does not sort. By changing the display type to dates, the x-axis values are automatically sorted.
This also changes the mouseover readout for bar and map data. When the display range is set to one day, it will only display that one day instead of a range.

![Screenshot 2022-10-04 144909](https://user-images.githubusercontent.com/113216142/193901493-797c8646-164e-4518-abcf-9c6c48fa06fc.png)

Fixes #688 

## Type of change
- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist
- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
