### PR TITLE
Fix various JSDoc linting errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,11 +10,11 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
         // uncomment this to enforce eslint-plugin-jsdoc rules (and add comma above)
-        // along with the plugings below for jsdoc.
+        // along with the plugins below for jsdoc.
         //the line of code below is in regards to https://github.com/OpenEnergyDashboard/OED/issues/396 
-        // "plugin:jsdoc/recommended"
+        "plugin:jsdoc/recommended"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -25,10 +25,10 @@
         "sourceType": "module"
     },
     "plugins": [
-        "@typescript-eslint"
+        "@typescript-eslint",
         //this section of code is for running jsdoc checker (eslint-plugin-jsdoc) https://github.com/OpenEnergyDashboard/OED/issues/396.
         // It needs to be uncommented if using jsdoc plugin and add a comma above.
-        // "jsdoc"
+        "jsdoc"
     ],
     "rules": {
         //https://github.com/typescript-eslint/typescript-eslint/issues/1824, indent is therefore turned off and we use typescript-eslint/indent instead
@@ -72,7 +72,8 @@
         "arrow-parens": [
             "error",
             "as-needed"
-        ]
+        ],
+        "jsdoc/newline-after-description": 0
     },
     "overrides": [
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,11 +10,11 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended"
         // uncomment this to enforce eslint-plugin-jsdoc rules (and add comma above)
         // along with the plugins below for jsdoc.
         //the line of code below is in regards to https://github.com/OpenEnergyDashboard/OED/issues/396 
-        "plugin:jsdoc/recommended"
+        // "plugin:jsdoc/recommended"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -25,16 +25,18 @@
         "sourceType": "module"
     },
     "plugins": [
-        "@typescript-eslint",
+        "@typescript-eslint"
         //this section of code is for running jsdoc checker (eslint-plugin-jsdoc) https://github.com/OpenEnergyDashboard/OED/issues/396.
         // It needs to be uncommented if using jsdoc plugin and add a comma above.
-        "jsdoc"
+        // "jsdoc"
     ],
     "rules": {
         //https://github.com/typescript-eslint/typescript-eslint/issues/1824, indent is therefore turned off and we use typescript-eslint/indent instead
         "indent": [
             "off"
         ],
+        // TODO: Decide whether this setting should be on or off
+        // "jsdoc/newline-after-description": 0,
         "@typescript-eslint/indent": [
             "error",
             "tab",
@@ -72,8 +74,7 @@
         "arrow-parens": [
             "error",
             "as-needed"
-        ],
-        "jsdoc/newline-after-description": 0
+        ]
     },
     "overrides": [
         {

--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -106,7 +106,7 @@ export function submitPreferences() {
 
 /**
  * @param {State} state The redux state.
- * @returns {boolean} Whether the data is fetching
+ * @returns {boolean} Whether preferences are fetching
  */
 function shouldFetchPreferenceData(state: State): boolean {
 	return !state.admin.isFetching;
@@ -114,7 +114,7 @@ function shouldFetchPreferenceData(state: State): boolean {
 
 /**
  * @param {State} state The redux state.
- * @returns {boolean}
+ * @returns {boolean} Whether preferences are submitted
  */
 function shouldSubmitPreferenceData(state: State): boolean {
 	return !state.admin.submitted;
@@ -144,7 +144,7 @@ function updateCikAndDBViews(): t.UpdateCikAndDBViews {
 
 /**
  * @param {State} state The redux state.
- * @returns {boolean} Whether or not the views are updating
+ * @returns {boolean} Whether or not the Cik and views are updating
  */
 function shouldUpdateCikAndDBViews(state: State): boolean {
 	return !state.admin.isUpdatingCikAndDBViews;

--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -141,6 +141,8 @@ function shouldUpdateCikAndDBViews(state: State): boolean {
 /**
  * Redo Cik and/or refresh reading views.
  * This function is called when some changes in units/conversions affect the Cik table or reading views.
+ * @param {boolean} shouldRedoCik Whether to refresh Cik.
+ * @param {boolean} shouldRefreshReadingViews Whether to refresh reading views.
  */
 export function updateCikAndDBViewsIfNeeded(shouldRedoCik: boolean, shouldRefreshReadingViews: boolean): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -104,10 +104,18 @@ export function submitPreferences() {
 	};
 }
 
+/**
+ * @param {State} state The redux state.
+ * @returns {boolean} Whether the data is fetching
+ */
 function shouldFetchPreferenceData(state: State): boolean {
 	return !state.admin.isFetching;
 }
 
+/**
+ * @param {State} state The redux state.
+ * @returns {boolean}
+ */
 function shouldSubmitPreferenceData(state: State): boolean {
 	return !state.admin.submitted;
 }
@@ -134,6 +142,10 @@ function updateCikAndDBViews(): t.UpdateCikAndDBViews {
 	return { type: ActionType.UpdateCikAndDBViews };
 }
 
+/**
+ * @param {State} state The redux state.
+ * @returns {boolean} Whether or not the views are updating
+ */
 function shouldUpdateCikAndDBViews(state: State): boolean {
 	return !state.admin.isUpdatingCikAndDBViews;
 }

--- a/src/client/app/actions/barReadings.ts
+++ b/src/client/app/actions/barReadings.ts
@@ -14,7 +14,7 @@ import { BarReadings } from '../types/readings';
  * @param {State} state the Redux state
  * @param {number} meterID the ID of the meter to check
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} barDuration the duration of each bar for which to check
+ * @param {moment.Duration} barDuration the duration of each bar for which to check
  * @param {number} unitID the ID of the unit for which to check
  * @returns {boolean} True if the readings for the given meter, time duration, bar length and unit are missing; false otherwise.
  */
@@ -50,7 +50,7 @@ export function shouldFetchMeterBarReadings(state: State, meterID: number, timeI
  * @param {State} state the Redux state
  * @param {number} groupID the ID of the group to check
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} barDuration the duration of each bar for which to check
+ * @param {moment.Duration} barDuration the duration of each bar for which to check
  * @param {number} unitID the ID of the unit for which to check
  * @returns {boolean} True if the readings for the given group, time duration, bar length and unit are missing; false otherwise.
  */
@@ -85,7 +85,7 @@ export function shouldFetchGroupBarReadings(state: State, groupID: number, timeI
 /**
  * @param {number} meterIDs the IDs of the meters to get readings
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} barDuration the duration of each bar for which to check
+ * @param {moment.Duration} barDuration the duration of each bar for which to check
  * @param {number} unitID the ID of the unit for which to check
  */
 export function requestMeterBarReadings(meterIDs: number[], timeInterval: TimeInterval, barDuration: moment.Duration,
@@ -96,7 +96,7 @@ export function requestMeterBarReadings(meterIDs: number[], timeInterval: TimeIn
 /**
  * @param {number} groupIDs the IDs of the groups to get readings
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} barDuration the duration of each bar for which to check
+ * @param {moment.Duration} barDuration the duration of each bar for which to check
  * @param {number} unitID the ID of the unit for which to check
  */
 export function requestGroupBarReadings(groupIDs: number[], timeInterval: TimeInterval, barDuration: moment.Duration,
@@ -107,7 +107,7 @@ export function requestGroupBarReadings(groupIDs: number[], timeInterval: TimeIn
 /**
  * @param {number} meterIDs the IDs of the meters to get readings
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} barDuration the duration of each bar for which to check
+ * @param {moment.Duration} barDuration the duration of each bar for which to check
  * @param {number} unitID the ID of the unit for which to check
  * @param {BarReadings} readings the readings for the given meters
  */
@@ -119,7 +119,7 @@ export function receiveMeterBarReadings(meterIDs: number[], timeInterval: TimeIn
 /**
  * @param {number} groupIDs the IDs of the groups to get readings
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} barDuration the duration of each bar for which to check
+ * @param {moment.Duration} barDuration the duration of each bar for which to check
  * @param {number} unitID the ID of the unit for which to check
  * @param {BarReadings} readings the readings for the given groups
  */
@@ -157,10 +157,10 @@ function fetchGroupBarReadings(groupIDs: number[], timeInterval: TimeInterval, u
 }
 
 /**
-* Fetches readings for the bar chart of all selected meters and groups, if needed.
-* @param {TimeInterval} timeInterval the interval over which to check
-* @param {number} unitID the ID of the unit for which to check
-*/
+ * Fetches readings for the bar chart of all selected meters and groups, if needed.
+ * @param {TimeInterval} timeInterval the interval over which to check
+ * @param {number} unitID the ID of the unit for which to check
+ */
 export function fetchNeededBarReadings(timeInterval: TimeInterval, unitID: number): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {
 		const state = getState();

--- a/src/client/app/actions/compareReadings.ts
+++ b/src/client/app/actions/compareReadings.ts
@@ -76,7 +76,7 @@ function shouldFetchGroupCompareReadings(state: State, groupID: number, timeInte
 /**
  * @param {number} meterIDs the IDs of the meters to get readings
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} compareShift time to shift the timeInterval to get previous interval
+ * @param {moment.Duration} compareShift time to shift the timeInterval to get previous interval
  * @param {number} unitID the ID of the unit for which to check
  */
 function requestMeterCompareReadings(meterIDs: number[], timeInterval: TimeInterval,
@@ -88,7 +88,7 @@ function requestMeterCompareReadings(meterIDs: number[], timeInterval: TimeInter
 /**
  * @param {number} groupIDs the IDs of the groups to get readings
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} compareShift time to shift the timeInterval to get previous interval
+ * @param {moment.Duration} compareShift time to shift the timeInterval to get previous interval
  * @param {number} unitID the ID of the unit for which to check
  */
 function requestGroupCompareReadings(groupIDs: number[], timeInterval: TimeInterval,
@@ -100,7 +100,7 @@ function requestGroupCompareReadings(groupIDs: number[], timeInterval: TimeInter
 /**
  * @param {number} meterIDs the IDs of the meters to get readings
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} compareShift time to shift the timeInterval to get previous interval
+ * @param {moment.Duration} compareShift time to shift the timeInterval to get previous interval
  * @param {number} unitID the ID of the unit for which to check
  * @param {CompareReadings} readings the readings for the given meters
  */
@@ -112,7 +112,7 @@ function receiveMeterCompareReadings(meterIDs: number[], timeInterval: TimeInter
 /**
  * @param {number} groupIDs the IDs of the groups to get readings
  * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} compareShift time to shift the timeInterval to get previous interval
+ * @param {moment.Duration} compareShift time to shift the timeInterval to get previous interval
  * @param {number} unitID the ID of the unit for which to check
  * @param {CompareReadings} readings the readings for the given meters
  */
@@ -123,10 +123,8 @@ function receiveGroupCompareReadings(groupIDs: number[], timeInterval: TimeInter
 
 /**
  * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {Moment.Duration} compareShift time to shift the timeInterval to get previous interval
+ * @param {ComparePeriod} comparePeriod the period over which to check
  * @param {number} unitID the ID of the unit for which to check
- * @param {CompareReadings} readings the readings for the given meters
  */
 function fetchMeterCompareReadings(meterIDs: number[], comparePeriod: ComparePeriod, unitID: number): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {
@@ -159,7 +157,7 @@ function fetchGroupCompareReadings(groupIDs: number[], comparePeriod: ComparePer
  * Fetches readings for the compare chart of all selected meterIDs if they are not already fetched or being fetched
  * @param {ComparePeriod} comparePeriod The period to fetch readings for on the compare chart
  * @param {number} unitID the ID of the unit for which to check
- * @return {*} An action to fetch the needed readings
+ * @returns {*} An action to fetch the needed readings
  */
 export function fetchNeededCompareReadings(comparePeriod: ComparePeriod, unitID: number): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/compareReadings.ts
+++ b/src/client/app/actions/compareReadings.ts
@@ -124,7 +124,7 @@ function receiveGroupCompareReadings(groupIDs: number[], timeInterval: TimeInter
 /**
  * @param {number} meterIDs the IDs of the meters to get readings
  * @param {ComparePeriod} comparePeriod the period over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param {number} unitID the ID of the unit to get readings in
  */
 function fetchMeterCompareReadings(meterIDs: number[], comparePeriod: ComparePeriod, unitID: number): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/currentUser.ts
+++ b/src/client/app/actions/currentUser.ts
@@ -19,8 +19,8 @@ export function receiveCurrentUser(data: User): t.ReceiveCurrentUser {
 
 /**
  * Check if we should fetch the current user's data. This function has the side effect of deleting an invalid token from local storage.
- * @param state
- * @returns Return true if we should fetch the current user's data. Returns false otherwise.
+ * @param {State} state The redux state
+ * @returns {boolean} Return true if we should fetch the current user's data. Returns false otherwise.
  */
 async function shouldFetchCurrentUser(state: State): Promise<boolean> {
 	// If we are currently fetching the current user, we should not fetch the data again.

--- a/src/client/app/actions/graph.ts
+++ b/src/client/app/actions/graph.ts
@@ -204,7 +204,7 @@ export interface LinkOptions {
 
 /**
  * Update graph options from a link
- * @param options - Object of possible values to dispatch with keys: meterIDs, groupIDs, chartType, barDuration, toggleBarStacking
+ * @param {LinkOptions} options - Object of possible values to dispatch with keys: meterIDs, groupIDs, chartType, barDuration, toggleBarStacking
  * @returns {function(*)}
  */
 export function changeOptionsFromLink(options: LinkOptions) {

--- a/src/client/app/actions/groups.ts
+++ b/src/client/app/actions/groups.ts
@@ -93,7 +93,7 @@ export function changeSelectedChildGroupsOfGroup(parentID: number, groupIDs: num
  * This is tracked on a per-group basis.
  * @param {number} parentID The ID of the group whose subgroups are being selected
  * @param {number[]} meterIDs The IDs of the new set of selected child meters
- * @returns {{type: string, parentID: *, meterIDs: *}}
+ * @returns {{type: string, parentID: number, meterIDs: [number]}}
  */
 export function changeSelectedChildMetersOfGroup(parentID: number, meterIDs: number[]): t.ChangeSelectedChildMetersPerGroupAction {
 	return { type: ActionType.ChangeSelectedChildMetersPerGroup, parentID, meterIDs };

--- a/src/client/app/actions/groups.ts
+++ b/src/client/app/actions/groups.ts
@@ -80,9 +80,9 @@ export function fetchGroupChildrenIfNeeded(groupID: number) {
 /**
  * Change the selected child groups of a group.
  * This is tracked on a per-group basis. (I.e., each group has its own list of selected child groups.)
- * @param parentID The ID of the group whose subgroups are being selected
- * @param groupIDs The IDs of the new set of selected subgroups
- * @return {{type: string, groupIDs: *}}
+ * @param {number} parentID The ID of the group whose subgroups are being selected
+ * @param {number[]} groupIDs The IDs of the new set of selected subgroups
+ * @returns {{type: string, groupIDs: [number]}}
  */
 export function changeSelectedChildGroupsOfGroup(parentID: number, groupIDs: number[]): t.ChangeSelectedChildGroupsPerGroupAction {
 	return { type: ActionType.ChangeSelectedChildGroupsPerGroup, parentID, groupIDs };
@@ -91,9 +91,9 @@ export function changeSelectedChildGroupsOfGroup(parentID: number, groupIDs: num
 /**
  * Change which child meters of a group are selected.
  * This is tracked on a per-group basis.
- * @param parentID The ID of the group whose subgroups are being selected
- * @param meterIDs The IDs of the new set of selected child meters
- * @return {{type: string, parentID: *, meterIDs: *}}
+ * @param {number} parentID The ID of the group whose subgroups are being selected
+ * @param {number[]} meterIDs The IDs of the new set of selected child meters
+ * @returns {{type: string, parentID: *, meterIDs: *}}
  */
 export function changeSelectedChildMetersOfGroup(parentID: number, meterIDs: number[]): t.ChangeSelectedChildMetersPerGroupAction {
 	return { type: ActionType.ChangeSelectedChildMetersPerGroup, parentID, meterIDs };
@@ -102,7 +102,7 @@ export function changeSelectedChildMetersOfGroup(parentID: number, meterIDs: num
 /**
  * Change the display mode of the groups page
  * @param newMode Either 'view', 'edit', or 'create'
- * @return {{type: string, newMode: String}}
+ * @returns {{type: string, newMode: string}}
  */
 export function changeDisplayMode(newMode: t.DisplayMode): t.ChangeDisplayModeAction {
 	return { type: ActionType.ChangeGroupsUIDisplayMode, newMode };
@@ -110,26 +110,34 @@ export function changeDisplayMode(newMode: t.DisplayMode): t.ChangeDisplayModeAc
 
 /**
  * Set state.groups.groupInEditing to a blank group
- * @return {{type: string}}
+ * @returns {{type: string}}
  */
 export function createNewBlankGroup(): t.CreateNewBlankGroupAction {
 	return { type: ActionType.CreateNewBlankGroup };
 }
 
-// Fire the action to actually overwrite `groupInEditing`
+/**
+ * Fire the action to actually overwrite `groupInEditing`
+ * @param {number} groupID Group id.
+ * @returns {{type: string, groupID: number}}
+ */
 function beginEditingGroup(groupID: number): t.BeginEditingGroupAction {
 	return { type: ActionType.BeginEditingGroup, groupID };
 }
 
-// Check if `groupInEditing` is clean (can it be overwritten).
+/**
+ * Check if `groupInEditing` is clean (can it be overwritten).
+ * @param {State} state The redux state
+ * @returns {boolean} Result of the check.
+ */
 function canBeginEditing(state: State): boolean {
 	return !state.groups.groupInEditing.dirty;
 }
 
 /**
  * Copy the group with the given ID into `groupInEditing` if allowed.
- * @param groupID The ID of the group to be edited
- * @return {function(*, *)}
+ * @param {number} groupID The ID of the group to be edited
+ * @returns {function(*, *)}
  */
 export function beginEditingIfPossible(groupID: number): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {
@@ -143,8 +151,8 @@ export function beginEditingIfPossible(groupID: number): Thunk {
 
 /**
  * Change the name of the group in editing
- * @param newName The new name
- * @return {{type: string, newName: String}}
+ * @param {string} newName The new name
+ * @returns {{type: string, newName: string}}
  */
 export function editGroupName(newName: string): t.EditGroupNameAction {
 	return { type: ActionType.EditGroupName, newName };
@@ -152,8 +160,8 @@ export function editGroupName(newName: string): t.EditGroupNameAction {
 
 /**
  * Change the GPS of the group in editing
- * @param newGPS The new GPS
- * @return {{type: string, newGPS: GPSPoint}}
+ * @param {GPSPoint} newGPS The new GPS
+ * @returns {{type: string, newGPS: GPSPoint}}
  */
 export function editGroupGPS(newGPS: GPSPoint): t.EditGroupGPSAction {
 	return { type: ActionType.EditGroupGPS, newGPS };
@@ -161,8 +169,8 @@ export function editGroupGPS(newGPS: GPSPoint): t.EditGroupGPSAction {
 
 /**
  * Change the displayable of the group in editing
- * @param newDisplay The new displayable
- * @return {{type: string, newDisplay: boolean}}
+ * @param {boolean} newDisplay The new displayable
+ * @returns {{type: string, newDisplay: boolean}}
  */
 export function editGroupDisplayable(newDisplay: boolean): t.EditGroupDisplayableAction {
 	return { type: ActionType.EditGroupDisplayable, newDisplay };
@@ -170,8 +178,8 @@ export function editGroupDisplayable(newDisplay: boolean): t.EditGroupDisplayabl
 
 /**
  * Change the note of the group in editing
- * @param newNote The new name
- * @return {{type: string, newNote: String}}
+ * @param {string} newNote The new name
+ * @returns {{type: string, newNote: string}}
  */
 export function editGroupNote(newNote: string): t.EditGroupNoteAction {
 	return { type: ActionType.EditGroupNote, newNote };
@@ -179,8 +187,8 @@ export function editGroupNote(newNote: string): t.EditGroupNoteAction {
 
 /**
  * Change the area of the group in editing
- * @param newArea The new area
- * @return {{type: string, newArea: number}}
+ * @param {number} newArea The new area
+ * @returns {{type: string, newArea: number}}
  */
 export function editGroupArea(newArea: number): t.EditGroupAreaAction {
 	return { type: ActionType.EditGroupArea, newArea };
@@ -188,16 +196,16 @@ export function editGroupArea(newArea: number): t.EditGroupAreaAction {
 
 /**
  * Change the child groups of the group in editing
- * @param groupIDs IDs of the new child groups
- * @return {{type: string, groupIDs: [Int]}}
+ * @param {number[]} groupIDs IDs of the new child groups
+ * @returns {{type: string, groupIDs: [number]}}
  */
 export function changeChildGroups(groupIDs: number[]): t.ChangeChildGroupsAction {
 	return { type: ActionType.ChangeChildGroups, groupIDs };
 }
 /**
  * Change the child meters of the group in editing
- * @param meterIDs IDs of the new set of child meters
- * @return {{type: string, meterIDs: [Int]}}
+ * @param {number[]} meterIDs IDs of the new set of child meters
+ * @returns {{type: string, meterIDs: [number]}}
  */
 export function changeChildMeters(meterIDs: number[]): t.ChangeChildMetersAction {
 	return { type: ActionType.ChangeChildMeters, meterIDs };
@@ -215,7 +223,7 @@ function markGroupInEditingNotSubmitted(): t.MarkGroupInEditingNotSubmittedActio
  * Use this to cancel group editing and allow `groupInEditing` to be overwritten later.
  * `groupInEditing` is dirty when it is storing changes that have not yet been committed to the database.
  * It is not clean until a request to store the changes has received a successful response.
- * @return {{type: string}}
+ * @returns {{type: string}}
  */
 export function markGroupInEditingClean(): t.MarkGroupInEditingCleanAction {
 	return { type: ActionType.MarkGroupInEditingClean };
@@ -305,7 +313,7 @@ function submitGroupEdits(group: t.GroupData & t.GroupID): Thunk {
  * If this is the case, decides whether it is a new group
  * being created, or an old group being edited, and calls the
  * appropriate helper function to handle the request.
- * @return {function(*, *)}
+ * @returns {function(*, *)}
  */
 export function submitGroupInEditingIfNeeded() {
 	return (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/map.ts
+++ b/src/client/app/actions/map.ts
@@ -66,8 +66,8 @@ export function setNewMap(): Thunk {
 
 /**
  * start a new calibration session
- * @param mode {CalibrationModeTypes} calibration modes
- * @param mapID {number} id of map being calibrated
+ * @param {CalibrationModeTypes} mode {CalibrationModeTypes} calibration modes
+ * @param {number} mapID {number} id of map being calibrated
  */
 export function setCalibration(mode: CalibrationModeTypes, mapID: number): Thunk {
 	return async (dispatch: Dispatch) => {
@@ -164,7 +164,7 @@ function updateCalibrationSet(calibratedPoint: CalibratedPoint): t.AppendCalibra
 
 /**
  * use a default number as the threshold in determining if it's safe to call the calibration function
- * @param state
+ * @param {State} state The redux state
  */
 function isReadyForCalculation(state: State): boolean {
 	const calibrationThreshold = 3;
@@ -176,6 +176,7 @@ function isReadyForCalculation(state: State): boolean {
 
 /**
  *  prepare data to required formats to pass it to function calculating mapScales
+ * @param {State} state The redux state
  */
 function prepareDataToCalculation(state: State): CalibrationResult {
 	const mapID = state.maps.calibratingMap;
@@ -256,7 +257,7 @@ export function submitNewMap(): Thunk {
 
 /**
  * submit changes of an existing map to database at the end of a calibration session
- * @param mapID the edited map being updated at database
+ * @param {number} mapID the edited map being updated at database
  */
 export function submitEditedMap(mapID: number): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {
@@ -299,7 +300,6 @@ export function submitEditedMap(mapID: number): Thunk {
  * permanently remove a map
  * @param mapID map to be removed
  */
-
 export function removeMap(mapID: number): Thunk {
 	return async (dispatch: Dispatch) => {
 		try {

--- a/src/client/app/actions/unsavedWarning.ts
+++ b/src/client/app/actions/unsavedWarning.ts
@@ -7,8 +7,8 @@ import * as t from '../types/redux/unsavedWarning';
 
 /**
  * Notify that there are unsaved changes
- * @param removeFunction The function to remove local changes
- * @param submitFunction The function to submit unsaved changes
+ * @param {*} removeFunction The function to remove local changes
+ * @param {*} submitFunction The function to submit unsaved changes
  */
 export function updateUnsavedChanges(removeFunction: any, submitFunction: any): t.UpdateUnsavedChangesAction {
 	return { type: ActionType.UpdateUnsavedChanges, removeFunction, submitFunction };

--- a/src/client/app/components/ChartDataSelectComponent.tsx
+++ b/src/client/app/components/ChartDataSelectComponent.tsx
@@ -266,7 +266,7 @@ export default function ChartDataSelectComponent() {
 /**
  * Determines the compatibility of units in the redux state for display in dropdown
  * @param {State} state - current redux state
- * @return {SelectOption[]} an array of SelectOption
+ * @returns {SelectOption[]} an array of SelectOption
  */
 function getUnitCompatibilityForDropdown(state: State) {
 
@@ -314,7 +314,7 @@ function getUnitCompatibilityForDropdown(state: State) {
 			}
 		});
 	}
-	// Ready to display unit. Put selectable ones before unselectable ones.
+	// Ready to display unit. Put selectable ones before non-selectable ones.
 	const finalUnits = getSelectOptionsByItem(compatibleUnits, incompatibleUnits, state.units);
 	return finalUnits;
 }
@@ -325,7 +325,7 @@ function getUnitCompatibilityForDropdown(state: State) {
 /**
  * Determines the compatibility of meters in the redux state for display in dropdown
  * @param {State} state - current redux state
- * @return {SelectOption[]} an array of SelectOption
+ * @returns {SelectOption[]} an array of SelectOption
  */
 export function getMeterCompatibilityForDropdown(state: State) {
 	// Holds all meters visible to the user
@@ -393,7 +393,7 @@ export function getMeterCompatibilityForDropdown(state: State) {
 /**
  * Determines the compatibility of group in the redux state for display in dropdown
  * @param {State} state - current redux state
- * @return {SelectOption[]} an array of SelectOption
+ * @returns {SelectOption[]} an array of SelectOption
  */
 export function getGroupCompatibilityForDropdown(state: State) {
 	// Holds all groups visible to the user
@@ -462,7 +462,7 @@ export function getGroupCompatibilityForDropdown(state: State) {
 /**
  * Filters all units that are of type meter or displayable type none from the redux state, as well as admin only units if the user is not an admin.
  * @param {State} state - current redux state
- * @return {UnitData[]} an array of UnitData
+ * @returns {UnitData[]} an array of UnitData
  */
 export function getVisibleUnitOrSuffixState(state: State) {
 	let visibleUnitsOrSuffixes;
@@ -484,10 +484,10 @@ export function getVisibleUnitOrSuffixState(state: State) {
 /**
  *  Returns a set of SelectOptions based on the type of state passed in and sets the visibility.
  * Visibility is determined by which set the items are contained in.
- * @param {State} state - current redux state, must be one of UnitsState, MetersState, or GroupsState
  * @param {Set<number>} compatibleItems - items that are compatible with current selected options
  * @param {Set<number>} incompatibleItems - units that are not compatible with current selected options
- * @return {SelectOption[]} an array of SelectOption
+ * @param {UnitsState | MetersState | GroupsState} state - current redux state, must be one of UnitsState, MetersState, or GroupsState
+ * @returns {SelectOption[]} an array of SelectOption
  */
 function getSelectOptionsByItem(compatibleItems: Set<number>, incompatibleItems: Set<number>, state: UnitsState | MetersState | GroupsState) {
 	// Holds the label of the select item, set dynamically according to the type of item passed in
@@ -543,7 +543,21 @@ function getSelectOptionsByItem(compatibleItems: Set<number>, incompatibleItems:
 	return _.sortBy(_.sortBy(finalItems, item => item.label.toLowerCase(), 'asc'), item => item.isDisabled, 'asc');
 }
 
-// Helper functions to determine what type of state was passed in
+/**
+ * Helper function to determine what type of state was passed in
+ * @param {*} state The state to check
+ * @returns {boolean} Whether or not this is a UnitsState
+ */
 function instanceOfUnitsState(state: any): state is UnitsState { return 'units' in state; }
+/**
+ * Helper function to determine what type of state was passed in
+ * @param {*} state The state to check
+ * @returns {boolean} Whether or not this is a MetersState
+ */
 function instanceOfMetersState(state: any): state is MetersState { return 'byMeterID' in state; }
+/**
+ * Helper function to determine what type of state was passed in
+ * @param {*} state The state to check
+ * @returns {boolean} Whether or not this is a GroupsState
+ */
 function instanceOfGroupsState(state: any): state is GroupsState { return 'byGroupID' in state; }

--- a/src/client/app/components/DashboardComponent.tsx
+++ b/src/client/app/components/DashboardComponent.tsx
@@ -121,6 +121,10 @@ export default class DashboardComponent extends React.Component<DashboardProps> 
 	}
 }
 
+/**
+ * Determines the line graph's slider interval based after the slider is moved
+ * @returns {string} The slider interval, either 'all' or a TimeInterval
+ */
 export function getRangeSliderInterval(): string {
 	const sliderContainer: any = document.querySelector('.rangeslider-bg');
 	const sliderBox: any = document.querySelector('.rangeslider-slidebox');

--- a/src/client/app/components/GraphicRateMenuComponent.tsx
+++ b/src/client/app/components/GraphicRateMenuComponent.tsx
@@ -11,6 +11,9 @@ import translate from '../utils/translate';
 import { updateLineGraphRate } from '../actions/graph'
 import { LineGraphRate, LineGraphRates } from '../types/redux/graph';
 
+/**
+ * React component that controls the line graph rate menu
+ */
 export default function GraphicRateMenuComponent() {
 	const dispatch = useDispatch();
 

--- a/src/client/app/components/HomeComponent.tsx
+++ b/src/client/app/components/HomeComponent.tsx
@@ -10,7 +10,7 @@ import TooltipHelpContainer from '../containers/TooltipHelpContainer';
 
 /**
  * Top-level React component that controls the home page
- * @return JSX to create the home page
+ * @returns JSX to create the home page
  */
 export default function HomeComponent() {
 	return (

--- a/src/client/app/components/UIOptionsComponent.tsx
+++ b/src/client/app/components/UIOptionsComponent.tsx
@@ -289,6 +289,7 @@ class UIOptionsComponent extends React.Component<UIOptionsPropsWithIntl, UIOptio
 
 	/**
 	 * Stores temporary barDuration until slider is released, used to update the UI of the slider
+	 * @param {number} value Bar duration to be stored
 	 */
 	private handleBarDurationChange(value: number) {
 		this.setState({ barDurationDays: value });

--- a/src/client/app/containers/CompareChartContainer.ts
+++ b/src/client/app/containers/CompareChartContainer.ts
@@ -18,11 +18,14 @@ interface CompareChartContainerProps {
 	entity: CompareEntity;
 }
 
-/* Passes the current redux state of the of the chart container and it's props, and turns it into props for the React
-*  component, which is what will be visible on the page. Makes it possible to access
-*  your reducer state objects from within your React components.
-*
-*  Returns the props object. */
+/**
+ * Passes the current redux state of the of the chart container and it's props, and turns it into props for the React
+ * component, which is what will be visible on the page. Makes it possible to access
+ * your reducer state objects from within your React components.
+ * @param {State} state The redux state
+ * @param {CompareChartContainerProps} ownProps Chart container props
+ * @returns {*} The props object
+ */
 function mapStateToProps(state: State, ownProps: CompareChartContainerProps): any {
 	const comparePeriod = state.graph.comparePeriod;
 	const datasets: any[] = [];

--- a/src/client/app/types/conversionArray.ts
+++ b/src/client/app/types/conversionArray.ts
@@ -20,7 +20,7 @@ export class ConversionArray {
 	}
 
 	/**
-	 * @returns returns true if pik has values and false if not yet filled in.
+	 * @returns {boolean} returns true if pik has values and false if not yet filled in.
 	 */
 	static pikAvailable() {
 		return this.available;

--- a/src/client/app/utils/Datasources.ts
+++ b/src/client/app/utils/Datasources.ts
@@ -11,9 +11,9 @@ export const DATA_TYPE_GROUP = DataType.Group;
 
 /**
  * Put item's id field in tgt if the item specifies a meter
- * @param {int[]} tgt The array to perhaps insert an item into
- * @param {{String, int}} item The item being considered
- * @return {Array} The modified tgt array
+ * @param {number[]} tgt The array to perhaps insert an item into
+ * @param {{String, number}} item The item being considered
+ * @returns {Array} The modified tgt array
  */
 export function metersFilterReduce(tgt: number[], item: DatasourceID) {
 	if (item.type === DATA_TYPE_METER) {
@@ -24,9 +24,9 @@ export function metersFilterReduce(tgt: number[], item: DatasourceID) {
 
 /**
  * Put item's id field in tgt if the item specifies a group
- * @param {int[]} tgt The array to perhaps insert an item into
- * @param {{String, int}} item The item being considered
- * @return {Array} The modified tgt array
+ * @param {number[]} tgt The array to perhaps insert an item into
+ * @param {{String, number}} item The item being considered
+ * @returns {Array} The modified tgt array
  */
 export function groupsFilterReduce(tgt: number[], item: DatasourceID) {
 	if (item.type === DATA_TYPE_GROUP) {

--- a/src/client/app/utils/calculateCompare.ts
+++ b/src/client/app/utils/calculateCompare.ts
@@ -6,6 +6,9 @@ import { TimeInterval } from '../../../common/TimeInterval';
 import * as moment from 'moment';
 import translate from '../utils/translate';
 
+/**
+ * @enum {ComparePeriod} 'Day' or 'Week' or 'FourWeeks'
+ */
 export enum ComparePeriod {
 	Day = 'Day',
 	Week = 'Week',
@@ -18,6 +21,10 @@ export enum SortingOrder {
 	Descending = 'Descending'
 }
 
+/**
+ * @param {string} comparePeriod A string to validate as a comparePeriod
+ * @returns {ComparePeriod} Validated enum
+ */
 export function validateComparePeriod(comparePeriod: string): ComparePeriod {
 	switch (comparePeriod) {
 		case 'Day':
@@ -31,6 +38,10 @@ export function validateComparePeriod(comparePeriod: string): ComparePeriod {
 	}
 }
 
+/**
+ * @param {string} sortingOrder A string to validate as a SortingOrder
+ * @returns {SortingOrder} Validated enum
+ */
 export function validateSortingOrder(sortingOrder: string): SortingOrder {
 	switch (sortingOrder) {
 		case 'Alphabetical':
@@ -44,6 +55,12 @@ export function validateSortingOrder(sortingOrder: string): SortingOrder {
 	}
 }
 
+/**
+ * Calculates a time interval for compare based on a period and moment
+ * @param {ComparePeriod} comparePeriod The compare length
+ * @param {moment.Moment} currentTime The current time as a moment
+ * @returns {TimeInterval} The time interval for compare
+ */
 export function calculateCompareTimeInterval(comparePeriod: ComparePeriod, currentTime: moment.Moment): TimeInterval {
 	// begin will be the start of the compare time and end will be the end of the compare time.
 	let begin;
@@ -79,6 +96,11 @@ export function calculateCompareTimeInterval(comparePeriod: ComparePeriod, curre
 	return compareTimeInterval;
 }
 
+/**
+ * Converts a comparePeriod into a moment duration
+ * @param {ComparePeriod} comparePeriod The compare length
+ * @returns {moment.Duration} The duration to compare
+ */
 export function calculateCompareDuration(comparePeriod: ComparePeriod): moment.Duration {
 	let compareDuration;
 	switch (comparePeriod) {
@@ -98,6 +120,11 @@ export function calculateCompareDuration(comparePeriod: ComparePeriod): moment.D
 	return compareDuration;
 }
 
+/**
+ * Calculates amount of time to shift as a moment duration
+ * @param {ComparePeriod} comparePeriod The compare length
+ * @returns {moment.Duration} The shift as a moment duration
+ */
 export function calculateCompareShift(comparePeriod: ComparePeriod): moment.Duration {
 	let compareShift;
 	switch (comparePeriod) {
@@ -124,7 +151,8 @@ export interface ComparePeriodLabels {
 
 /**
  * Determines the human-readable names of a comparison period.
- * @param comparePeriod the machine-readable name of the period
+ * @param {ComparePeriod} comparePeriod the machine-readable name of the period
+ * @returns {{prev: string, current: string}} human-readable names for the compare period
  */
 export function getComparePeriodLabels(comparePeriod: ComparePeriod): ComparePeriodLabels {
 	switch (comparePeriod) {
@@ -142,9 +170,10 @@ export function getComparePeriodLabels(comparePeriod: ComparePeriod): ComparePer
 
 /**
  * Composes a label to summarize compare chart data.
- * @param change the ratio of change between the current and previous period
- * @param name the name of the entity being measured
- * @param labels the names of the periods in question
+ * @param {number} change the ratio of change between the current and previous period
+ * @param {string} name the name of the entity being measured
+ * @param {{prev: string, current: string}} labels the names of the periods in question
+ * @returns {string} The label summary
  */
 export function getCompareChangeSummary(change: number, name: string, labels: ComparePeriodLabels): string {
 	if (isNaN(change)) { return ''; }

--- a/src/client/app/utils/calculateCompare.ts
+++ b/src/client/app/utils/calculateCompare.ts
@@ -7,7 +7,7 @@ import * as moment from 'moment';
 import translate from '../utils/translate';
 
 /**
- * @enum {ComparePeriod} 'Day' or 'Week' or 'FourWeeks'
+ * @enum {ComparePeriod} 'Day', 'Week' or 'FourWeeks'
  */
 export enum ComparePeriod {
 	Day = 'Day',
@@ -15,7 +15,10 @@ export enum ComparePeriod {
 	FourWeeks = 'FourWeeks'
 }
 
-export enum SortingOrder {
+/**
+ * @enum {SortingOrder} 'Alphabetical', 'Ascending' or 'Descending'
+ */
+ export enum SortingOrder {
 	Alphabetical = 'Alphabetical',
 	Ascending = 'Ascending',
 	Descending = 'Descending'
@@ -96,8 +99,9 @@ export function calculateCompareTimeInterval(comparePeriod: ComparePeriod, curre
 	return compareTimeInterval;
 }
 
+// TODO This function does not appear to be used - should it be removed?
 /**
- * Converts a comparePeriod into a moment duration
+ * Converts a comparePeriod into a moment duration for the quality of the readings to use.
  * @param {ComparePeriod} comparePeriod The compare length
  * @returns {moment.Duration} The duration to compare
  */

--- a/src/client/app/utils/calculateCompare.ts
+++ b/src/client/app/utils/calculateCompare.ts
@@ -18,7 +18,7 @@ export enum ComparePeriod {
 /**
  * @enum {SortingOrder} 'Alphabetical', 'Ascending' or 'Descending'
  */
- export enum SortingOrder {
+export enum SortingOrder {
 	Alphabetical = 'Alphabetical',
 	Ascending = 'Ascending',
 	Descending = 'Descending'

--- a/src/client/app/utils/calibration.ts
+++ b/src/client/app/utils/calibration.ts
@@ -68,11 +68,11 @@ export interface Dimensions {
 
 /**
  * Returns true if item (meter or group) and map and reasonably defined and false otherwise.
- * @param itemID ID to be used for logging errors
- * @param type DataType to distinguish between meter and group
- * @param map map info to check
- * @param gps GPS Point to check
- * @returns True if map is defined with origin & opposite and meter with valid GPS
+ * @param {number} itemID ID to be used for logging errors
+ * @param {DataType} type DataType to distinguish between meter and group
+ * @param {MapMetadata} map map info to check
+ * @param {GPSPoint} gps GPS Point to check
+ * @returns {boolean} True if map is defined with origin & opposite and meter with valid GPS
  */
 export function itemMapInfoOk(itemID: number, type: DataType, map: MapMetadata, gps?: GPSPoint): boolean {
 	if (map === undefined) { return false; }
@@ -86,9 +86,9 @@ export function itemMapInfoOk(itemID: number, type: DataType, map: MapMetadata, 
 
 /**
  * Returns true if point lies within the map to display on.
- * @param size The map size that is being used.
- * @param point The point being considered for display in user map grid coordinates.
- * @returns true if within map and false otherwise.
+ * @param {Dimensions} size The map size that is being used.
+ * @param {CartesianPoint} point The point being considered for display in user map grid coordinates.
+ * @returns {boolean} true if within map and false otherwise.
  */
 export function itemDisplayableOnMap(size: Dimensions, point: CartesianPoint): boolean {
 	// The user map is a rectangle that is parallel to the Plotly grid. Thus, the point
@@ -102,8 +102,8 @@ export function itemDisplayableOnMap(size: Dimensions, point: CartesianPoint): b
  * Checks if the string is a valid GPS representation. This requires it to be two numbers
  * separated by a comma and the GPS values to be within allowed values.
  * Note it causes a popup if the GPS values are not valid.
- * @param input The string to check for GPS values
- * @returns true if string is GPS and false otherwise.
+ * @param {string} input The string to check for GPS values
+ * @returns {boolean} true if string is GPS and false otherwise.
  */
 export function isValidGPSInput(input: string): boolean {
 	if (input.indexOf(',') === -1) { // if there is no comma
@@ -128,12 +128,13 @@ export function isValidGPSInput(input: string): boolean {
 
 /**
  * Calculates the GPS unit per coordinate unit.
- * @param origin The GPS value for the origin that was computed during calibration.
+ * @param {GPSPoint} origin The GPS value for the origin that was computed during calibration.
  * 	This is the bottom, left corner of the user map.
- * @param opposite The GPS value for the opposite that was computed during calibration.
+ * @param {GPSPoint} opposite The GPS value for the opposite that was computed during calibration.
  * 	This is the top, right corner of the user map.
- * @param imageDimensions This is the size of the normalized map image.
- * @returns a pair {deltaX, deltaY} representing the GPS degree per unit (x, y)
+ * @param {Dimensions} size This is the size of the normalized map image.
+ * @param {number} northAngle
+ * @returns {MapScale} a pair {deltaX, deltaY} representing the GPS degree per unit (x, y)
  * 	on true north map grid.
  */
 export function calculateScaleFromEndpoints(origin: GPSPoint, opposite: GPSPoint, size: Dimensions, northAngle: number): MapScale {
@@ -147,11 +148,12 @@ export function calculateScaleFromEndpoints(origin: GPSPoint, opposite: GPSPoint
 
 /**
  * Convert the gps value to the equivalent Plotly grid coordinates on user map.
- * @param size The normalized size of the map
- * @param gps The GPS coordinate to convert
- * @param originGPS The GPS value of the origin on the true north map.
- * @param scaleOfMap The GPS degree per unit x, y on the true north map.
- * @returns x, y value of the gps point on the user map.
+ * @param {Dimensions} size The normalized size of the map
+ * @param {GPSPoint} gps The GPS coordinate to convert
+ * @param {GPSPoint} originGPS The GPS value of the origin on the true north map.
+ * @param {MapScale} scaleOfMap The GPS degree per unit x, y on the true north map.
+ * @param {number} northAngle
+ * @returns {CartesianPoint} x, y value of the gps point on the user map.
  */
 export function gpsToUserGrid(size: Dimensions, gps: GPSPoint, originGPS: GPSPoint, scaleOfMap: MapScale, northAngle: number): CartesianPoint {
 	// We need the origin x, y value by starting from 0, 0 on the user map and
@@ -174,9 +176,10 @@ export function gpsToUserGrid(size: Dimensions, gps: GPSPoint, originGPS: GPSPoi
  * origin and opposite points. It also calculates the relative error for this
  * scale by finding the maximum difference between the calculated scale and the
  * one from each pair of calibration points. It returns all three of these values.
- * @param calibrationSet All the points clicked by the user for calibration.
- * @param imageDimensions The dimensions of the original map to use from the user.
- * @returns The error and the origin & opposite point in GPS to use for mapping.
+ * @param {CalibratedPoint[]} calibrationSet All the points clicked by the user for calibration.
+ * @param {Dimensions} imageDimensions The dimensions of the original map to use from the user.
+ * @param {number} northAngle
+ * @returns {CalibrationResult} The error and the origin & opposite point in GPS to use for mapping.
  */
 export function calibrate(calibrationSet: CalibratedPoint[], imageDimensions: Dimensions, northAngle: number): CalibrationResult {
 	// Normalize dimensions to grid used in Plotly
@@ -288,9 +291,9 @@ export function calibrate(calibrationSet: CalibratedPoint[], imageDimensions: Di
 
 /**
  * Return the change in GPS degree per unit on map grid.
- * @param p1 First point to use in calculation.
- * @param p2 Second point to use in calculation.
- * @returns a pair {deltaX, deltaY} representing the GPS degree per unit (x, y) on map grid.
+ * @param {CalibratedPoint} p1 First point to use in calculation.
+ * @param {CalibratedPoint} p2 Second point to use in calculation.
+ * @returns {{number, number}} a pair {deltaX, deltaY} representing the GPS degree per unit (x, y) on map grid.
  */
 function calculateScale(p1: CalibratedPoint, p2: CalibratedPoint) {
 	// Calculate the change in GPS longitude and x point and then use to get the GPS degree
@@ -310,8 +313,8 @@ function calculateScale(p1: CalibratedPoint, p2: CalibratedPoint) {
 
 /**
  * Normalize image dimensions to fit within the default 500*500 pixel-sized graph.
- * @param dimensions The size (width, height) of the map loaded into OED
- * @return Normalized size of map so no more than 500 on either side.
+ * @param {Dimensions} dimensions The size (width, height) of the map loaded into OED
+ * @returns {Dimensions} Normalized size of map so no more than 500 on either side.
  */
 export function normalizeImageDimensions(dimensions: Dimensions): Dimensions {
 	let width;
@@ -334,10 +337,10 @@ export function normalizeImageDimensions(dimensions: Dimensions): Dimensions {
 
 /**
  * Shifts point by 1/2 size dimensions.
- * @param size The size of the image (normally normalized map size)
- * @param point The (x,y) pair for the point to be shifted
- * @param direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
- * @returns (x,y) pair shifted by 1/2 the width and height of map image
+ * @param {Dimensions} size The size of the image (normally normalized map size)
+ * @param {CartesianPoint} point The (x,y) pair for the point to be shifted
+ * @param {number} direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
+ * @returns {CartesianPoint} (x,y) pair shifted by 1/2 the width and height of map image
  */
 export function shift(size: Dimensions, point: CartesianPoint, direction: number): CartesianPoint {
 	// 1/2 the image sizes that will be used in shift.
@@ -353,9 +356,9 @@ export function shift(size: Dimensions, point: CartesianPoint, direction: number
 
 /**
  * Rotates point counterclockwise through angle.
- * @param angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
- * @param point (x,y) pair to rotate.
- * @returns Rotated (x,y) pair.
+ * @param {number} angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
+ * @param {CartesianPoint} point (x,y) pair to rotate.
+ * @returns {CartesianPoint} Rotated (x,y) pair.
  */
 export function rotate(angleDeg: number, point: CartesianPoint): CartesianPoint {
 	// Convert angle to radians.
@@ -370,11 +373,11 @@ export function rotate(angleDeg: number, point: CartesianPoint): CartesianPoint 
 
 /**
  * This shifts the point and then rotates by the angle. Typically used to go from user map to true north.
- * @param size The size of the image (normally normalized map size)
- * @param point The (x,y) pair for the point to be shifted & rotated
- * @param direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
- * @param angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
- * @returns (x,y) pair shifted by 1/2 the width and height of map image and rotated by angleDeg
+ * @param {Dimensions} size The size of the image (normally normalized map size)
+ * @param {CartesianPoint} point The (x,y) pair for the point to be shifted & rotated
+ * @param {number} direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
+ * @param {number} angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
+ * @returns {CartesianPoint} (x,y) pair shifted by 1/2 the width and height of map image and rotated by angleDeg
  */
 export function shiftRotate(size: Dimensions, point: CartesianPoint, direction: number, angleDeg: number): CartesianPoint {
 	// Note you typically shift because the rotation must occur around the center of the map but the plotly coordinates
@@ -387,11 +390,11 @@ export function shiftRotate(size: Dimensions, point: CartesianPoint, direction: 
 
 /**
  * This rotates the point by the angle and then shifts. Typically used to go from true north to user map.
- * @param size The size of the image (normally normalized map size)
- * @param point The (x,y) pair for the point to be rotated & shifted
- * @param direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
- * @param angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
- * @returns (x,y) pair shifted by 1/2 the width and height of map image
+ * @param {Dimensions} size The size of the image (normally normalized map size)
+ * @param {CartesianPoint} point The (x,y) pair for the point to be rotated & shifted
+ * @param {number} direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
+ * @param {number} angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
+ * @returns {CartesianPoint} (x,y) pair shifted by 1/2 the width and height of map image
  */
 export function rotateShift(size: Dimensions, point: CartesianPoint, direction: number, angleDeg: number): CartesianPoint {
 	// Now rotate the centered image by the angle given.
@@ -406,8 +409,9 @@ export function rotateShift(size: Dimensions, point: CartesianPoint, direction: 
 /**
  * Returns the origin of the user map converted to the true north map. Note that it is in
  * in the bottom, left on the user map but in the center on the true north map.
- * @param size the normalized map dimensions
- * @returns The origin coordinates on the true north map
+ * @param {Dimensions} size the normalized map dimensions
+ * @param {number} northAngle
+ * @returns {CartesianPoint} The origin coordinates on the true north map
  */
 export function trueNorthOrigin(size: Dimensions, northAngle: number): CartesianPoint {
 	// Origin coordinate on user map is (0, 0).
@@ -420,8 +424,9 @@ export function trueNorthOrigin(size: Dimensions, northAngle: number): Cartesian
  * Similar to trueNorthOrigin function but returns the opposite corner of the user map converted
  * to the true north map. Note that it is in the top, right of the user map but
  * relative to the center on the true north map.
- * @param size the normalized map dimensions
- * @returns The opposite coordinates on the true north map
+ * @param {Dimensions} size the normalized map dimensions
+ * @param {number} northAngle
+ * @returns {CartesianPoint} The opposite coordinates on the true north map
  */
 export function trueNorthOpposite(size: Dimensions, northAngle: number): CartesianPoint {
 	// The opposite coordinate is the size since it is in the top, right corner

--- a/src/client/app/utils/calibration.ts
+++ b/src/client/app/utils/calibration.ts
@@ -133,7 +133,7 @@ export function isValidGPSInput(input: string): boolean {
  * @param {GPSPoint} opposite The GPS value for the opposite that was computed during calibration.
  * 	This is the top, right corner of the user map.
  * @param {Dimensions} size This is the size of the normalized map image.
- * @param {number} northAngle
+ * @param {number} northAngle The angle between true north and straight up on the map image.
  * @returns {MapScale} a pair {deltaX, deltaY} representing the GPS degree per unit (x, y)
  * 	on true north map grid.
  */
@@ -152,7 +152,7 @@ export function calculateScaleFromEndpoints(origin: GPSPoint, opposite: GPSPoint
  * @param {GPSPoint} gps The GPS coordinate to convert
  * @param {GPSPoint} originGPS The GPS value of the origin on the true north map.
  * @param {MapScale} scaleOfMap The GPS degree per unit x, y on the true north map.
- * @param {number} northAngle
+ * @param {number} northAngle The angle between true north and straight up on the map image.
  * @returns {CartesianPoint} x, y value of the gps point on the user map.
  */
 export function gpsToUserGrid(size: Dimensions, gps: GPSPoint, originGPS: GPSPoint, scaleOfMap: MapScale, northAngle: number): CartesianPoint {
@@ -178,7 +178,7 @@ export function gpsToUserGrid(size: Dimensions, gps: GPSPoint, originGPS: GPSPoi
  * one from each pair of calibration points. It returns all three of these values.
  * @param {CalibratedPoint[]} calibrationSet All the points clicked by the user for calibration.
  * @param {Dimensions} imageDimensions The dimensions of the original map to use from the user.
- * @param {number} northAngle
+ * @param {number} northAngle The angle between true north and straight up on the map image.
  * @returns {CalibrationResult} The error and the origin & opposite point in GPS to use for mapping.
  */
 export function calibrate(calibrationSet: CalibratedPoint[], imageDimensions: Dimensions, northAngle: number): CalibrationResult {
@@ -410,7 +410,7 @@ export function rotateShift(size: Dimensions, point: CartesianPoint, direction: 
  * Returns the origin of the user map converted to the true north map. Note that it is in
  * in the bottom, left on the user map but in the center on the true north map.
  * @param {Dimensions} size the normalized map dimensions
- * @param {number} northAngle
+ * @param {number} northAngle The angle between true north and straight up on the map image.
  * @returns {CartesianPoint} The origin coordinates on the true north map
  */
 export function trueNorthOrigin(size: Dimensions, northAngle: number): CartesianPoint {
@@ -425,7 +425,7 @@ export function trueNorthOrigin(size: Dimensions, northAngle: number): Cartesian
  * to the true north map. Note that it is in the top, right of the user map but
  * relative to the center on the true north map.
  * @param {Dimensions} size the normalized map dimensions
- * @param {number} northAngle
+ * @param {number} northAngle The angle between true north and straight up on the map image.
  * @returns {CartesianPoint} The opposite coordinates on the true north map
  */
 export function trueNorthOpposite(size: Dimensions, northAngle: number): CartesianPoint {

--- a/src/client/app/utils/determineCompatibleUnits.ts
+++ b/src/client/app/utils/determineCompatibleUnits.ts
@@ -11,9 +11,9 @@ import { GroupDefinition } from 'types/redux/groups';
 
 /**
  * The intersect operation of two sets.
- * @param setA The first set.
- * @param setB The second set.
- * @returns The intersection of two sets.
+ * @param {Set<number>} setA The first set.
+ * @param {Set<number>} setB The second set.
+ * @returns {Set<number>} The intersection of two sets.
  */
 export function setIntersect(setA: Set<number>, setB: Set<number>): Set<number> {
 	return new Set(Array.from(setA).filter(i => setB.has(i)));
@@ -21,8 +21,8 @@ export function setIntersect(setA: Set<number>, setB: Set<number>): Set<number> 
 
 /**
  * Takes a set of meter ids and returns the set of compatible unit ids.
- * @param meters The set of meter ids.
- * @returns
+ * @param {Set<number>} meters The set of meter ids.
+ * @returns {Set<number>} The set of compatible units.
  */
 export function unitsCompatibleWithMeters(meters: Set<number>): Set<number> {
 	const state = store.getState();
@@ -58,8 +58,8 @@ export function unitsCompatibleWithMeters(meters: Set<number>): Set<number> {
 
 /**
  * Returns a set of units ids that are compatible with a specific unit id.
- * @param unitId The unit id.
- * @returns
+ * @param {number} unitId The unit id.
+ * @returns {Set<number>} The set of units compatible with the given id.
  */
 export function unitsCompatibleWithUnit(unitId: number): Set<number> {
 	// unitSet starts as an empty set.
@@ -87,8 +87,8 @@ export function unitsCompatibleWithUnit(unitId: number): Set<number> {
 
 /**
  * Returns the row index in Pik for a meter unit.
- * @param unitId The unit id.
- * @returns
+ * @param {number} unitId The unit id.
+ * @returns {number} The row index.
  */
 export function pRowFromUnit(unitId: number): number {
 	const state = store.getState();
@@ -101,8 +101,8 @@ export function pRowFromUnit(unitId: number): number {
 
 /**
  * Returns the unit id given the row in Pik.
- * @param row The row to find the associated unit.
- * @returns
+ * @param {number} row The row to find the associated unit.
+ * @returns {number} The unit id.
  */
 export function unitFromPRow(row: number): number {
 	const state = store.getState();
@@ -115,8 +115,8 @@ export function unitFromPRow(row: number): number {
 
 /**
  * Returns the unit id given the column in Pik.
- * @param column The column to find the associated unit.
- * @returns
+ * @param {number} column The column to find the associated unit.
+ * @returns {number} The unit id.
  */
 export function unitFromPColumn(column: number): number {
 	const state = store.getState();
@@ -129,8 +129,8 @@ export function unitFromPColumn(column: number): number {
 
 /**
  * Returns the set of meters's ids associated with the groupId used.
- * @param groupId The groupId.
- * @returns the set of deep children of this group
+ * @param {number} groupId The groupId.
+ * @returns {Set<number>} the set of deep children of this group
  */
 export function metersInGroup(groupId: number): Set<number> {
 	const state = store.getState();

--- a/src/client/app/utils/hasPermissions.ts
+++ b/src/client/app/utils/hasPermissions.ts
@@ -5,16 +5,22 @@
 import { UserRole } from '../types/items';
 
 /**
- * Checks if the role A has the permission of the role B.
+ * Checks if the user has the permissions of a given role.
+ * @param {UserRole} user User role to evaluate
+ * @param {UserRole} compareTo User role to compare to
+ * @returns {boolean} Whether or not the user has the permissions
  */
-export function hasPermissions(userA: UserRole, userB: UserRole): boolean {
+export function hasPermissions(user: UserRole, compareTo: UserRole): boolean {
 	// Admins always have any other role.
-	return userA === UserRole.ADMIN || userA === userB;
+	return user === UserRole.ADMIN || user === compareTo;
 }
 
 /**
  * Checks if the role A is an Admin.
+ *
+ * @param {UserRole} user User role to evaluate
+ * @returns {boolean} Whether or not role A is an admin
  */
-export function isRoleAdmin(A: UserRole): boolean {
-	return A === UserRole.ADMIN;
+export function isRoleAdmin(user: UserRole): boolean {
+	return user === UserRole.ADMIN;
 }

--- a/src/client/app/utils/hasPermissions.ts
+++ b/src/client/app/utils/hasPermissions.ts
@@ -8,7 +8,7 @@ import { UserRole } from '../types/items';
  * Checks if the user has the permissions of a given role.
  * @param {UserRole} user User role to evaluate
  * @param {UserRole} compareTo User role to compare to
- * @returns {boolean} Whether or not the user has the permissions
+ * @returns {boolean} Whether or not the user has the compareTo role
  */
 export function hasPermissions(user: UserRole, compareTo: UserRole): boolean {
 	// Admins always have any other role.
@@ -16,10 +16,9 @@ export function hasPermissions(user: UserRole, compareTo: UserRole): boolean {
 }
 
 /**
- * Checks if the role A is an Admin.
- *
+ * Checks if user is an Admin.
  * @param {UserRole} user User role to evaluate
- * @returns {boolean} Whether or not role A is an admin
+ * @returns {boolean} Whether or not user is an admin
  */
 export function isRoleAdmin(user: UserRole): boolean {
 	return user === UserRole.ADMIN;


### PR DESCRIPTION
# Description

Fixes in a lot of files for various jsdoc problems. Mainly just updating param and return types.

Also added a TODO item to decide whether newline-after-description should be on or off. Jsdoc recommends this setting, but it adds a lot of needless space to the code.

Partly addresses #769 

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist
- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
