### PR TITLE
chore: Remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,12 @@
         "@types/history": "~4.7.9",
         "@types/react-router": "~5.1.17",
         "@types/react-router-dom": "~5.3.2",
-        "attr-accept": "~2.2.1",
         "axios": "~0.24.0",
         "babel-core": "~7.0.0-bridge.0",
         "babel-plugin-formatjs": "~10.3.12",
         "bcryptjs": "~2.4.3",
         "body-parser": "~1.18.3",
         "bootstrap": "~4.3.1",
-        "chokidar": "~3.5.2",
-        "co": "~4.6.0",
         "cookie-parser": "~1.4.4",
         "csv": "~5.3.2",
         "debug": "~4.3.2",
@@ -33,12 +30,8 @@
         "express": "~4.17.3",
         "express-rate-limit": "~5.5.1",
         "history": "~4.7.2",
-        "http-signature": "~1.3.6",
-        "jquery": "~3.5.0",
-        "json-schema": "~0.4.0",
         "jsonschema": "~1.2.4",
         "jsonwebtoken": "~9.0.0",
-        "jsprim": "~2.0.2",
         "lodash": "~4.17.21",
         "lodash-webpack-plugin": "~0.11.6",
         "md5": "~2.2.1",
@@ -96,7 +89,7 @@
         "@types/moment": "~2.13.0",
         "@types/plotly.js": "~2.12.5",
         "@types/rc-slider": "~8.2.3",
-        "@types/react": "~17.0.35",
+        "@types/react": "~17.0.53",
         "@types/react-dom": "~17.0.10",
         "@types/react-notification-system": "~0.2.41",
         "@types/react-redux": "~7.1.16",
@@ -105,24 +98,23 @@
         "acorn": "~8.7.0",
         "assert": "~2.0.0",
         "babel-loader": "~8.2.3",
-        "babel-plugin-lodash": "~3.2.11",
         "babel-polyfill": "~6.26.0",
         "buffer": "~6.0.3",
         "chai": "~3.5.0",
         "chai-as-promised": "~6.0.0",
         "chai-http": "~4.2.1",
-        "cryptiles": "~4.1.3",
         "css-loader": "~6.4.0",
         "eslint": "~8.10.0",
         "eslint-plugin-react": "~7.28.0",
         "mocha": "~9.2.2",
-        "mock-require": "~2.0.2",
         "nodemon": "~2.0.15",
         "sinon": "~12.0.0",
         "source-map-loader": "~3.0.0",
         "stream-browserify": "~3.0.0",
-        "style-loader": "~3.3.1",
-        "tsutils": "~3.19.1"
+        "style-loader": "~3.3.1"
+      },
+      "peerDependencies": {
+        "babel-plugin-lodash": "~3.3.4"
       }
     },
     "node_modules/@babel/cli": {
@@ -3083,9 +3075,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.35.tgz",
-      "integrity": "sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==",
+      "version": "17.0.53",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.53.tgz",
+      "integrity": "sha512-1yIpQR2zdYu1Z/dc1OxC+MA6GR240u3gcnP4l6mvj/PJiVaqHsQPmWttsvHsfnhfPbU2FuGmo0wSITPygjBmsw==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4259,13 +4251,16 @@
       }
     },
     "node_modules/babel-plugin-lodash": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.11.tgz",
-      "integrity": "sha1-Icj97J/hg176pzeHPjkCvdZtVwE=",
-      "dev": true,
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "peer": true,
       "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
         "glob": "^7.1.1",
-        "lodash": "^4.17.2"
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -4499,16 +4494,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
-    },
-    "node_modules/boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "deprecated": "This module has moved and is now available at @hapi/boom. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dev": true,
-      "dependencies": {
-        "hoek": "6.x.x"
-      }
     },
     "node_modules/bootstrap": {
       "version": "4.3.1",
@@ -4892,18 +4877,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/caller-id": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
-      "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
-      "dev": true,
-      "dependencies": {
-        "stack-trace": "~0.0.7"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5153,15 +5126,6 @@
       "dev": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
-      }
-    },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
       }
     },
     "node_modules/color-alpha": {
@@ -5619,16 +5583,6 @@
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/cryptiles": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-      "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-      "deprecated": "This module has moved and is now available at @hapi/cryptiles. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dev": true,
-      "dependencies": {
-        "boom": "7.x.x"
       }
     },
     "node_modules/crypto-browserify": {
@@ -8426,13 +8380,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
-      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dev": true
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -8541,19 +8488,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^2.0.2",
-        "sshpk": "^1.14.1"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/https-browserify": {
@@ -9357,11 +9291,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9477,20 +9406,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
-      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -10306,18 +10221,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/mock-require": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
-      "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
-      "dev": true,
-      "dependencies": {
-        "caller-id": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/moment": {
@@ -12926,6 +12829,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
+      "peer": true
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -14496,21 +14405,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
-    },
-    "node_modules/tsutils": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.19.1.tgz",
-      "integrity": "sha512-GEdoBf5XI324lu7ycad7s6laADfnAqCw6wLGI+knxvw9vsIYBaJfYdmeCEG3FMMUiSm3OGgNb+m6utsWf5h9Vw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
@@ -18163,9 +18057,9 @@
       }
     },
     "@types/react": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.35.tgz",
-      "integrity": "sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==",
+      "version": "17.0.53",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.53.tgz",
+      "integrity": "sha512-1yIpQR2zdYu1Z/dc1OxC+MA6GR240u3gcnP4l6mvj/PJiVaqHsQPmWttsvHsfnhfPbU2FuGmo0wSITPygjBmsw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -19062,13 +18956,16 @@
       }
     },
     "babel-plugin-lodash": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.11.tgz",
