### PR TITLE
802 make page button non dynamic

### DIFF
--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -40,13 +40,13 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		const showOptions = getPage() === '';
 		const renderLoginButton = !hasToken();
 		const shouldHomeButtonDisabled = getPage() === '';
-		const renderAdminButton = loggedInAsAdmin && getPage() !== 'admin';
+		const renderAdminButton = loggedInAsAdmin && getPage() == 'admin';
 		const shouldGroupsButtonDisabled = getPage() === 'groups';
 		const shouldMetersButtonDisabled = getPage() === 'meters';
-		const renderMapsButton =loggedInAsAdmin && getPage() !== 'maps';
-		const renderCSVButton = role && hasPermissions(role, UserRole.CSV) && getPage() !== 'csv';
-		const renderUnitsButton = loggedInAsAdmin && getPage() !== 'units';
-		const renderConversionsButton = loggedInAsAdmin && getPage() !== 'conversions';
+		const renderMapsButton =loggedInAsAdmin && getPage() == 'maps';
+		const renderCSVButton = Boolean(role && hasPermissions(role, UserRole.CSV) && getPage() == 'csv');
+		const renderUnitsButton = loggedInAsAdmin && getPage() == 'units';
+		const renderConversionsButton = loggedInAsAdmin && getPage() == 'conversions';
 		const renderLogoutButton = hasToken();
 
 		const loginLinkStyle: React.CSSProperties = {
@@ -103,14 +103,20 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 				<div className={this.props.showCollapsedMenuButton ? 'd-none d-lg-block' : ''}>
 					<TooltipHelpContainer page='all' />
 					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
-					<Link style={adminLinkStyle} to='/admin'><Button outline><FormattedMessage id='admin.panel' /></Button></Link>
-					<Link style={conversionsLinkStyle} to='/conversions'><Button outline><FormattedMessage id='conversions' /></Button></Link>
-					<Link style={csvLinkStyle} to='/csv'><Button outline><FormattedMessage id='csv' /></Button></Link>
+					<Link style={adminLinkStyle} to='/admin'><Button disabled={renderAdminButton} outline><FormattedMessage id='admin.panel' /></Button></Link>
+					<Link
+						style={conversionsLinkStyle}
+						to='/conversions'>
+						<Button disabled={renderConversionsButton}
+							outline><FormattedMessage id='conversions' />
+						</Button>
+					</Link>
+					<Link style={csvLinkStyle} to='/csv'><Button disabled={renderCSVButton} outline><FormattedMessage id='csv' /></Button></Link>
 					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
 					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
-					<Link style={mapsLinkStyle} to='/maps'><Button outline><FormattedMessage id='maps' /></Button></Link>
+					<Link style={mapsLinkStyle} to='/maps'><Button disabled={renderMapsButton} outline><FormattedMessage id='maps' /></Button></Link>
 					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
-					<Link style={unitsLinkStyle} to='/units'><Button outline><FormattedMessage id='units' /></Button></Link>
+					<Link style={unitsLinkStyle} to='/units'><Button disabled={renderUnitsButton} outline><FormattedMessage id='units' /></Button></Link>
 					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
 					<Link style={logoutButtonStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
 				</div>

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -40,13 +40,13 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		const showOptions = getPage() === '';
 		const renderLoginButton = !hasToken();
 		const shouldHomeButtonDisabled = getPage() === '';
-		const renderAdminButton = loggedInAsAdmin && getPage() !== 'admin';
+		const shouldAdminButtonDisabled = loggedInAsAdmin && getPage() == 'admin';
 		const shouldGroupsButtonDisabled = getPage() === 'groups';
 		const shouldMetersButtonDisabled = getPage() === 'meters';
-		const renderMapsButton = loggedInAsAdmin && getPage() !== 'maps';
-		const renderCSVButton = role && hasPermissions(role, UserRole.CSV) && getPage() !== 'csv';
-		const renderUnitsButton = loggedInAsAdmin && getPage() !== 'units';
-		const renderConversionsButton = loggedInAsAdmin && getPage() !== 'conversions';
+		const shouldMapsButtonDisabled = loggedInAsAdmin && getPage() == 'maps';
+		const shouldCSVButtonDisabled = role && hasPermissions(role, UserRole.CSV) && getPage() == 'csv';
+		const shouldUnitsButtonDisabled = loggedInAsAdmin && getPage() == 'units';
+		const shouldConversionsButtonDisabled = loggedInAsAdmin && getPage() == 'conversions';
 		const renderLogoutButton = hasToken();
 
 		const loginLinkStyle: React.CSSProperties = {
@@ -58,10 +58,11 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 			paddingLeft: '5px'
 		};
 		const adminLinkStyle: React.CSSProperties = {
-			display: renderAdminButton ? 'inline' : 'none'
+			display: 'inline',
+			paddingLeft: '5px'
 		};
 		const csvLinkStyle: React.CSSProperties = {
-			display: renderCSVButton ? 'inline' : 'none',
+			display: 'inline',
 			paddingLeft: '5px'
 		};
 		const groupsLinkStyle: React.CSSProperties = {
@@ -73,15 +74,15 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 			paddingLeft: '5px'
 		};
 		const mapsLinkStyle: React.CSSProperties = {
-			display: renderMapsButton ? 'inline' : 'none',
+			display: 'inline',
 			paddingLeft: '5px'
 		};
 		const unitsLinkStyle: React.CSSProperties = {
-			display: renderUnitsButton ? 'inline' : 'none',
+			display: 'inline',
 			paddingLeft: '5px'
 		};
 		const conversionsLinkStyle: React.CSSProperties = {
-			display: renderConversionsButton ? 'inline' : 'none',
+			display: 'inline',
 			paddingLeft: '5px'
 		};
 		const logoutButtonStyle: React.CSSProperties = {
@@ -102,15 +103,15 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 				<div className={this.props.showCollapsedMenuButton ? 'd-none d-lg-block' : ''}>
 					<TooltipHelpContainer page='all' />
 					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
-					<Link style={adminLinkStyle} to='/admin'><Button outline><FormattedMessage id='admin.panel' /></Button></Link>
+					<Link style={adminLinkStyle} to='/admin'><Button disabled={shouldAdminButtonDisabled} outline><FormattedMessage id='admin.panel' /></Button></Link>
 					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
 					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
-					<Link style={mapsLinkStyle} to='/maps'><Button outline><FormattedMessage id='maps' /></Button></Link>
-					<Link style={csvLinkStyle} to='/csv'><Button outline><FormattedMessage id='csv' /></Button></Link>
+					<Link style={mapsLinkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>
+					<Link style={csvLinkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
 					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
 					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
-					<Link style={unitsLinkStyle} to='/units'><Button outline><FormattedMessage id='units' /></Button></Link>
-					<Link style={conversionsLinkStyle} to='/conversions'><Button outline><FormattedMessage id='conversions' /></Button></Link>
+					<Link style={unitsLinkStyle} to='/units'><Button disabled={shouldUnitsButtonDisabled} outline><FormattedMessage id='units' /></Button></Link>
+					<Link style={conversionsLinkStyle} to='/conversions'><Button disabled={shouldConversionsButtonDisabled} outline><FormattedMessage id='conversions' /></Button></Link>
 					<Link style={logoutButtonStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
 				</div>
 			</div>

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -33,27 +33,56 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		this.handleLogOut = this.handleLogOut.bind(this);
 	}
 
+	// TODO: Consider removing the getPage() !=== (currentPage) so nav bar is consistent across all pages.
 	public render() {
 		const role = this.props.role;
 		const loggedInAsAdmin = this.props.loggedInAsAdmin;
 		const showOptions = getPage() === '';
 		const renderLoginButton = !hasToken();
 		const shouldHomeButtonDisabled = getPage() === '';
-		const shouldAdminButtonDisabled = loggedInAsAdmin && getPage() == 'admin';
+		const renderAdminButton = loggedInAsAdmin && getPage() !== 'admin';
 		const shouldGroupsButtonDisabled = getPage() === 'groups';
 		const shouldMetersButtonDisabled = getPage() === 'meters';
-		const shouldMapsButtonDisabled = loggedInAsAdmin && getPage() == 'maps';
-		const shouldCSVButtonDisabled = Boolean(role && hasPermissions(role, UserRole.CSV) && getPage() == 'csv');
-		const shouldUnitsButtonDisabled = loggedInAsAdmin && getPage() == 'units';
-		const shouldConversionsButtonDisabled = loggedInAsAdmin && getPage() == 'conversions';
+		const renderMapsButton =loggedInAsAdmin && getPage() !== 'maps';
+		const renderCSVButton = role && hasPermissions(role, UserRole.CSV) && getPage() !== 'csv';
+		const renderUnitsButton = loggedInAsAdmin && getPage() !== 'units';
+		const renderConversionsButton = loggedInAsAdmin && getPage() !== 'conversions';
 		const renderLogoutButton = hasToken();
 
-		const linkStyle: React.CSSProperties = {
+		const loginLinkStyle: React.CSSProperties = {
+			display: renderLoginButton ? 'inline' : 'none',
+			paddingLeft: '5px'
+		};
+		const homeLinkStyle: React.CSSProperties = {
 			display: 'inline',
 			paddingLeft: '5px'
 		};
-		const loginLinkStyle: React.CSSProperties = {
-			display: renderLoginButton ? 'inline' : 'none',
+		const adminLinkStyle: React.CSSProperties = {
+			display: renderAdminButton || loggedInAsAdmin ? 'inline' : 'none',
+			paddingLeft: '5px'
+		};
+		const csvLinkStyle: React.CSSProperties = {
+			display: renderCSVButton || loggedInAsAdmin ? 'inline' : 'none',
+			paddingLeft: '5px'
+		};
+		const groupsLinkStyle: React.CSSProperties = {
+			display: 'inline',
+			paddingLeft: '5px'
+		};
+		const metersLinkStyle: React.CSSProperties = {
+			display: 'inline',
+			paddingLeft: '5px'
+		};
+		const mapsLinkStyle: React.CSSProperties = {
+			display: renderMapsButton || loggedInAsAdmin ? 'inline' : 'none',
+			paddingLeft: '5px'
+		};
+		const unitsLinkStyle: React.CSSProperties = {
+			display: renderUnitsButton || loggedInAsAdmin ? 'inline' : 'none',
+			paddingLeft: '5px'
+		};
+		const conversionsLinkStyle: React.CSSProperties = {
+			display: renderConversionsButton || loggedInAsAdmin ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
 		const logoutButtonStyle: React.CSSProperties = {
@@ -74,21 +103,15 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 				<div className={this.props.showCollapsedMenuButton ? 'd-none d-lg-block' : ''}>
 					<TooltipHelpContainer page='all' />
 					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
-					<Link style={linkStyle} to='/admin'><Button disabled={shouldAdminButtonDisabled} outline><FormattedMessage id='admin.panel' /></Button></Link>
-					<Link style={linkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
-					<Link style={linkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
-					<Link style={linkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>
-					<Link style={linkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
-					<Link style={linkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
+					<Link style={adminLinkStyle} to='/admin'><Button outline><FormattedMessage id='admin.panel' /></Button></Link>
+					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
+					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
+					<Link style={mapsLinkStyle} to='/maps'><Button outline><FormattedMessage id='maps' /></Button></Link>
+					<Link style={csvLinkStyle} to='/csv'><Button outline><FormattedMessage id='csv' /></Button></Link>
+					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
 					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
-					<Link style={linkStyle} to='/units'><Button disabled={shouldUnitsButtonDisabled} outline><FormattedMessage id='units' /></Button></Link>
-					<Link
-						style={linkStyle}
-						to='/conversions'>
-						<Button disabled={shouldConversionsButtonDisabled} outline>
-							<FormattedMessage id='conversions' />
-						</Button>
-					</Link>
+					<Link style={unitsLinkStyle} to='/units'><Button outline><FormattedMessage id='units' /></Button></Link>
+					<Link style={conversionsLinkStyle} to='/conversions'><Button outline><FormattedMessage id='conversions' /></Button></Link>
 					<Link style={logoutButtonStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
 				</div>
 			</div>

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -33,7 +33,6 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		this.handleLogOut = this.handleLogOut.bind(this);
 	}
 
-	// TODO: Consider removing the getPage() !=== (currentPage) so nav bar is consistent across all pages.
 	public render() {
 		const role = this.props.role;
 		const loggedInAsAdmin = this.props.loggedInAsAdmin;
@@ -44,7 +43,7 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		const shouldGroupsButtonDisabled = getPage() === 'groups';
 		const shouldMetersButtonDisabled = getPage() === 'meters';
 		const shouldMapsButtonDisabled = loggedInAsAdmin && getPage() == 'maps';
-		const shouldCSVButtonDisabled = role ? hasPermissions(role, UserRole.CSV) : getPage() == 'csv';
+		const shouldCSVButtonDisabled = Boolean(role && hasPermissions(role, UserRole.CSV) && getPage() == 'csv');
 		const shouldUnitsButtonDisabled = loggedInAsAdmin && getPage() == 'units';
 		const shouldConversionsButtonDisabled = loggedInAsAdmin && getPage() == 'conversions';
 		const renderLogoutButton = hasToken();
@@ -61,7 +60,6 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 			display: renderLogoutButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
-
 
 		return (
 			<div>

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -39,10 +39,10 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		const loggedInAsAdmin = this.props.loggedInAsAdmin;
 		const showOptions = getPage() === '';
 		const renderLoginButton = !hasToken();
-		const renderHomeButton = getPage() !== '';
+		const shouldHomeButtonDisabled = getPage() === '';
 		const renderAdminButton = loggedInAsAdmin && getPage() !== 'admin';
-		const renderGroupsButton = getPage() !== 'groups';
-		const renderMetersButton = getPage() !== 'meters';
+		const shouldGroupsButtonDisabled = getPage() === 'groups';
+		const shouldMetersButtonDisabled = getPage() === 'meters';
 		const renderMapsButton = loggedInAsAdmin && getPage() !== 'maps';
 		const renderCSVButton = role && hasPermissions(role, UserRole.CSV) && getPage() !== 'csv';
 		const renderUnitsButton = loggedInAsAdmin && getPage() !== 'units';
@@ -54,7 +54,7 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 			paddingLeft: '5px'
 		};
 		const homeLinkStyle: React.CSSProperties = {
-			display: renderHomeButton ? 'inline' : 'none',
+			display: 'inline',
 			paddingLeft: '5px'
 		};
 		const adminLinkStyle: React.CSSProperties = {
@@ -65,11 +65,11 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 			paddingLeft: '5px'
 		};
 		const groupsLinkStyle: React.CSSProperties = {
-			display: renderGroupsButton ? 'inline' : 'none',
+			display: 'inline',
 			paddingLeft: '5px'
 		};
 		const metersLinkStyle: React.CSSProperties = {
-			display: renderMetersButton ? 'inline' : 'none',
+			display: 'inline',
 			paddingLeft: '5px'
 		};
 		const mapsLinkStyle: React.CSSProperties = {
@@ -103,11 +103,11 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 					<TooltipHelpContainer page='all' />
 					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
 					<Link style={adminLinkStyle} to='/admin'><Button outline><FormattedMessage id='admin.panel' /></Button></Link>
-					<Link style={groupsLinkStyle} to='/groups'><Button outline><FormattedMessage id='groups' /></Button></Link>
-					<Link style={metersLinkStyle} to='/meters'><Button outline><FormattedMessage id='meters' /></Button></Link>
+					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
+					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
 					<Link style={mapsLinkStyle} to='/maps'><Button outline><FormattedMessage id='maps' /></Button></Link>
 					<Link style={csvLinkStyle} to='/csv'><Button outline><FormattedMessage id='csv' /></Button></Link>
-					<Link style={homeLinkStyle} to='/'><Button outline><FormattedMessage id='home' /></Button></Link>
+					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
 					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
 					<Link style={unitsLinkStyle} to='/units'><Button outline><FormattedMessage id='units' /></Button></Link>
 					<Link style={conversionsLinkStyle} to='/conversions'><Button outline><FormattedMessage id='conversions' /></Button></Link>

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -92,14 +92,60 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 							outline><FormattedMessage id='conversions' />
 						</Button>
 					</Link>
-					<Link style={csvLinkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
-					<Link style={linkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
-					<Link style={linkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
-					<Link style={adminViewableLinkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>
-					<Link style={linkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
-					<Link style={adminViewableLinkStyle} to='/units'><Button disabled={shouldUnitsButtonDisabled} outline><FormattedMessage id='units' /></Button></Link>
-					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
-					<Link style={adminViewableLinkStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
+					<Link
+						style={csvLinkStyle}
+						to='/csv'>
+						<Button disabled={shouldCSVButtonDisabled}
+							outline><FormattedMessage id='csv' />
+						</Button>
+					</Link>
+					<Link
+						style={linkStyle}
+						to='/groups'>
+						<Button disabled={shouldGroupsButtonDisabled}
+							outline><FormattedMessage id='groups' />
+						</Button>
+					</Link>
+					<Link
+						style={linkStyle}
+						to='/'>
+						<Button disabled={shouldHomeButtonDisabled}
+							outline><FormattedMessage id='home' />
+						</Button>
+					</Link>
+					<Link
+						style={adminViewableLinkStyle}
+						to='/maps'>
+						<Button disabled={shouldMapsButtonDisabled}
+							outline><FormattedMessage id='maps' />
+						</Button>
+					</Link>
+					<Link
+						style={linkStyle}
+						to='/meters'>
+						<Button disabled={shouldMetersButtonDisabled}
+							outline><FormattedMessage id='meters' />
+						</Button>
+					</Link>
+					<Link
+						style={adminViewableLinkStyle}
+						to='/units'>
+						<Button disabled={shouldUnitsButtonDisabled}
+							outline><FormattedMessage id='units' />
+						</Button>
+					</Link>
+					<Link
+						style={loginLinkStyle}
+						to='/login'>
+						<Button outline><FormattedMessage id='log.in' />
+						</Button>
+					</Link>
+					<Link
+						style={adminViewableLinkStyle}
+						to='/'>
+						<Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' />
+						</Button>
+					</Link>
 				</div>
 			</div>
 		);

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -35,63 +35,28 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 
 	// TODO: Consider removing the getPage() !=== (currentPage) so nav bar is consistent across all pages.
 	public render() {
-		const role = this.props.role;
 		const loggedInAsAdmin = this.props.loggedInAsAdmin;
 		const showOptions = getPage() === '';
 		const renderLoginButton = !hasToken();
 		const shouldHomeButtonDisabled = getPage() === '';
-		const renderAdminButton = loggedInAsAdmin;
 		const shouldAdminButtonDisabled = getPage() === 'admin';
 		const shouldGroupsButtonDisabled = getPage() === 'groups';
 		const shouldMetersButtonDisabled = getPage() === 'meters';
-		const renderMapsButton = loggedInAsAdmin;
 		const shouldMapsButtonDisabled = getPage() === 'maps';
-		const renderCSVButton = Boolean(role && hasPermissions(role, UserRole.CSV));
 		const shouldCSVButtonDisabled = getPage() === 'csv';
-		const renderUnitsButton = loggedInAsAdmin;
 		const shouldUnitsButtonDisabled = getPage() === 'units';
-		const renderConversionsButton = loggedInAsAdmin;
 		const shouldConversionsButtonDisabled = getPage() === 'conversions';
-		const renderLogoutButton = hasToken();
 
+		const linkStyle: React.CSSProperties = {
+			display: 'inline',
+			paddingLeft: '5px'
+		};
 		const loginLinkStyle: React.CSSProperties = {
 			display: renderLoginButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
-		const homeLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const adminLinkStyle: React.CSSProperties = {
-			display: renderAdminButton ? 'inline' : 'none',
-			paddingLeft: '5px'
-		};
-		const csvLinkStyle: React.CSSProperties = {
-			display: renderCSVButton ? 'inline' : 'none',
-			paddingLeft: '5px'
-		};
-		const groupsLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const metersLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const mapsLinkStyle: React.CSSProperties = {
-			display: renderMapsButton ? 'inline' : 'none',
-			paddingLeft: '5px'
-		};
-		const unitsLinkStyle: React.CSSProperties = {
-			display: renderUnitsButton ? 'inline' : 'none',
-			paddingLeft: '5px'
-		};
-		const conversionsLinkStyle: React.CSSProperties = {
-			display: renderConversionsButton ? 'inline' : 'none',
-			paddingLeft: '5px'
-		};
-		const logoutButtonStyle: React.CSSProperties = {
-			display: renderLogoutButton ? 'inline' : 'none',
+		const adminViewableLinkStyle= {
+			display: loggedInAsAdmin ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
 
@@ -108,22 +73,28 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 				<div className={this.props.showCollapsedMenuButton ? 'd-none d-lg-block' : ''}>
 					<TooltipHelpContainer page='all' />
 					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
-					<Link style={adminLinkStyle} to='/admin'><Button disabled={shouldAdminButtonDisabled} outline><FormattedMessage id='admin.panel' /></Button></Link>
 					<Link
-						style={conversionsLinkStyle}
+						style={adminViewableLinkStyle}
+						to='/admin'>
+						<Button disabled={shouldAdminButtonDisabled}
+							outline><FormattedMessage id='admin.panel' />
+						</Button>
+					</Link>
+					<Link
+						style={adminViewableLinkStyle}
 						to='/conversions'>
 						<Button disabled={shouldConversionsButtonDisabled}
 							outline><FormattedMessage id='conversions' />
 						</Button>
 					</Link>
-					<Link style={csvLinkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
-					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
-					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
-					<Link style={mapsLinkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>
-					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
-					<Link style={unitsLinkStyle} to='/units'><Button disabled={shouldUnitsButtonDisabled} outline><FormattedMessage id='units' /></Button></Link>
+					<Link style={adminViewableLinkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
+					<Link style={linkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
+					<Link style={linkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
+					<Link style={adminViewableLinkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>
+					<Link style={linkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
+					<Link style={adminViewableLinkStyle} to='/units'><Button disabled={shouldUnitsButtonDisabled} outline><FormattedMessage id='units' /></Button></Link>
 					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
-					<Link style={logoutButtonStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
+					<Link style={adminViewableLinkStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
 				</div>
 			</div>
 		);

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -40,13 +40,18 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		const showOptions = getPage() === '';
 		const renderLoginButton = !hasToken();
 		const shouldHomeButtonDisabled = getPage() === '';
-		const renderAdminButton = loggedInAsAdmin && getPage() == 'admin';
+		const renderAdminButton = loggedInAsAdmin;
+		const shouldAdminButtonDisabled = getPage() === 'admin';
 		const shouldGroupsButtonDisabled = getPage() === 'groups';
 		const shouldMetersButtonDisabled = getPage() === 'meters';
-		const renderMapsButton =loggedInAsAdmin && getPage() == 'maps';
-		const renderCSVButton = Boolean(role && hasPermissions(role, UserRole.CSV) && getPage() == 'csv');
-		const renderUnitsButton = loggedInAsAdmin && getPage() == 'units';
-		const renderConversionsButton = loggedInAsAdmin && getPage() == 'conversions';
+		const renderMapsButton = loggedInAsAdmin;
+		const shouldMapsButtonDisabled = getPage() === 'maps';
+		const renderCSVButton = Boolean(role && hasPermissions(role, UserRole.CSV));
+		const shouldCSVButtonDisabled = getPage() === 'csv';
+		const renderUnitsButton = loggedInAsAdmin;
+		const shouldUnitsButtonDisabled = getPage() === 'units';
+		const renderConversionsButton = loggedInAsAdmin;
+		const shouldConversionsButtonDisabled = getPage() === 'conversions';
 		const renderLogoutButton = hasToken();
 
 		const loginLinkStyle: React.CSSProperties = {
@@ -58,11 +63,11 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 			paddingLeft: '5px'
 		};
 		const adminLinkStyle: React.CSSProperties = {
-			display: renderAdminButton || loggedInAsAdmin ? 'inline' : 'none',
+			display: renderAdminButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
 		const csvLinkStyle: React.CSSProperties = {
-			display: renderCSVButton || loggedInAsAdmin ? 'inline' : 'none',
+			display: renderCSVButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
 		const groupsLinkStyle: React.CSSProperties = {
@@ -74,15 +79,15 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 			paddingLeft: '5px'
 		};
 		const mapsLinkStyle: React.CSSProperties = {
-			display: renderMapsButton || loggedInAsAdmin ? 'inline' : 'none',
+			display: renderMapsButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
 		const unitsLinkStyle: React.CSSProperties = {
-			display: renderUnitsButton || loggedInAsAdmin ? 'inline' : 'none',
+			display: renderUnitsButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
 		const conversionsLinkStyle: React.CSSProperties = {
-			display: renderConversionsButton || loggedInAsAdmin ? 'inline' : 'none',
+			display: renderConversionsButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
 		const logoutButtonStyle: React.CSSProperties = {
@@ -103,20 +108,20 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 				<div className={this.props.showCollapsedMenuButton ? 'd-none d-lg-block' : ''}>
 					<TooltipHelpContainer page='all' />
 					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
-					<Link style={adminLinkStyle} to='/admin'><Button disabled={renderAdminButton} outline><FormattedMessage id='admin.panel' /></Button></Link>
+					<Link style={adminLinkStyle} to='/admin'><Button disabled={shouldAdminButtonDisabled} outline><FormattedMessage id='admin.panel' /></Button></Link>
 					<Link
 						style={conversionsLinkStyle}
 						to='/conversions'>
-						<Button disabled={renderConversionsButton}
+						<Button disabled={shouldConversionsButtonDisabled}
 							outline><FormattedMessage id='conversions' />
 						</Button>
 					</Link>
-					<Link style={csvLinkStyle} to='/csv'><Button disabled={renderCSVButton} outline><FormattedMessage id='csv' /></Button></Link>
+					<Link style={csvLinkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
 					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
 					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
-					<Link style={mapsLinkStyle} to='/maps'><Button disabled={renderMapsButton} outline><FormattedMessage id='maps' /></Button></Link>
+					<Link style={mapsLinkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>
 					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
-					<Link style={unitsLinkStyle} to='/units'><Button disabled={renderUnitsButton} outline><FormattedMessage id='units' /></Button></Link>
+					<Link style={unitsLinkStyle} to='/units'><Button disabled={shouldUnitsButtonDisabled} outline><FormattedMessage id='units' /></Button></Link>
 					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
 					<Link style={logoutButtonStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
 				</div>

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -33,8 +33,8 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		this.handleLogOut = this.handleLogOut.bind(this);
 	}
 
-	// TODO: Consider removing the getPage() !=== (currentPage) so nav bar is consistent across all pages.
 	public render() {
+		const role = this.props.role;
 		const loggedInAsAdmin = this.props.loggedInAsAdmin;
 		const showOptions = getPage() === '';
 		const renderLoginButton = !hasToken();
@@ -44,6 +44,7 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		const shouldMetersButtonDisabled = getPage() === 'meters';
 		const shouldMapsButtonDisabled = getPage() === 'maps';
 		const shouldCSVButtonDisabled = getPage() === 'csv';
+		const renderCSVButton = Boolean(role && hasPermissions(role, UserRole.CSV));
 		const shouldUnitsButtonDisabled = getPage() === 'units';
 		const shouldConversionsButtonDisabled = getPage() === 'conversions';
 
@@ -55,8 +56,12 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 			display: renderLoginButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
-		const adminViewableLinkStyle= {
+		const adminViewableLinkStyle: React.CSSProperties = {
 			display: loggedInAsAdmin ? 'inline' : 'none',
+			paddingLeft: '5px'
+		};
+		const csvLinkStyle: React.CSSProperties = {
+			display: renderCSVButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
 
@@ -87,7 +92,7 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 							outline><FormattedMessage id='conversions' />
 						</Button>
 					</Link>
-					<Link style={adminViewableLinkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
+					<Link style={csvLinkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
 					<Link style={linkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
 					<Link style={linkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
 					<Link style={adminViewableLinkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -104,14 +104,14 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 					<TooltipHelpContainer page='all' />
 					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
 					<Link style={adminLinkStyle} to='/admin'><Button outline><FormattedMessage id='admin.panel' /></Button></Link>
-					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
-					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
-					<Link style={mapsLinkStyle} to='/maps'><Button outline><FormattedMessage id='maps' /></Button></Link>
-					<Link style={csvLinkStyle} to='/csv'><Button outline><FormattedMessage id='csv' /></Button></Link>
-					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
-					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
-					<Link style={unitsLinkStyle} to='/units'><Button outline><FormattedMessage id='units' /></Button></Link>
 					<Link style={conversionsLinkStyle} to='/conversions'><Button outline><FormattedMessage id='conversions' /></Button></Link>
+					<Link style={csvLinkStyle} to='/csv'><Button outline><FormattedMessage id='csv' /></Button></Link>
+					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
+					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
+					<Link style={mapsLinkStyle} to='/maps'><Button outline><FormattedMessage id='maps' /></Button></Link>
+					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
+					<Link style={unitsLinkStyle} to='/units'><Button outline><FormattedMessage id='units' /></Button></Link>
+					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
 					<Link style={logoutButtonStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
 				</div>
 			</div>

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -44,51 +44,24 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		const shouldGroupsButtonDisabled = getPage() === 'groups';
 		const shouldMetersButtonDisabled = getPage() === 'meters';
 		const shouldMapsButtonDisabled = loggedInAsAdmin && getPage() == 'maps';
-		const shouldCSVButtonDisabled = role && hasPermissions(role, UserRole.CSV) && getPage() == 'csv';
+		const shouldCSVButtonDisabled = role ? hasPermissions(role, UserRole.CSV) : getPage() == 'csv';
 		const shouldUnitsButtonDisabled = loggedInAsAdmin && getPage() == 'units';
 		const shouldConversionsButtonDisabled = loggedInAsAdmin && getPage() == 'conversions';
 		const renderLogoutButton = hasToken();
 
+		const linkStyle: React.CSSProperties = {
+			display: 'inline',
+			paddingLeft: '5px'
+		};
 		const loginLinkStyle: React.CSSProperties = {
 			display: renderLoginButton ? 'inline' : 'none',
-			paddingLeft: '5px'
-		};
-		const homeLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const adminLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const csvLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const groupsLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const metersLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const mapsLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const unitsLinkStyle: React.CSSProperties = {
-			display: 'inline',
-			paddingLeft: '5px'
-		};
-		const conversionsLinkStyle: React.CSSProperties = {
-			display: 'inline',
 			paddingLeft: '5px'
 		};
 		const logoutButtonStyle: React.CSSProperties = {
 			display: renderLogoutButton ? 'inline' : 'none',
 			paddingLeft: '5px'
 		};
+
 
 		return (
 			<div>
@@ -103,15 +76,21 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 				<div className={this.props.showCollapsedMenuButton ? 'd-none d-lg-block' : ''}>
 					<TooltipHelpContainer page='all' />
 					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
-					<Link style={adminLinkStyle} to='/admin'><Button disabled={shouldAdminButtonDisabled} outline><FormattedMessage id='admin.panel' /></Button></Link>
-					<Link style={groupsLinkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
-					<Link style={metersLinkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
-					<Link style={mapsLinkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>
-					<Link style={csvLinkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
-					<Link style={homeLinkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
+					<Link style={linkStyle} to='/admin'><Button disabled={shouldAdminButtonDisabled} outline><FormattedMessage id='admin.panel' /></Button></Link>
+					<Link style={linkStyle} to='/groups'><Button disabled={shouldGroupsButtonDisabled} outline><FormattedMessage id='groups' /></Button></Link>
+					<Link style={linkStyle} to='/meters'><Button disabled={shouldMetersButtonDisabled} outline><FormattedMessage id='meters' /></Button></Link>
+					<Link style={linkStyle} to='/maps'><Button disabled={shouldMapsButtonDisabled} outline><FormattedMessage id='maps' /></Button></Link>
+					<Link style={linkStyle} to='/csv'><Button disabled={shouldCSVButtonDisabled} outline><FormattedMessage id='csv' /></Button></Link>
+					<Link style={linkStyle} to='/'><Button disabled={shouldHomeButtonDisabled} outline><FormattedMessage id='home' /></Button></Link>
 					<Link style={loginLinkStyle} to='/login'><Button outline><FormattedMessage id='log.in' /></Button></Link>
-					<Link style={unitsLinkStyle} to='/units'><Button disabled={shouldUnitsButtonDisabled} outline><FormattedMessage id='units' /></Button></Link>
-					<Link style={conversionsLinkStyle} to='/conversions'><Button disabled={shouldConversionsButtonDisabled} outline><FormattedMessage id='conversions' /></Button></Link>
+					<Link style={linkStyle} to='/units'><Button disabled={shouldUnitsButtonDisabled} outline><FormattedMessage id='units' /></Button></Link>
+					<Link
+						style={linkStyle}
+						to='/conversions'>
+						<Button disabled={shouldConversionsButtonDisabled} outline>
+							<FormattedMessage id='conversions' />
+						</Button>
+					</Link>
 					<Link style={logoutButtonStyle} to='/'><Button outline onClick={this.handleLogOut}><FormattedMessage id='log.out' /></Button></Link>
 				</div>
 			</div>


### PR DESCRIPTION
# Description
As part of the CodeDay Microinternship, our group, @AriseTran @TrongQuocLe @tranchung163 @Cao1224, made changes to the page buttons so that the buttons are always displaying and will be greyed out depending on the tab that the user is on. 
Issue #802  was caused by the page buttons originally being made dynamic.

https://user-images.githubusercontent.com/104533320/198497982-e2804028-0a96-4e63-91ae-d1b83c459288.mp4

Fixes #802 


## Type of change
- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist
- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request