### PR TITLE
meters hidden

### DIFF
--- a/src/client/app/components/ChartDataSelectComponent.tsx
+++ b/src/client/app/components/ChartDataSelectComponent.tsx
@@ -514,6 +514,9 @@ function getSelectOptionsByItem(compatibleItems: Set<number>, incompatibleItems:
 			label = state.byGroupID[itemId].name;
 		}
 		else { label = ''; }
+		// TODO This is a bit of a hack. When an admin logs in they may not have the new state so label is null.
+		// This should clear once the state is loaded.
+		label = label === null ? '' : label;
 		finalItems.push({
 			value: itemId,
 			label: label,
@@ -533,6 +536,9 @@ function getSelectOptionsByItem(compatibleItems: Set<number>, incompatibleItems:
 			label = state.byGroupID[itemId].name;
 		}
 		else { label = ''; }
+		// TODO This is a bit of a hack. When an admin logs in they may not have the new state so label is null.
+		// This should clear once the state is loaded.
+		label = label === null ? '' : label;
 		finalItems.push({
 			value: itemId,
 			label: label,

--- a/src/client/app/components/meters/MetersDetailComponent.tsx
+++ b/src/client/app/components/meters/MetersDetailComponent.tsx
@@ -39,6 +39,16 @@ export default function MetersDetailComponent() {
 	const currentUser = useSelector((state: State) => state.currentUser.profile);
 	const loggedInAsAdmin = (currentUser !== null) && isRoleAdmin(currentUser.role);
 
+	// We only want displayable meters if non-admins because they still have
+	// non-displayable in state.
+	let visibleMeters
+	if (loggedInAsAdmin) {
+		visibleMeters = MetersState;
+	} else {
+		visibleMeters = _.filter(MetersState, (meter: MeterData) => {
+			return meter.displayable === true
+		});
+	}
 
 	// Units state
 	const units = useSelector((state: State) => state.units.units);
@@ -122,7 +132,7 @@ export default function MetersDetailComponent() {
 				{metersStateLoaded && unitsStateLoaded &&
 					<div className="card-container">
 						{/* Create a MeterViewComponent for each MeterData in Meters State after sorting by identifier */}
-						{Object.values(MetersState)
+						{Object.values(visibleMeters)
 							.sort((MeterA: MeterData, MeterB: MeterData) => (MeterA.identifier.toLowerCase() > MeterB.identifier.toLowerCase()) ? 1 :
 								((MeterB.identifier.toLowerCase() > MeterA.identifier.toLowerCase()) ? -1 : 0))
 							.map(MeterData => (<MeterViewComponent

--- a/src/client/app/containers/groups/GroupViewContainer.ts
+++ b/src/client/app/containers/groups/GroupViewContainer.ts
@@ -9,12 +9,13 @@ import { Dispatch } from '../../types/redux/actions';
 import { State } from '../../types/redux/state';
 import { DisplayMode } from '../../types/redux/groups';
 import { isRoleAdmin } from '../../utils/hasPermissions';
-function mapStateToProps(state: State, ownProps: {id: number}) {
+function mapStateToProps(state: State, ownProps: { id: number }) {
 	const id = ownProps.id;
 	const childMeterNames: string[] = [];
 	state.groups.byGroupID[id].childMeters.forEach((meterID: number) => {
-		if (state.meters.byMeterID[meterID] !== undefined) {
-			childMeterNames.push(state.meters.byMeterID[meterID].name.trim());
+		// See below with same logic for why.
+		if (state.meters.byMeterID[meterID] !== undefined && state.meters.byMeterID[meterID].identifier !== null) {
+			childMeterNames.push(state.meters.byMeterID[meterID].identifier.trim());
 		}
 	});
 	childMeterNames.sort();
@@ -29,14 +30,17 @@ function mapStateToProps(state: State, ownProps: {id: number}) {
 	const trueGroupSize = state.groups.byGroupID[id].childGroups.length;
 	const deepMeterNames: string[] = [];
 	state.groups.byGroupID[id].deepMeters.forEach((meterID: number) => {
-		if (state.meters.byMeterID[meterID] !== undefined) {
-			deepMeterNames.push(state.meters.byMeterID[meterID].name.trim());
+		// TODO We need a more general fix for hidden groups and meters but waiting until the major changes for units is done.
+		// Meter state should no longer be undefined but leaving for now.
+		// Also must check for null name since we do that for non-admin. Same above.
+		if (state.meters.byMeterID[meterID] !== undefined && state.meters.byMeterID[meterID].identifier !== null) {
+			deepMeterNames.push(state.meters.byMeterID[meterID].identifier.trim());
 		}
 	});
 	deepMeterNames.sort();
 	const currentUser = state.currentUser.profile;
 	let loggedInAsAdmin = false;
-	if(currentUser !== null){
+	if (currentUser !== null) {
 		loggedInAsAdmin = isRoleAdmin(currentUser.role);
 	}
 

--- a/src/server/test/web/meters.js
+++ b/src/server/test/web/meters.js
@@ -14,14 +14,17 @@ const moment = require('moment-timezone');
 const gps = new Point(90, 45);
 const Unit = require('../../models/Unit');
 
+// TODO These tests are not as good as they should be now that information on
+// meters is returned to all users. They should be updated.
+
 /**
  * Verifies the values in the meter are the ones expected.
  * @param {*} meters If # meters > 1 then array of meters, else single meter
  * @param {*} length # meters to check and in meters
- * @param {*} offset How much to add to values expected to relate to meter index
+ * @param {*} isAdmin true if user is admin and sees all meter details.
  * @param {*} unit The unit id to check
  */
-function expectMetersToBeEquivalent(meters, length, offset, unit) {
+function expectMetersToBeEquivalent(meters, length, isAdmin, unit) {
 	for (let i = 0; i < length; i++) {
 		// If length is 1 then it is not an array.
 		let meter;
@@ -32,42 +35,36 @@ function expectMetersToBeEquivalent(meters, length, offset, unit) {
 		}
 		// Everyone can see this info on all meters
 		expect(meter).to.have.property('id');
+		expect(meter).to.have.property('enabled', true);
 		expect(meter).to.have.property('gps');
 		expect(meter.gps).to.have.property('latitude', gps.latitude);
 		expect(meter.gps).to.have.property('longitude', gps.longitude);
-		expect(meter).to.have.property('enabled', true);
-		// Copied from /src/server/routes/meters.js
-		// TODO: remove this line when usages of meter.name are replaced with meter.identifer
-		// Without this, things will break for non-logged in users because we currently rely on
-		// the internal name being available. As noted in #605, the intent is to not send the
-		// name to a user if they are not logged in.
-		expect(meter).to.have.property('identifier', 'Identified ' + (i + offset));
-		expect(meter).to.have.property('area', (i + offset) * 10.0);
-		expect(meter).to.have.property('unitId', unit);
-		expect(meter).to.have.property('defaultGraphicUnit', unit);
-		// A couple of properties differ if displayable or not.
 		// The first 3 are visible but the 4th is not visible where its name is special.
 		if (i < 3) {
-			expect(meter).to.have.property('name', `Meter ${i + offset}`);
 			expect(meter).to.have.property('displayable', true);
 		} else {
 			// This is the extra meter visible to admins.
-			expect(meter).to.have.property('name', 'Not Visible');
 			expect(meter).to.have.property('displayable', false);
 		}
-		if (length === 4) {
+		expect(meter).to.have.property('identifier', (isAdmin === true || meter.displayable === true) ? 'Identified ' + (i + 1) : null);
+		expect(meter).to.have.property('area', (i + 1) * 10.0);
+		expect(meter).to.have.property('unitId', unit);
+		expect(meter).to.have.property('defaultGraphicUnit', unit);
+		if (isAdmin) {
 			// Admin so see more values
+			// Last meter name differs since admin only.
+			expect(meter).to.have.property('name', i === 3 ? 'Not Visible' : `Meter ${i + 1}`);
 			expect(meter).to.have.property('url', '1.1.1.1');
 			expect(meter).to.have.property('meterType', Meter.type.MAMAC);
-			expect(meter).to.have.property('timeZone', 'TZ' + (i + offset));
-			expect(meter).to.have.property('note', `notes ${i + offset}`);
+			expect(meter).to.have.property('timeZone', 'TZ' + (i + 1));
+			expect(meter).to.have.property('note', `notes ${i + 1}`);
 			expect(meter).to.have.property('cumulative', true);
 			expect(meter).to.have.property('cumulativeReset', true);
 			expect(meter).to.have.property('cumulativeResetStart', '01:01:25');
 			expect(meter).to.have.property('cumulativeResetEnd', '05:05:05');
 			expect(meter).to.have.property('readingGap', 5.1);
 			expect(meter).to.have.property('readingVariation', 7.3);
-			expect(meter).to.have.property('reading', (i + offset) * 1.0);
+			expect(meter).to.have.property('reading', (i + 1) * 1.0);
 			expect(meter).to.have.property('readingDuplication', 1);
 			expect(meter).to.have.property('timeSort', 'increasing');
 			expect(meter).to.have.property('endOnlyTime', false);
@@ -75,6 +72,7 @@ function expectMetersToBeEquivalent(meters, length, offset, unit) {
 			expect(meter).to.have.property('endTimestamp', '2020-07-02 01:00:10');
 			expect(meter).to.have.property('previousEnd', '2020-03-05T13:15:13.000Z');
 		} else {
+			expect(meter).to.have.property('name', null);
 			expect(meter).to.have.property('url', null);
 			expect(meter).to.have.property('meterType', null);
 			expect(meter).to.have.property('timeZone', null);
@@ -113,7 +111,7 @@ mocha.describe('meters API', () => {
 		expect(res.body).to.have.lengthOf(0);
 	});
 
-	mocha.it('returns all visible meters', async () => {
+	mocha.it('returns all meters', async () => {
 		const conn = testDB.getConnection();
 		await new Meter(undefined, 'Meter 1', '1.1.1.1', true, true, Meter.type.MAMAC, 'TZ1', gps,
 			'Identified 1', 'notes 1', 10.0, true, true, '01:01:25', '05:05:05', 5.1, 7.3, 1, 'increasing', false,
@@ -131,8 +129,8 @@ mocha.describe('meters API', () => {
 		const res = await chai.request(app).get('/api/meters');
 		expect(res).to.have.status(200);
 		expect(res).to.be.json;
-		expect(res.body).to.have.lengthOf(3);
-		expectMetersToBeEquivalent(res.body, 3, 1, unitId);
+		expect(res.body).to.have.lengthOf(4);
+		expectMetersToBeEquivalent(res.body, 4, false, unitId);
 	});
 	mocha.describe('Admin role:', () => {
 		let token;
@@ -160,7 +158,7 @@ mocha.describe('meters API', () => {
 			expect(res).to.have.status(200);
 			expect(res).to.be.json;
 			expect(res.body).to.have.lengthOf(4);
-			expectMetersToBeEquivalent(res.body, 4, 1, unitId);
+			expectMetersToBeEquivalent(res.body, 4, true, unitId);
 		});
 	});
 
@@ -183,7 +181,7 @@ mocha.describe('meters API', () => {
 					token = res.body.token;
 				});
 
-				mocha.it('should only return visible meters and visible data', async () => {
+				mocha.it('should only return visible data', async () => {
 					const conn = testDB.getConnection();
 					await new Meter(undefined, 'Meter 1', '1.1.1.1', true, true, Meter.type.MAMAC, 'TZ1', gps,
 						'Identified 1', 'notes 1', 10.0, true, true, '01:01:25', '05:05:05', 5.1, 7.3, 1, 'increasing', false,
@@ -201,8 +199,8 @@ mocha.describe('meters API', () => {
 					const res = await chai.request(app).get('/api/meters').set('token', token);
 					expect(res).to.have.status(200);
 					expect(res).to.be.json;
-					expect(res.body).to.have.lengthOf(3);
-					expectMetersToBeEquivalent(res.body, 3, 1, unitId);
+					expect(res.body).to.have.lengthOf(4);
+					expectMetersToBeEquivalent(res.body, 4, false, unitId);
 				});
 
 				mocha.it(`should reject requests from ${role} to edit meters`, async () => {
@@ -216,17 +214,18 @@ mocha.describe('meters API', () => {
 	mocha.it('returns details on a single meter by ID', async () => {
 		const conn = testDB.getConnection();
 		await new Meter(undefined, 'Meter 1', '1.1.1.1', true, true, Meter.type.MAMAC, 'TZ1', gps,
-			'Identified 1', 'notes 1', 10.0, true, true, '01:01:25', '05:05:05', 5.1, 7.3, 1, 'increasing', false,
+			'Identified 2', 'notes 1', 20.0, true, true, '01:01:25', '05:05:05', 5.1, 7.3, 1, 'increasing', false,
 			1.0, '0001-01-01 23:59:59', '2020-07-02 01:00:10', '2020-03-05 13:15:13', unitId, unitId).insert(conn);
+		// Bit of a hack to set the second meter to Identified 1 so passes test. Same for area.
 		const meter2 = new Meter(undefined, 'Meter 2', '1.1.1.1', true, true, Meter.type.MAMAC, 'TZ2', gps,
-			'Identified 2', 'notes 2', 20.0, true, true, '01:01:25', '05:05:05', 5.1, 7.3, 1, 'increasing', false,
+			'Identified 1', 'notes 2', 10.0, true, true, '01:01:25', '05:05:05', 5.1, 7.3, 1, 'increasing', false,
 			2.0, '0001-01-01 23:59:59', '2020-07-02 01:00:10', '2020-03-05 13:15:13', unitId, unitId);
 		await meter2.insert(conn);
 
 		const res = await chai.request(app).get(`/api/meters/${meter2.id}`);
 		expect(res).to.have.status(200);
 		expect(res).to.be.json;
-		expectMetersToBeEquivalent(res.body, 1, 2, unitId);
+		expectMetersToBeEquivalent(res.body, 1, false, unitId);
 	});
 
 	mocha.it('responds appropriately when the meter in question does not exist', async () => {


### PR DESCRIPTION
# Description

- Non-displayable meter state is now returned but with most information hidden. This allows graphing of groups containing these meters without exposing much meter info.
- Groups now use the meter identifier to be consistent with meters.
- The change caused some issues with groups so they were updated to protect against missing information.
There are TODOs about making the fix better. This should be revisited when group are done converting to units and modals.

Fixes #790.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

OED needs to come up with a general fix for non-displayable items for non-admins and implement it consistently across the code base.
