### PR TITLE
Fix automated test generating script

### DIFF
--- a/src/server/data/automatedTestingData.js
+++ b/src/server/data/automatedTestingData.js
@@ -493,6 +493,7 @@ async function insertSpecialMeters(conn) {
 			undefined, // reading
 			undefined, // startTimestamp
 			undefined, // endTimestamp
+			undefined, // previousEnd
 			meterUnit, // unit
 			meterGraphicUnit // default graphic unit
 		);

--- a/src/server/data/automatedTestingData.js
+++ b/src/server/data/automatedTestingData.js
@@ -475,7 +475,7 @@ async function insertSpecialMeters(conn) {
 			null, // URL
 			false, // enabled
 			meterData[3], //displayable
-			'other', //type
+			'other', // type
 			null, // timezone
 			undefined, // gps
 			undefined, // identifier
@@ -489,7 +489,7 @@ async function insertSpecialMeters(conn) {
 			90000, // readingVariation
 			undefined, //readingDuplication
 			undefined, // timeSort
-			undefined, //endOnlyTime
+			undefined, // endOnlyTime
 			undefined, // reading
 			undefined, // startTimestamp
 			undefined, // endTimestamp

--- a/src/server/models/obvius/processConfigFile.js
+++ b/src/server/models/obvius/processConfigFile.js
@@ -39,34 +39,35 @@ async function processConfigFile(configFile) {
 	}
 	for (internalMeterName of Object.keys(metersHash)) {
 		metersArray.push(new Meter(
-			undefined,
-			internalMeterName,
-			undefined,
-			false,
-			false,
-			Meter.type.OBVIUS,
-			null,
-			undefined,
+			undefined, // id
+			internalMeterName, // name
+			undefined, // URL
+			false, // enabled
+			false, // displayable
+			Meter.type.OBVIUS, // type 
+			null, // timezone
+			undefined, // gps
 			// Sometimes the NAME is not unique so append with internalMeterName so does not fail
 			// the uniqueness of the identifier.
-			metersHash[internalMeterName].NAME + ' for ' + internalMeterName,
-			'created via obvious config upload on ' + moment().format(),
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
+			metersHash[internalMeterName].NAME + ' for ' + internalMeterName, // identifier
+			'created via obvious config upload on ' + moment().format(), // note
+			undefined, //area
+			undefined, // cumulative
+			undefined, // cumulativeReset
+			undefined, // cumulativeResetStart
+			undefined, // cumulativeResetEnd
+			undefined, // readingGap
+			undefined, // readingVariation
+			undefined, // readingDuplication
+			undefined, // timeSort
 			// Obvious meters only have one reading so end only.
-			true,
-			undefined,
-			undefined,
-			undefined,
-			unitId,
-			unitId
+			true, // endOnlyTime
+			undefined, // reading
+			undefined, // startTimestamp
+			undefined, // endTimestamp
+			undefined, // previousEnd
+			unitId, // unit
+			unitId // default graphic unit
 			)
 		);
 	}

--- a/src/server/services/csvPipeline/uploadReadings.js
+++ b/src/server/services/csvPipeline/uploadReadings.js
@@ -38,6 +38,7 @@ async function uploadReadings(req, res, filepath, conn) {
 			} else {
 				// If createMeter is true, we will create the meter for the user.
 				// The meter type is unknown so set to other.
+				// This uses a lot of default values for meter parameters.
 				const tempMeter = new Meter(undefined, meterName, undefined, false, false, Meter.type.OTHER, undefined, undefined, meterName,
 					'created via reading upload on ' + moment().format());
 				await tempMeter.insert(conn);

--- a/src/server/services/obvius/loadLogfileToReadings.js
+++ b/src/server/services/obvius/loadLogfileToReadings.js
@@ -24,10 +24,34 @@ async function loadLogfileToReadings(serialNumber, ipAddress, logfile, conn) {
 			// Data was sent for a meter that did not have a config file sent before this.
 			// As a result, we cannot know the unit so make unknown for now.
 			// The admin need to set the unit before making it displayable or it cannot be graphed.
-			meter = new Meter(undefined, `${serialNumber}.${i}`, ipAddress, true, false, Meter.type.OBVIUS,
-				null, undefined, `OBVIUS ${serialNumber} COLUMN ${i}`, 'created via obvius log upload on ' +
-				moment().format(), undefined, undefined, undefined, undefined, undefined, undefined, undefined,
-				undefined, undefined, true, undefined, undefined, undefined, undefined, undefined);
+			meter = new Meter(
+				undefined, // id
+				`${serialNumber}.${i}`, // name
+				ipAddress, // URL
+				true, // enabled
+				false, // displayable
+				Meter.type.OBVIUS, // type
+				null, //timezone
+				undefined, // gps
+				`OBVIUS ${serialNumber} COLUMN ${i}`, // identifier
+				'created via obvius log upload on ' + moment().format(), // note
+				undefined, // area
+				undefined, // cumulative
+				undefined, //cumulativeReset
+				undefined, // cumulativeResetStart
+				undefined, // cumulativeResetEnd
+				undefined, // readingGap
+				undefined, // readingVariation
+				undefined, //readingDuplication
+				undefined, // timeSort
+				true, // endOnlyTime
+				undefined, // reading
+				undefined, // startTimestamp
+				undefined, // endTimestamp
+				undefined, // previousEnd
+				undefined, // unit
+				undefined // default graphic unit
+			);
 			await meter.insert(conn);
 			log.warn('WARNING: Created a meter (' + `${serialNumber}.${i}` +
 				') that does not already exist. Normally obvius meters created by an uploaded ConfigFile.');

--- a/src/server/services/readMamacMeters.js
+++ b/src/server/services/readMamacMeters.js
@@ -52,8 +52,8 @@ async function getMeterInfo(url, ip, csvLine) {
 	// TODO: get the unit when the MAMAC meter is first probed and created.
 	// For now, we assume they are kWh as before resource generalization.
 	let displayable = true;
-	const kWhUnit = await Unit.getByName( 'kWh', conn );
-	let unitId; 
+	const kWhUnit = await Unit.getByName('kWh', conn);
+	let unitId;
 	if (kWhUnit === null) {
 		log.warn("kWh not found while creating MAMAC meter so units set to undefined and not displayable");
 		displayable = false;
@@ -66,8 +66,34 @@ async function getMeterInfo(url, ip, csvLine) {
 		.then(xml => {
 			const name = xml.Maverick.NodeID[0];
 			// For historical reasons, MAMAC meters store the IP address and not the URL.
-			return new Meter(undefined, name, ip, true, displayable, Meter.type.MAMAC, null, undefined, undefined,
-				'created via MAMAC meter upload on ' + moment().format(), unitId, unitId);
+			return new Meter(
+				undefined, // id
+				name, // name
+				ip, // URL
+				true, // enabled
+				displayable, // displayable
+				Meter.type.MAMAC, // type
+				null, // timezone
+				undefined, //gps
+				undefined, // identifier
+				'created via MAMAC meter upload on ' + moment().format(), // note
+				null, //area
+				undefined, // cumulative
+				undefined, //cumulativeReset
+				undefined, // cumulativeResetStart
+				undefined, // cumulativeResetEnd
+				90000, // readingGap
+				90000, // readingVariation
+				undefined, //readingDuplication
+				undefined, // timeSort
+				undefined, //endOnlyTime
+				undefined, // reading
+				undefined, // startTimestamp
+				undefined, // endTimestamp
+				undefined, // previousEnd
+				unitId, // unit
+				unitId // default graphic unit
+			);
 		});
 }
 
@@ -89,7 +115,7 @@ function infoForAllMeters(rows, conn) {
 async function insertMeters(rows, conn) {
 	const errors = [];
 	await Promise.all(infoForAllMeters(rows, conn).map(
-			(promise, index) => promise
+		(promise, index) => promise
 			.then(async meter => {
 				if (await meter.existsByName(conn)) {
 					log.info(`CSV line ${index + 2}: Skipping existing meter ${meter.name}`);
@@ -98,7 +124,7 @@ async function insertMeters(rows, conn) {
 				}
 			})
 			.catch(error => errors.push(error))
-		)
+	)
 	);
 	return errors;
 }

--- a/src/server/test/db/baselineTests.js
+++ b/src/server/test/db/baselineTests.js
@@ -14,6 +14,7 @@ mocha.describe('Baselines', () => {
 	mocha.it('can be saved and retrieved', async () => {
 		conn = testDB.getConnection();
 		// Need a meter in the database
+		// TODO: If used note this does not have the more recent meter values.
 		const meter = new Meter(undefined, 'Larry', null, false, true, Meter.type.MAMAC, null, gps);
 		await meter.insert(conn);
 		const reading = new Reading(

--- a/src/server/test/db/compareTests.js
+++ b/src/server/test/db/compareTests.js
@@ -33,8 +33,34 @@ mocha.describe('Compare readings', () => {
 		await redoCik(conn);
 		// Make the meter be a kWh meter.
 		const meterUnitId = (await Unit.getByName('Electric_utility', conn)).id;
-		await new Meter(undefined, 'Meter', null, false, true, Meter.type.OTHER, 'CST', undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
-			undefined, undefined, undefined, undefined, undefined, meterUnitId, meterUnitId).insert(conn);
+		await new Meter(
+			undefined, // id
+			'Meter', // name
+			null, // URL
+			false, // enabled
+			true, // displayable
+			Meter.type.OTHER, // type
+			'CST', // timezone
+			undefined, // gps
+			undefined, // identifier
+			undefined, // note
+			undefined, // area
+			undefined, // cumulative
+			undefined, //cumulativeReset
+			undefined, // cumulativeResetStart
+			undefined, // cumulativeResetEnd
+			undefined, // readingGap
+			undefined, // readingVariation
+			undefined, //readingDuplication
+			undefined, // timeSort
+			true, // endOnlyTime
+			undefined, // reading
+			undefined, // startTimestamp
+			undefined, // endTimestamp
+			undefined, // previousEnd
+			meterUnitId, // unit
+			meterUnitId // default graphic unit
+		).insert(conn);
 		meter = await Meter.getByName('Meter', conn);
 		await Reading.insertAll([
 			new Reading(meter.id, 1, prevStart, prevEnd),


### PR DESCRIPTION
# Description

PR #781 added a new column (`previousEnd`) for the meter table, which leads to a small bug in the `testData` script. This PR fixes this issue.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations
