### PR TITLE
update chart links, esp. for units/rates

### DIFF
--- a/src/client/app/actions/graph.ts
+++ b/src/client/app/actions/graph.ts
@@ -18,6 +18,10 @@ import { fetchNeededMapReadings } from './mapReadings';
 import { changeSelectedMap, fetchMapsDetails } from './map';
 import { fetchUnitsDetailsIfNeeded } from './units';
 
+export function changeRenderOnce() {
+	return { type: ActionType.ConfirmGraphRenderOnce };
+}
+
 export function changeChartToRender(chartType: t.ChartTypes): t.ChangeChartToRenderAction {
 	return { type: ActionType.ChangeChartToRender, chartType };
 }

--- a/src/client/app/actions/graph.ts
+++ b/src/client/app/actions/graph.ts
@@ -235,7 +235,7 @@ export function changeOptionsFromLink(options: LinkOptions) {
 		dispatchSecond.push(updateLineGraphRate(options.rate));
 	}
 	if (options.barDuration) {
-		dispatchSecond.push(changeBarDuration(options.barDuration));
+		dispatchFirst.push(changeBarDuration(options.barDuration));
 	}
 	if (options.serverRange) {
 		dispatchSecond.push(changeGraphZoomIfNeeded(options.serverRange));
@@ -256,7 +256,7 @@ export function changeOptionsFromLink(options: LinkOptions) {
 		dispatchSecond.push(setOptionsVisibility(options.optionsVisibility));
 	}
 	if (options.mapID) {
-		// TODO here and elsewhere should be IfNeeded.
+		// TODO here and elsewhere should be IfNeeded but need to check that all state updates are done when edit, etc.
 		dispatchFirst.push(fetchMapsDetails());
 		dispatchSecond.push(changeSelectedMap(options.mapID));
 	}

--- a/src/client/app/actions/graph.ts
+++ b/src/client/app/actions/graph.ts
@@ -15,7 +15,7 @@ import * as t from '../types/redux/graph';
 import * as m from '../types/redux/map';
 import { ComparePeriod, SortingOrder } from '../utils/calculateCompare';
 import { fetchNeededMapReadings } from './mapReadings';
-import { changeSelectedMap } from './map';
+import { changeSelectedMap, fetchMapsDetails } from './map';
 import { fetchUnitsDetailsIfNeeded } from './units';
 
 export function changeChartToRender(chartType: t.ChartTypes): t.ChangeChartToRenderAction {
@@ -256,6 +256,8 @@ export function changeOptionsFromLink(options: LinkOptions) {
 		dispatchSecond.push(setOptionsVisibility(options.optionsVisibility));
 	}
 	if (options.mapID) {
+		// TODO here and elsewhere should be IfNeeded.
+		dispatchFirst.push(fetchMapsDetails());
 		dispatchSecond.push(changeSelectedMap(options.mapID));
 	}
 	return (dispatch: Dispatch) => Promise.all(dispatchFirst.map(dispatch))

--- a/src/client/app/actions/graph.ts
+++ b/src/client/app/actions/graph.ts
@@ -216,9 +216,12 @@ export interface LinkOptions {
  */
 export function changeOptionsFromLink(options: LinkOptions) {
 	const dispatchFirst: Thunk[] = [setHotlinkedAsync(true)];
-	const dispatchSecond: Array<Thunk | t.ChangeChartToRenderAction | t.ChangeBarStackingAction
-		| t.ChangeGraphZoomAction | t.ChangeCompareSortingOrderAction | t.SetOptionsVisibility
-		| m.UpdateSelectedMapAction | t.UpdateLineGraphRate> = [];
+	// Visual Studio indents after the first line in autoformat but ESLint does not like that in this case so override.
+	/* eslint-disable @typescript-eslint/indent */
+	const dispatchSecond: Array<Thunk | t.ChangeChartToRenderAction | t.ChangeBarStackingAction |
+		t.ChangeGraphZoomAction | t.ChangeCompareSortingOrderAction | t.SetOptionsVisibility |
+		m.UpdateSelectedMapAction | t.UpdateLineGraphRate> = [];
+	/* eslint-enable @typescript-eslint/indent */
 
 	if (options.meterIDs) {
 		dispatchFirst.push(fetchMetersDetailsIfNeeded());

--- a/src/client/app/components/RouteComponent.tsx
+++ b/src/client/app/components/RouteComponent.tsx
@@ -42,8 +42,10 @@ interface RouteProps {
 	defaultLanguage: LanguageTypes;
 	loggedInAsAdmin: boolean;
 	role: UserRole;
+	renderOnce: boolean;
 	changeOptionsFromLink(options: LinkOptions): Promise<any[]>;
 	clearCurrentUser(): any;
+	changeRenderOnce(): any;
 }
 
 export default class RouteComponent extends React.Component<RouteProps> {
@@ -150,85 +152,99 @@ export default class RouteComponent extends React.Component<RouteProps> {
 	 * @param search The string of queries in the path
 	 */
 	public linkToGraph(component: JSX.Element, search: string) {
-		const queries: any = queryString.parse(search);
-		if (!_.isEmpty(queries)) {
-			try {
-				const options: LinkOptions = {};
-				for (const [key, infoObj] of _.entries(queries)) {
-					// TODO The upgrade of TypeScript lead to it giving an error for the type of infoObj
-					// which it thinks is unknown. I'm not sure why and this is code from the history
-					// package (see modules/@types/history/index.d.ts). What follows is a hack where
-					// the type is cast to any. This removes the problem and also allowed the removal
-					// of the ! to avoid calling toString when it is a bad value. I think this is okay
-					// because the toString documentation indicates it works fine with any type including
-					// null and unknown. If it does convert then the default case will catch it as an error.
-					// I want to get rid of this issue so Travis testing is not stopped by this. However,
-					// we should look into this typing issue more to see what might be a better fix.
-					const fixTypeIssue: any = infoObj as any;
-					const info: string = fixTypeIssue.toString();
-					switch (key) {
-						case 'meterIDs':
-							options.meterIDs = info.split(',').map(s => parseInt(s));
-							break;
-						case 'groupIDs':
-							options.groupIDs = info.split(',').map(s => parseInt(s));
-							break;
-						case 'chartType':
-							options.chartType = info as ChartTypes;
-							break;
-						case 'unitID':
-							options.unitID = parseInt(info);
-							break;
-						case 'rate':
-							const params = info.split(',');
-							options.rate = { label: params[0], rate: parseFloat(params[1]) } as LineGraphRate;
-							break;
-						case 'barDuration':
-							options.barDuration = moment.duration(parseInt(info), 'days');
-							break;
-						case 'barStacking':
-							if (this.props.barStacking.toString() !== info) {
-								options.toggleBarStacking = true;
-							}
-							break;
-						case 'comparePeriod':
-							options.comparePeriod = validateComparePeriod(info);
-							break;
-						case 'compareSortingOrder':
-							options.compareSortingOrder = validateSortingOrder(info);
-							break;
-						case 'optionsVisibility':
-							options.optionsVisibility = (info === 'true');
-							break;
-						case 'mapID':
-							options.mapID = (parseInt(info));
-							break;
-						case 'serverRange':
-							options.serverRange = TimeInterval.fromString(info);
-							/**
-							 * commented out since days from present feature is not currently used
-							 */
-							// const index = info.indexOf('dfp');
-							// if (index === -1) {
-							// 	options.serverRange = TimeInterval.fromString(info);
-							// } else {
-							// 	const message = info.substring(0, index);
-							// 	const stringField = this.getNewIntervalFromMessage(message);
-							// 	options.serverRange = TimeInterval.fromString(stringField);
-							// }
-							break;
-						case 'sliderRange':
-							options.sliderRange = TimeInterval.fromString(info);
-							break;
-						default:
-							throw new Error('Unknown query parameter');
+		/*
+		 * This stops the chart links from processing more than once. Initially renderOnce is false
+		 * so the code executes but then it is set to true near the end so it will not do it again.
+		 * This is somewhat more efficient but, more importantly, it fixed a bug. The URL did not clear
+		 * until a different page was loaded. While most selections did not route /graph, some do
+		 * so this function is called. The bug was that when the user clicked on bar stacking, that
+		 * action caused the action to happen but then it happened again here. This caused the boolean
+		 * to flip twice so it was unchanged in the end. It is possible that other issues could exist
+		 * but should be gone now.
+		*/
+		if (!this.props.renderOnce) {
+			const queries: any = queryString.parse(search);
+			if (!_.isEmpty(queries)) {
+				try {
+					const options: LinkOptions = {};
+					for (const [key, infoObj] of _.entries(queries)) {
+						// TODO The upgrade of TypeScript lead to it giving an error for the type of infoObj
+						// which it thinks is unknown. I'm not sure why and this is code from the history
+						// package (see modules/@types/history/index.d.ts). What follows is a hack where
+						// the type is cast to any. This removes the problem and also allowed the removal
+						// of the ! to avoid calling toString when it is a bad value. I think this is okay
+						// because the toString documentation indicates it works fine with any type including
+						// null and unknown. If it does convert then the default case will catch it as an error.
+						// I want to get rid of this issue so Travis testing is not stopped by this. However,
+						// we should look into this typing issue more to see what might be a better fix.
+						const fixTypeIssue: any = infoObj as any;
+						const info: string = fixTypeIssue.toString();
+						switch (key) {
+							case 'meterIDs':
+								options.meterIDs = info.split(',').map(s => parseInt(s));
+								break;
+							case 'groupIDs':
+								options.groupIDs = info.split(',').map(s => parseInt(s));
+								break;
+							case 'chartType':
+								options.chartType = info as ChartTypes;
+								break;
+							case 'unitID':
+								options.unitID = parseInt(info);
+								break;
+							case 'rate':
+								const params = info.split(',');
+								options.rate = { label: params[0], rate: parseFloat(params[1]) } as LineGraphRate;
+								break;
+							case 'barDuration':
+								options.barDuration = moment.duration(parseInt(info), 'days');
+								break;
+							case 'barStacking':
+								if (this.props.barStacking.toString() !== info) {
+									options.toggleBarStacking = true;
+								}
+								break;
+							case 'comparePeriod':
+								options.comparePeriod = validateComparePeriod(info);
+								break;
+							case 'compareSortingOrder':
+								options.compareSortingOrder = validateSortingOrder(info);
+								break;
+							case 'optionsVisibility':
+								options.optionsVisibility = (info === 'true');
+								break;
+							case 'mapID':
+								options.mapID = (parseInt(info));
+								break;
+							case 'serverRange':
+								options.serverRange = TimeInterval.fromString(info);
+								/**
+								 * commented out since days from present feature is not currently used
+								 */
+								// const index = info.indexOf('dfp');
+								// if (index === -1) {
+								// 	options.serverRange = TimeInterval.fromString(info);
+								// } else {
+								// 	const message = info.substring(0, index);
+								// 	const stringField = this.getNewIntervalFromMessage(message);
+								// 	options.serverRange = TimeInterval.fromString(stringField);
+								// }
+								break;
+							case 'sliderRange':
+								options.sliderRange = TimeInterval.fromString(info);
+								break;
+							default:
+								throw new Error('Unknown query parameter');
+						}
 					}
+					// The chartlink was processed so note so will not be done again.
+					this.props.changeRenderOnce();
+					if (Object.keys(options).length > 0) {
+						this.props.changeOptionsFromLink(options);
+					}
+				} catch (err) {
+					showErrorNotification(translate('failed.to.link.graph'));
 				}
-				if (Object.keys(options).length > 0) {
-					this.props.changeOptionsFromLink(options);
-				}
-			} catch (err) {
-				showErrorNotification(translate('failed.to.link.graph'));
 			}
 		}
 		return component;

--- a/src/client/app/components/RouteComponent.tsx
+++ b/src/client/app/components/RouteComponent.tsx
@@ -179,6 +179,8 @@ export default class RouteComponent extends React.Component<RouteProps> {
 						// we should look into this typing issue more to see what might be a better fix.
 						const fixTypeIssue: any = infoObj as any;
 						const info: string = fixTypeIssue.toString();
+						// ESLint does not want const params in the one case it is used so put here.
+						let params;
 						switch (key) {
 							case 'meterIDs':
 								options.meterIDs = info.split(',').map(s => parseInt(s));
@@ -193,7 +195,7 @@ export default class RouteComponent extends React.Component<RouteProps> {
 								options.unitID = parseInt(info);
 								break;
 							case 'rate':
-								const params = info.split(',');
+								params = info.split(',');
 								options.rate = { label: params[0], rate: parseFloat(params[1]) } as LineGraphRate;
 								break;
 							case 'barDuration':

--- a/src/client/app/components/RouteComponent.tsx
+++ b/src/client/app/components/RouteComponent.tsx
@@ -166,7 +166,6 @@ export default class RouteComponent extends React.Component<RouteProps> {
 					// we should look into this typing issue more to see what might be a better fix.
 					const fixTypeIssue: any = infoObj as any;
 					const info: string = fixTypeIssue.toString();
-					let params;
 					switch (key) {
 						case 'meterIDs':
 							options.meterIDs = info.split(',').map(s => parseInt(s));
@@ -181,7 +180,7 @@ export default class RouteComponent extends React.Component<RouteProps> {
 							options.unitID = parseInt(info);
 							break;
 						case 'rate':
-							params = info.split(',');
+							const params = info.split(',');
 							options.rate = { label: params[0], rate: parseFloat(params[1]) } as LineGraphRate;
 							break;
 						case 'barDuration':

--- a/src/client/app/components/RouteComponent.tsx
+++ b/src/client/app/components/RouteComponent.tsx
@@ -15,7 +15,7 @@ import AdminComponent from './admin/AdminComponent';
 import { LinkOptions } from 'actions/graph';
 import { hasToken, deleteToken } from '../utils/token';
 import { showErrorNotification } from '../utils/notifications';
-import { ChartTypes } from '../types/redux/graph';
+import { ChartTypes, LineGraphRate } from '../types/redux/graph';
 import { LanguageTypes } from '../types/redux/i18n';
 import { verificationApi } from '../utils/api';
 import translate from '../utils/translate';
@@ -166,6 +166,7 @@ export default class RouteComponent extends React.Component<RouteProps> {
 					// we should look into this typing issue more to see what might be a better fix.
 					const fixTypeIssue: any = infoObj as any;
 					const info: string = fixTypeIssue.toString();
+					let params;
 					switch (key) {
 						case 'meterIDs':
 							options.meterIDs = info.split(',').map(s => parseInt(s));
@@ -175,6 +176,13 @@ export default class RouteComponent extends React.Component<RouteProps> {
 							break;
 						case 'chartType':
 							options.chartType = info as ChartTypes;
+							break;
+						case 'unitID':
+							options.unitID = parseInt(info);
+							break;
+						case 'rate':
+							params = info.split(',');
+							options.rate = { label: params[0], rate: parseFloat(params[1]) } as LineGraphRate;
 							break;
 						case 'barDuration':
 							options.barDuration = moment.duration(parseInt(info), 'days');

--- a/src/client/app/containers/ChartLinkContainer.ts
+++ b/src/client/app/containers/ChartLinkContainer.ts
@@ -14,7 +14,19 @@ import { State } from '../types/redux/state';
 *  Returns the updated link text */
 function mapStateToProps(state: State) {
 	const chartType = state.graph.chartToRender;
-	let linkText = `${window.location.href}graph?`;
+	// Determine the beginning of the URL to add arguments to.
+	// This is the current URL.
+	const winLocHref = window.location.href;
+	// See if graph? is in URL. We add that when it comes in as a chartlink.
+	// Want to remove so we can start without the current arguments.
+	let startOfParams = winLocHref.indexOf('graph?');
+	console.log('winLocHref: ', winLocHref, ' startOfParams: ', startOfParams);
+	// It is -1 if not there. In that case use the full length string.
+	startOfParams = startOfParams === -1 ? winLocHref.length : startOfParams;
+	// Grab the start of URL to what was just determined.
+	const baseURL = winLocHref.substring(0, startOfParams);
+	// Add graph? since we want to route to graph and have a ? before any arguments.
+	let linkText = `${baseURL}graph?`;
 	// let weeklyLink = ''; // reflects graph 7 days from present, with user selected meters and groups;
 	if (state.graph.selectedMeters.length > 0) {
 		linkText += `meterIDs=${state.graph.selectedMeters.toString()}&`;

--- a/src/client/app/containers/ChartLinkContainer.ts
+++ b/src/client/app/containers/ChartLinkContainer.ts
@@ -46,10 +46,8 @@ function mapStateToProps(state: State) {
 			break;
 	}
 	const unitID = state.graph.selectedUnit;
-	//const rate = state.graph.lineGraphRate.rate.toString();
-	linkText += `unitID=${unitID.toString()}&`;
-	linkText += `rate=${state.graph.lineGraphRate.label.toString()},${state.graph.lineGraphRate.rate.toString()}&`;
-	// linkText += `rate=${state.units.units[unitID].secInRate}&`;
+	linkText += `&unitID=${unitID.toString()}`;
+	linkText += `&rate=${state.graph.lineGraphRate.label.toString()},${state.graph.lineGraphRate.rate.toString()}`;
 	return {
 		linkText,
 		chartType

--- a/src/client/app/containers/ChartLinkContainer.ts
+++ b/src/client/app/containers/ChartLinkContainer.ts
@@ -45,6 +45,11 @@ function mapStateToProps(state: State) {
 		default:
 			break;
 	}
+	const unitID = state.graph.selectedUnit;
+	//const rate = state.graph.lineGraphRate.rate.toString();
+	linkText += `unitID=${unitID.toString()}&`;
+	linkText += `rate=${state.graph.lineGraphRate.label.toString()},${state.graph.lineGraphRate.rate.toString()}&`;
+	// linkText += `rate=${state.units.units[unitID].secInRate}&`;
 	return {
 		linkText,
 		chartType

--- a/src/client/app/containers/ChartLinkContainer.ts
+++ b/src/client/app/containers/ChartLinkContainer.ts
@@ -20,7 +20,6 @@ function mapStateToProps(state: State) {
 	// See if graph? is in URL. We add that when it comes in as a chartlink.
 	// Want to remove so we can start without the current arguments.
 	let startOfParams = winLocHref.indexOf('graph?');
-	console.log('winLocHref: ', winLocHref, ' startOfParams: ', startOfParams);
 	// It is -1 if not there. In that case use the full length string.
 	startOfParams = startOfParams === -1 ? winLocHref.length : startOfParams;
 	// Grab the start of URL to what was just determined.

--- a/src/client/app/containers/ExportContainer.ts
+++ b/src/client/app/containers/ExportContainer.ts
@@ -32,47 +32,53 @@ function mapStateToProps(state: State) {
 		for (const groupID of state.graph.selectedGroups) {
 			const byGroupID = state.readings.line.byGroupID[groupID];
 			if (byGroupID !== undefined) {
-				const readingsData = byGroupID[timeInterval.toString()][unitID];
-				if (readingsData !== undefined && !readingsData.isFetching) {
-					const label = state.groups.byGroupID[groupID].name;
-					if (readingsData.readings === undefined) {
-						throw new Error('Unacceptable condition: readingsData.readings is undefined.');
-					}
+				const byTimeInterval = byGroupID[timeInterval.toString()];
+				if (byTimeInterval !== undefined) {
+					const readingsData = byTimeInterval[unitID];
+					if (readingsData !== undefined && !readingsData.isFetching) {
+						const label = state.groups.byGroupID[groupID].name;
+						if (readingsData.readings === undefined) {
+							throw new Error('Unacceptable condition: readingsData.readings is undefined.');
+						}
 
-					const dataPoints: Array<{ x: number, y: number, z: number }> = _.values(readingsData.readings)
-						.map(transformLineReadingToLegacy)
-						.map((v: [number, number, number]) => ({ x: v[0], y: v[1], z: v[2] })
-						);
-					datasets.push({
-						label,
-						id: state.groups.byGroupID[groupID].id,
-						currentChart: chart,
-						exportVals: dataPoints
-					});
+						const dataPoints: Array<{ x: number, y: number, z: number }> = _.values(readingsData.readings)
+							.map(transformLineReadingToLegacy)
+							.map((v: [number, number, number]) => ({ x: v[0], y: v[1], z: v[2] })
+							);
+						datasets.push({
+							label,
+							id: state.groups.byGroupID[groupID].id,
+							currentChart: chart,
+							exportVals: dataPoints
+						});
+					}
 				}
 			}
 		}
 		for (const meterID of state.graph.selectedMeters) {
 			const byMeterID = state.readings.line.byMeterID[meterID];
 			if (byMeterID !== undefined) {
-				const readingsData = byMeterID[timeInterval.toString()][unitID];
-				if (readingsData !== undefined && !readingsData.isFetching) {
-					const label = state.meters.byMeterID[meterID].name;
-					if (readingsData.readings === undefined) {
-						throw new Error('Unacceptable condition: readingsData.readings is undefined.');
-					}
+				const byTimeInterval = byMeterID[timeInterval.toString()];
+				if (byTimeInterval !== undefined) {
+					const readingsData = byTimeInterval[unitID];
+					if (readingsData !== undefined && !readingsData.isFetching) {
+						const label = state.meters.byMeterID[meterID].name;
+						if (readingsData.readings === undefined) {
+							throw new Error('Unacceptable condition: readingsData.readings is undefined.');
+						}
 
-					const dataPoints: Array<{ x: number, y: number, z: number }> = _.values(readingsData.readings)
-						.map(transformLineReadingToLegacy)
-						.map(
-							(v: [number, number, number]) => ({ x: v[0], y: v[1], z: v[2] })
-						);
-					datasets.push({
-						label,
-						id: state.meters.byMeterID[meterID].id,
-						currentChart: chart,
-						exportVals: dataPoints
-					});
+						const dataPoints: Array<{ x: number, y: number, z: number }> = _.values(readingsData.readings)
+							.map(transformLineReadingToLegacy)
+							.map(
+								(v: [number, number, number]) => ({ x: v[0], y: v[1], z: v[2] })
+							);
+						datasets.push({
+							label,
+							id: state.meters.byMeterID[meterID].id,
+							currentChart: chart,
+							exportVals: dataPoints
+						});
+					}
 				}
 			}
 		}

--- a/src/client/app/containers/RouteContainer.ts
+++ b/src/client/app/containers/RouteContainer.ts
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import RouteComponent from '../components/RouteComponent';
 import { Dispatch } from '../types/redux/actions';
 import { State } from '../types/redux/state';
-import { changeOptionsFromLink, LinkOptions } from '../actions/graph';
+import { changeOptionsFromLink, LinkOptions, changeRenderOnce } from '../actions/graph';
 import { clearCurrentUser } from '../actions/currentUser';
 import { isRoleAdmin } from '../utils/hasPermissions';
 import { UserRole } from '../types/items';
@@ -24,14 +24,18 @@ function mapStateToProps(state: State) {
 		barStacking: state.graph.barStacking,
 		defaultLanguage: state.admin.defaultLanguage,
 		loggedInAsAdmin,
-		role
+		role,
+		// true if the chartlink rendering has been done.
+		renderOnce: state.graph.renderOnce,
 	};
 }
 
 function mapDispatchToProps(dispatch: Dispatch) {
 	return {
 		changeOptionsFromLink: (options: LinkOptions) => dispatch(changeOptionsFromLink(options)),
-		clearCurrentUser: () => dispatch(clearCurrentUser())
+		clearCurrentUser: () => dispatch(clearCurrentUser()),
+		// Set the state to indicate chartlinks have been rendered.
+		changeRenderOnce: () => dispatch(changeRenderOnce())
 	};
 }
 

--- a/src/client/app/containers/RouteContainer.ts
+++ b/src/client/app/containers/RouteContainer.ts
@@ -26,7 +26,7 @@ function mapStateToProps(state: State) {
 		loggedInAsAdmin,
 		role,
 		// true if the chartlink rendering has been done.
-		renderOnce: state.graph.renderOnce,
+		renderOnce: state.graph.renderOnce
 	};
 }
 

--- a/src/client/app/reducers/graph.ts
+++ b/src/client/app/reducers/graph.ts
@@ -22,11 +22,18 @@ const defaultState: GraphState = {
 	barStacking: false,
 	hotlinked: false,
 	optionsVisibility: true,
-	lineGraphRate: {label: 'hour', rate: 1}
+	lineGraphRate: {label: 'hour', rate: 1},
+	renderOnce: false
 };
 
 export default function graph(state = defaultState, action: GraphAction) {
 	switch (action.type) {
+		case ActionType.ConfirmGraphRenderOnce: {
+			return {
+				...state,
+				renderOnce: true
+			};
+		}
 		case ActionType.UpdateSelectedMeters:
 			return {
 				...state,

--- a/src/client/app/types/redux/actions.ts
+++ b/src/client/app/types/redux/actions.ts
@@ -52,6 +52,7 @@ export enum ActionType {
 	ChangeCompareSortingOrder = 'CHANGE_COMPARE_SORTING_ORDER',
 	SetHotlinked = 'SET_HOTLINKED',
 	UpdateLineGraphRate = 'UPDATE_LINE_GRAPH_RATE',
+	ConfirmGraphRenderOnce = 'CONFIRM_GRAPH_RENDER_ONCE',
 
 	RequestGroupsDetails = 'REQUEST_GROUPS_DETAILS',
 	ReceiveGroupsDetails = 'RECEIVE_GROUPS_DETAILS',

--- a/src/client/app/types/redux/graph.ts
+++ b/src/client/app/types/redux/graph.ts
@@ -91,6 +91,10 @@ export interface UpdateLineGraphRate {
 	lineGraphRate: LineGraphRate;
 }
 
+export interface ConfirmGraphRenderOnce {
+	type: ActionType.ConfirmGraphRenderOnce;
+}
+
 export type GraphAction =
 	| ChangeGraphZoomAction
 	| ChangeSliderRangeAction
@@ -105,7 +109,8 @@ export type GraphAction =
 	| SetHotlinked
 	| ChangeCompareSortingOrderAction
 	| SetOptionsVisibility
-	| UpdateLineGraphRate;
+	| UpdateLineGraphRate
+	| ConfirmGraphRenderOnce;
 
 export interface LineGraphRate {
 	label: string,
@@ -127,4 +132,5 @@ export interface GraphState {
 	hotlinked: boolean;
 	optionsVisibility: boolean;
 	lineGraphRate: LineGraphRate;
+	renderOnce: boolean;
 }


### PR DESCRIPTION
# Description

Resource generalization added units and rates to graphics. These now work with chart links so you can reproduce these graphics with the new values. While making these changes some other items were found/addressed:

- The bug stopping map chart links from working was fixed (issue #701)
- A bug that did not start the options from the correct base URL when getting a chart link from a page that was opened with a chart link was fixed.
- The code reprocessed the chart link options on many routes until a new page URL was used. This caused a bug where bar stacking did not work and was inefficient. It was fixed.
- Fixed a bug where the bar duration was not set on the menu UI.

Fixes #701, Fixed #813

This PR is a follow on to PR #839. The initial commit on this PR reproduces that work in that PR that related to chart links. The original PR was put in by @Jumpman5 (their work, the effort of other(s) and some by @huss). Redoing the work lost the commit record from that PR but this is meant to document this. I did this because:

- The original PR had work unrelated to chart links.
- The PR was from a repo created directly on the OED organization and this caused issues in working with the PR.
- I was too lazy to fix this in another way (sorry).

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

An existing issue where the slider range is not reproduced was noticed and issue #853 was created.