-      "integrity": "sha1-Icj97J/hg176pzeHPjkCvdZtVwE=",
-      "dev": true,
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "peer": true,
       "requires": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
         "glob": "^7.1.1",
-        "lodash": "^4.17.2"
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
       }
     },
     "babel-plugin-macros": {
@@ -19271,15 +19168,6 @@
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
           "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
         }
-      }
-    },
-    "boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "dev": true,
-      "requires": {
-        "hoek": "6.x.x"
       }
     },
     "bootstrap": {
@@ -19581,15 +19469,6 @@
         "get-intrinsic": "^1.0.2"
       }
     },
-    "caller-id": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
-      "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
-      "dev": true,
-      "requires": {
-        "stack-trace": "~0.0.7"
-      }
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -19784,11 +19663,6 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-alpha": {
       "version": "1.0.4",
@@ -20178,15 +20052,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-    },
-    "cryptiles": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-      "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-      "dev": true,
-      "requires": {
-        "boom": "7.x.x"
-      }
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -22442,12 +22307,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
-      "dev": true
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -22540,16 +22399,6 @@
             "picomatch": "^2.2.3"
           }
         }
-      }
-    },
-    "http-signature": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^2.0.2",
-        "sshpk": "^1.14.1"
       }
     },
     "https-browserify": {
@@ -23098,11 +22947,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -23198,17 +23042,6 @@
             "lru-cache": "^6.0.0"
           }
         }
-      }
-    },
-    "jsprim": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
-      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
       }
     },
     "jsx-ast-utils": {
@@ -23832,15 +23665,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "mock-require": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
-      "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
-      "dev": true,
-      "requires": {
-        "caller-id": "^0.1.0"
       }
     },
     "moment": {
@@ -25957,6 +25781,12 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
+    "require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
+      "peer": true
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -27205,15 +27035,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
-    },
-    "tsutils": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.19.1.tgz",
-      "integrity": "sha512-GEdoBf5XI324lu7ycad7s6laADfnAqCw6wLGI+knxvw9vsIYBaJfYdmeCEG3FMMUiSm3OGgNb+m6utsWf5h9Vw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
     },
     "tty-browserify": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"
   },
+  "peerDependencies": {
+    "babel-plugin-lodash": "~3.3.4"
+  },
   "dependencies": {
     "@babel/plugin-proposal-object-rest-spread": "~7.16.7",
     "@babel/preset-react": "~7.16.7",
@@ -71,15 +74,12 @@
     "@types/history": "~4.7.9",
     "@types/react-router": "~5.1.17",
     "@types/react-router-dom": "~5.3.2",
-    "attr-accept": "~2.2.1",
     "axios": "~0.24.0",
     "babel-core": "~7.0.0-bridge.0",
     "babel-plugin-formatjs": "~10.3.12",
     "bcryptjs": "~2.4.3",
     "body-parser": "~1.18.3",
     "bootstrap": "~4.3.1",
-    "chokidar": "~3.5.2",
-    "co": "~4.6.0",
     "cookie-parser": "~1.4.4",
     "csv": "~5.3.2",
     "debug": "~4.3.2",
@@ -89,12 +89,8 @@
     "express": "~4.17.3",
     "express-rate-limit": "~5.5.1",
     "history": "~4.7.2",
-    "http-signature": "~1.3.6",
-    "jquery": "~3.5.0",
-    "json-schema": "~0.4.0",
     "jsonschema": "~1.2.4",
     "jsonwebtoken": "~9.0.0",
-    "jsprim": "~2.0.2",
     "lodash": "~4.17.21",
     "lodash-webpack-plugin": "~0.11.6",
     "md5": "~2.2.1",
@@ -152,7 +148,7 @@
     "@types/moment": "~2.13.0",
     "@types/plotly.js": "~2.12.5",
     "@types/rc-slider": "~8.2.3",
-    "@types/react": "~17.0.35",
+    "@types/react": "~17.0.53",
     "@types/react-dom": "~17.0.10",
     "@types/react-notification-system": "~0.2.41",
     "@types/react-redux": "~7.1.16",
@@ -161,23 +157,19 @@
     "acorn": "~8.7.0",
     "assert": "~2.0.0",
     "babel-loader": "~8.2.3",
-    "babel-plugin-lodash": "~3.2.11",
     "babel-polyfill": "~6.26.0",
     "buffer": "~6.0.3",
     "chai": "~3.5.0",
     "chai-as-promised": "~6.0.0",
     "chai-http": "~4.2.1",
-    "cryptiles": "~4.1.3",
     "css-loader": "~6.4.0",
     "eslint": "~8.10.0",
     "eslint-plugin-react": "~7.28.0",
     "mocha": "~9.2.2",
-    "mock-require": "~2.0.2",
     "nodemon": "~2.0.15",
     "sinon": "~12.0.0",
     "source-map-loader": "~3.0.0",
     "stream-browserify": "~3.0.0",
-    "style-loader": "~3.3.1",
-    "tsutils": "~3.19.1"
+    "style-loader": "~3.3.1"
   }
 }


### PR DESCRIPTION
# Description

In `package.json`, there were several dependencies that weren't being used. Over the years, they seem to have been accidentally included in various PRs. This increases `npm install` installation time, and is a security risk.

This fixes that by removing the items from `package.json`. None of the dependencies were `require`'d in any other part of the codebase, so they are fit for removal.

The `babel-plugin-lodash` is a special case as it's recommended for use by `lodash-webpack-plugin`. Since it's not a direct dependency, its status was changed to a `peerDependency`.

## Type of change

- [X] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [X] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [X] I have removed text in ( ) from the issue request

## Limitations

There are a few dependencies that are only used in one or two places, that could be removed since these functions are built into NodeJS these days. But that's for a different PR.