### PR TITLE
use identifier in graphics

### DIFF
--- a/src/client/app/containers/BarChartContainer.ts
+++ b/src/client/app/containers/BarChartContainer.ts
@@ -56,7 +56,7 @@ function mapStateToProps(state: State) {
 			byMeterID[timeInterval.toString()][barDuration.toISOString()] !== undefined) {
 			const readingsData = byMeterID[timeInterval.toString()][barDuration.toISOString()][unitID];
 			if (readingsData !== undefined && !readingsData.isFetching) {
-				const label = state.meters.byMeterID[meterID].name;
+				const label = state.meters.byMeterID[meterID].identifier;
 				const colorID = meterID;
 				if (readingsData.readings === undefined) {
 					throw new Error('Unacceptable condition: readingsData.readings is undefined.');

--- a/src/client/app/containers/CompareChartContainer.ts
+++ b/src/client/app/containers/CompareChartContainer.ts
@@ -94,7 +94,7 @@ function mapStateToProps(state: State, ownProps: CompareChartContainerProps): an
 
 	// Compose the text to display to the user.
 	const entity = ownProps.entity;
-	const changeSummary = getCompareChangeSummary(entity.change, entity.name, periodLabels);
+	const changeSummary = getCompareChangeSummary(entity.change, entity.identifier, periodLabels);
 
 	const barColor = 'rgba(218, 165, 32, 1)';
 

--- a/src/client/app/containers/LineChartContainer.ts
+++ b/src/client/app/containers/LineChartContainer.ts
@@ -66,7 +66,7 @@ function mapStateToProps(state: State) {
 		if (byMeterID !== undefined) {
 			const readingsData = byMeterID[timeInterval.toString()][unitID];
 			if (readingsData !== undefined && !readingsData.isFetching) {
-				const label = state.meters.byMeterID[meterID].name;
+				const label = state.meters.byMeterID[meterID].identifier;
 				const colorID = meterID;
 				if (readingsData.readings === undefined) {
 					throw new Error('Unacceptable condition: readingsData.readings is undefined.');

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -119,7 +119,7 @@ function mapStateToProps(state: State) {
 							// This protects against there being no readings or that the data is being updated.
 							if (readingsData !== undefined && !readingsData.isFetching) {
 								// Meter name to include in hover on graph.
-								const label = state.meters.byMeterID[meterID].name;
+								const label = state.meters.byMeterID[meterID].identifier;
 								// The usual color for this meter.
 								colors.push(getGraphColor(meterID, DataType.Meter));
 								if (readingsData.readings === undefined) {

--- a/src/client/app/containers/MultiCompareChartContainer.ts
+++ b/src/client/app/containers/MultiCompareChartContainer.ts
@@ -14,6 +14,7 @@ export interface CompareEntity {
 	id: number;
 	isGroup: boolean;
 	name: string;
+	identifier: string;
 	change: number;
 	currUsage: number;
 	prevUsage: number;
@@ -41,12 +42,14 @@ function getDataForIDs(ids: number[], isGroup: boolean, state: State): CompareEn
 	const entities: CompareEntity[] = [];
 	for (const id of ids) {
 		let name: string;
+		let identifier: string = 'none';
 		let readingsData: CompareReadingsData | undefined;
 		if (isGroup) {
 			name = getGroupName(state, id);
 			readingsData = getGroupReadingsData(state, id, timeInterval, compareShift);
 		} else {
 			name = getMeterName(state, id);
+			identifier = getMeterIdentifier(state, id);
 			readingsData = getMeterReadingsData(state, id, timeInterval, compareShift);
 		}
 		if (isReadingsDataValid(readingsData)) {
@@ -54,7 +57,7 @@ function getDataForIDs(ids: number[], isGroup: boolean, state: State): CompareEn
 			const currUsage = readingsData!.curr_use!;
 			const prevUsage = readingsData!.prev_use!;
 			const change = calculateChange(currUsage, prevUsage);
-			const entity: CompareEntity = { id, isGroup, name, change, currUsage, prevUsage };
+			const entity: CompareEntity = { id, isGroup, name, identifier, change, currUsage, prevUsage };
 			entities.push(entity);
 			/* eslint-enable @typescript-eslint/no-non-null-assertion */
 		}
@@ -74,6 +77,13 @@ function getMeterName(state: State, meterID: number): string {
 		return '';
 	}
 	return state.meters.byMeterID[meterID].name;
+}
+
+function getMeterIdentifier(state: State, meterID: number): string {
+	if (state.meters.byMeterID[meterID] === undefined) {
+		return '';
+	}
+	return state.meters.byMeterID[meterID].identifier;
 }
 
 function getGroupReadingsData(state: State, groupID: number, timeInterval: TimeInterval,
@@ -128,12 +138,12 @@ function sortIDs(ids: CompareEntity[], sortingOrder: SortingOrder): CompareEntit
 	switch (sortingOrder) {
 		case SortingOrder.Alphabetical:
 			ids.sort((a, b) => {
-				const nameA = a.name.toLowerCase().trim();
-				const nameB = b.name.toLowerCase().trim();
-				if (nameA < nameB) {
+				const identifierA = a.identifier.toLowerCase().trim();
+				const identifierB = b.identifier.toLowerCase().trim();
+				if (identifierA < identifierB) {
 					return -1;
 				}
-				if (nameA > nameB) {
+				if (identifierA > identifierB) {
 					return 1;
 				}
 				return 0;


### PR DESCRIPTION
# Description

The resource generalization upgrades changed the meter menus to use the identifier instead of the name. This should complete the process of switching from meter name to identifier by also making this change on all four graphics pages. It uses the identifier for the meters at the top and on the hover text. It also sorts by identifier on the compare page. As this is part of the ongoing work that has not been given to users, there is no issue associated with it.

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known.
