### PR TITLE
Multiple Fixes: Fixes issues with Modals (Issue #794)

### DIFF
--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -15,6 +15,7 @@ import { hasPermissions } from '../utils/hasPermissions';
 import { FlipLogOutStateAction } from '../types/redux/unsavedWarning';
 
 interface HeaderButtonsProps {
+	isModal: boolean;
 	showCollapsedMenuButton: boolean;
 	loggedInAsAdmin: boolean;
 	role: UserRole | null;
@@ -47,6 +48,7 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 		const renderCSVButton = Boolean(role && hasPermissions(role, UserRole.CSV));
 		const shouldUnitsButtonDisabled = getPage() === 'units';
 		const shouldConversionsButtonDisabled = getPage() === 'conversions';
+		const dataFor = this.props.isModal ? 'all-modal' : 'all';
 
 		const linkStyle: React.CSSProperties = {
 			display: 'inline',
@@ -80,8 +82,8 @@ export default class HeaderButtonsComponent extends React.Component<HeaderButton
 					}
 				</div>
 				<div className={this.props.showCollapsedMenuButton ? 'd-none d-lg-block' : ''}>
-					<TooltipHelpContainer page='all' />
-					<TooltipMarkerComponent page='all' helpTextId='help.home.header' />
+					<TooltipHelpContainer page={dataFor} />
+					<TooltipMarkerComponent page={dataFor} helpTextId='help.home.header' />
 					<Link
 						style={adminViewableLinkStyle}
 						to='/admin'>

--- a/src/client/app/components/HeaderComponent.tsx
+++ b/src/client/app/components/HeaderComponent.tsx
@@ -50,7 +50,7 @@ class HeaderComponent extends React.Component<HeaderProps> {
 					</div>
 					<div className='col-4 justify-content-end' style={divRightStyle}>
 						{ this.props.optionsVisibility ?
-							<HeaderButtonsContainer showCollapsedMenuButton />
+							<HeaderButtonsContainer showCollapsedMenuButton isModal={false}/>
 							: <MenuModalComponent
 								showOptions={getPage() === ''}
 								showCollapsedMenuButton={false}

--- a/src/client/app/components/MenuModalComponent.tsx
+++ b/src/client/app/components/MenuModalComponent.tsx
@@ -60,7 +60,7 @@ export default class MenuModalComponent extends React.Component<MenuModalProps, 
 							<p style={labelStyle}>
 								<FormattedMessage id='navigation' />:
 							</p>
-							<HeaderButtonsContainer  showCollapsedMenuButton={false} isModal />
+							<HeaderButtonsContainer  showCollapsedMenuButton={false} isModal={true} />
 						</div>
 						{ this.props.showOptions &&
 							<UIOptionsContainer />

--- a/src/client/app/components/MenuModalComponent.tsx
+++ b/src/client/app/components/MenuModalComponent.tsx
@@ -60,7 +60,7 @@ export default class MenuModalComponent extends React.Component<MenuModalProps, 
 							<p style={labelStyle}>
 								<FormattedMessage id='navigation' />:
 							</p>
-							<HeaderButtonsContainer  showCollapsedMenuButton={false} />
+							<HeaderButtonsContainer  showCollapsedMenuButton={false} isModal />
 						</div>
 						{ this.props.showOptions &&
 							<UIOptionsContainer />

--- a/src/client/app/components/conversion/CreateConversionModalComponent.tsx
+++ b/src/client/app/components/conversion/CreateConversionModalComponent.tsx
@@ -171,9 +171,9 @@ export default function CreateConversionModalComponent(props: CreateConversionMo
 			<Modal show={showModal} onHide={handleClose}>
 				<Modal.Header>
 					<Modal.Title> <FormattedMessage id="create.conversion" />
-						<TooltipHelpContainer page='conversions' />
+						<TooltipHelpContainer page='conversions-create' />
 						<div style={tooltipStyle}>
-							<TooltipMarkerComponent page='conversions' helpTextId={tooltipStyle.tooltipCreateConversionView} />
+							<TooltipMarkerComponent page='conversions-create' helpTextId={tooltipStyle.tooltipCreateConversionView} />
 						</div>
 					</Modal.Title>
 				</Modal.Header>

--- a/src/client/app/components/conversion/EditConversionModalComponent.tsx
+++ b/src/client/app/components/conversion/EditConversionModalComponent.tsx
@@ -155,9 +155,9 @@ export default function EditConversionModalComponent(props: EditConversionModalC
 			<Modal show={props.show} onHide={props.handleClose}>
 				<Modal.Header>
 					<Modal.Title> <FormattedMessage id="conversion.edit.conversion" />
-						<TooltipHelpContainer page='conversions' />
+						<TooltipHelpContainer page='conversions-edit' />
 						<div style={tooltipStyle}>
-							<TooltipMarkerComponent page='conversions' helpTextId={tooltipStyle.tooltipEditConversionView} />
+							<TooltipMarkerComponent page='conversions-edit' helpTextId={tooltipStyle.tooltipEditConversionView} />
 						</div>
 					</Modal.Title>
 				</Modal.Header>

--- a/src/client/app/components/meters/CreateMeterModalComponent.tsx
+++ b/src/client/app/components/meters/CreateMeterModalComponent.tsx
@@ -327,9 +327,9 @@ export default function CreateMeterModalComponent(props: CreateMeterModalCompone
 			<Modal show={showModal} onHide={handleClose}>
 				<Modal.Header>
 					<Modal.Title> <FormattedMessage id="meter.create" />
-						<TooltipHelpContainer page='meters' />
+						<TooltipHelpContainer page='meters-create' />
 						<div style={tooltipStyle}>
-							<TooltipMarkerComponent page='meters' helpTextId={tooltipStyle.tooltipCreateMeterView} />
+							<TooltipMarkerComponent page='meters-create' helpTextId={tooltipStyle.tooltipCreateMeterView} />
 						</div>
 					</Modal.Title>
 				</Modal.Header>

--- a/src/client/app/components/meters/EditMeterModalComponent.tsx
+++ b/src/client/app/components/meters/EditMeterModalComponent.tsx
@@ -360,9 +360,9 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 			<Modal show={props.show} onHide={props.handleClose}>
 				<Modal.Header>
 					<Modal.Title> <FormattedMessage id="edit.meter" />
-						<TooltipHelpContainer page='meters' />
+						<TooltipHelpContainer page='meters-edit' />
 						<div style={tooltipStyle}>
-							<TooltipMarkerComponent page='meters' helpTextId={tooltipStyle.tooltipEditMeterView} />
+							<TooltipMarkerComponent page='meters-edit' helpTextId={tooltipStyle.tooltipEditMeterView} />
 						</div>
 					</Modal.Title>
 				</Modal.Header>

--- a/src/client/app/components/unit/CreateUnitModalComponent.tsx
+++ b/src/client/app/components/unit/CreateUnitModalComponent.tsx
@@ -105,9 +105,9 @@ export default function CreateUnitModalComponent() {
 			<Modal show={showModal} onHide={handleClose}>
 				<Modal.Header>
 					<Modal.Title> <FormattedMessage id="create.unit" />
-						<TooltipHelpContainer page='units' />
+						<TooltipHelpContainer page='units-create' />
 						<div style={tooltipStyle}>
-							<TooltipMarkerComponent page='units' helpTextId={tooltipStyle.tooltipCreateUnitView} />
+							<TooltipMarkerComponent page='units-create' helpTextId={tooltipStyle.tooltipCreateUnitView} />
 						</div>
 					</Modal.Title>
 				</Modal.Header>

--- a/src/client/app/components/unit/EditUnitModalComponent.tsx
+++ b/src/client/app/components/unit/EditUnitModalComponent.tsx
@@ -151,9 +151,9 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 			<Modal show={props.show} onHide={props.handleClose}>
 				<Modal.Header>
 					<Modal.Title> <FormattedMessage id="edit.unit" />
-						<TooltipHelpContainer page='units' />
+						<TooltipHelpContainer page='units-edit' />
 						<div style={tooltipStyle}>
-							<TooltipMarkerComponent page='units' helpTextId={tooltipStyle.tooltipEditUnitView} />
+							<TooltipMarkerComponent page='units-edit' helpTextId={tooltipStyle.tooltipEditUnitView} />
 						</div>
 					</Modal.Title>
 				</Modal.Header>

--- a/src/client/app/containers/HeaderButtonsContainer.tsx
+++ b/src/client/app/containers/HeaderButtonsContainer.tsx
@@ -12,7 +12,7 @@ import { clearCurrentUser } from '../actions/currentUser';
 import { UserRole } from '../types/items';
 import { flipLogOutState } from '../actions/unsavedWarning';
 
-function mapStateToProps(state: State, ownProps: { showCollapsedMenuButton: boolean }) {
+function mapStateToProps(state: State, ownProps: { showCollapsedMenuButton: boolean, isModal: boolean}) {
 	const currentUser = state.currentUser.profile;
 	let loggedInAsAdmin = false;
 	let role: UserRole | null = null;


### PR DESCRIPTION
Fixes #794

# Description

(This resolves the tooltips not being shown after displaying a modal. Also fixes an issue with the Menu Modal not allowing tooltips for mobile users on the front page.)

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

No limitations.
