### PR TITLE
chore: Replace `es6-promisify` with `util.promisify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "csv": "~5.3.2",
         "debug": "~4.3.2",
         "dotenv": "~9.0.0",
-        "es6-promisify": "~5.0.0",
         "express": "~4.17.3",
         "express-rate-limit": "~5.5.1",
         "history": "~4.7.2",
@@ -6752,19 +6751,6 @@
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
       "dev": true
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "node_modules/es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dependencies": {
-        "es6-promise": "^4.0.3"
-      }
     },
     "node_modules/es6-symbol": {
       "version": "3.1.3",
@@ -21574,19 +21560,6 @@
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
       "dev": true
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
     },
     "es6-symbol": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "csv": "~5.3.2",
     "debug": "~4.3.2",
     "dotenv": "~9.0.0",
-    "es6-promisify": "~5.0.0",
     "express": "~4.17.3",
     "express-rate-limit": "~5.5.1",
     "history": "~4.7.2",

--- a/src/server/data/automatedTestingData.js
+++ b/src/server/data/automatedTestingData.js
@@ -6,7 +6,6 @@
  * This file contains a series of functions used to generate (at some point automated - hopefully) test data.
  */
 
-const promisify = require('es6-promisify');
 const { generateSine, generateCosine } = require('./generateTestingData');
 const Unit = require('../models/Unit');
 const { insertUnits, insertStandardUnits, insertConversions, insertStandardConversions, insertMeters, insertGroups } = require('../util/insertData');
@@ -168,7 +167,7 @@ async function generateCosineSquaredTestingData(amplitude = 1) {
  * The next five functions -- generateFourDayTestingData(), generateFourHourTestingData(), generateTwentyThreeMinuteTestingData(),
  * generateFifteenMinuteTestingData(), and generateOneMinuteTestingData() -- have no parameters as they generate one year of data at
  * pre-specified intervals. All have wave periods of 45 days for easy visual display.
- * 
+ *
  * Please see the documentation for 'generateSine()' under 'generateTestingData.js' for more details.
  */
 

--- a/src/server/data/generateTestingData.js
+++ b/src/server/data/generateTestingData.js
@@ -16,14 +16,14 @@
  */
 
 // Imports
+const util = require('util');
 const fs = require('fs').promises;
 const stringify = require('csv-stringify');
 const _ = require('lodash');
 const moment = require('moment');
-const promisify = require('es6-promisify');
 const { log } = require('../log');
 
-const stringifyCSV = promisify(stringify);
+const stringifyCSV = util.promisify(stringify);
 /* Our main export is the generateSine function. We break this into several parts:
  * 1. Generate the moments in time within a specified range and at a specified time step from a given range.
  * 2. For each moment determine how much time as elapsed (as a decimal) within its respective period.
@@ -32,7 +32,7 @@ const stringifyCSV = promisify(stringify);
  * 		use is a function of radians and sin(x) = sin(x/P * P * 2 * PI)
  * 4. We zip the array of moments and their corresponding sine values into a matrix,
  * which we will use write into a csv file.
- * 
+ *
  * It is believed this is okay with moment and local time shifts because it is all done here and the dates/times
  * are stored as strings without timezones that OED can correctly import.
  */

--- a/src/server/services/pipeline-in-progress/readCsv.js
+++ b/src/server/services/pipeline-in-progress/readCsv.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const util = require('util');
 const csv = require('csv');
-const fs = require('fs');
-const promisify = require('es6-promisify');
+const fs = require('fs').promises;
 
-const readFile = promisify(fs.readFile);
-const parseCsv = promisify(csv.parse);
+const parseCsv = util.promisify(csv.parse);
 
 /**
  * Returns a promise to read the given CSV file into an array of arrays.
@@ -16,7 +15,7 @@ const parseCsv = promisify(csv.parse);
  * @return {Promise.<array.<array>>}
  */
 async function readCsv(fileName, headerRow) {
-	const buffer = await readFile(fileName);
+	const buffer = await fs.readFile(fileName);
 	if (headerRow) {
 		// For now we ignore the header row by starting the parse on line 2.
 		// If we ever allow the rearrange based on header row name then this

--- a/src/server/services/readCsv.js
+++ b/src/server/services/readCsv.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const util = require('util');
+const fs = require('fs').promises;
 const csv = require('csv');
-const fs = require('fs');
-const promisify = require('es6-promisify');
 
-const readFile = promisify(fs.readFile);
-const parseCsv = promisify(csv.parse);
+const parseCsv = util.promisify(csv.parse);
 
 /**
  * Returns a promise to read the given CSV file into an array of arrays.
@@ -15,7 +14,7 @@ const parseCsv = promisify(csv.parse);
  * @return {Promise.<array.<array>>}
  */
 async function readCsv(fileName) {
-	const buffer = await readFile(fileName);
+	const buffer = await fs.readFile(fileName);
 	return await parseCsv(buffer.toString());
 }
 

--- a/src/server/services/readMamacData.js
+++ b/src/server/services/readMamacData.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const util = require('util');
 const reqPromise = require('request-promise-native');
-const promisify = require('es6-promisify');
 const csv = require('csv');
 const moment = require('moment');
 const Reading = require('../models/Reading');
 const loadArrayInput = require('./pipeline-in-progress/loadArrayInput');
 
-const parseCsv = promisify(csv.parse);
+const parseCsv = util.promisify(csv.parse);
 
 function parseTimestamp(raw, line) {
 	raw = raw.trim();

--- a/src/server/services/readMamacMeters.js
+++ b/src/server/services/readMamacMeters.js
@@ -4,15 +4,15 @@
 
 const reqPromise = require('request-promise-native');
 const readCsv = require('./readCsv');
-const promisify = require('es6-promisify');
 const parseString = require('xml2js').parseString;
 const Meter = require('../models/Meter');
+const util = require('util');
 const _ = require('lodash');
 const stopDB = require('../models/database').stopDB;
 const { log } = require('../log');
 const moment = require('moment');
 
-const parseXMLPromisified = promisify(parseString);
+const parseXMLPromisified = util.promisify(parseString);
 
 async function parseCSV(filename) {
 	// returns a list of lists representing the lines of the file

--- a/src/server/test/generateTestDataTests.js
+++ b/src/server/test/generateTestDataTests.js
@@ -7,15 +7,15 @@
  * library chai.
  */
 
+const util = require('util');
 const _ = require('lodash');
 const chai = require('chai');
 const mocha = require('mocha');
 const expect = chai.expect;
 const fs = require('fs').promises;
 const moment = require('moment');
-const promisify = require('es6-promisify');
 const csv = require('csv');
-const parseCsv = promisify(csv.parse);
+const parseCsv = util.promisify(csv.parse);
 const path = require('path');
 
 const generateData = require('../data/generateTestingData'); // To get this file compile ../data/generateTestingData.ts

--- a/src/server/test/web/csvPipelineTest.js
+++ b/src/server/test/web/csvPipelineTest.js
@@ -9,12 +9,12 @@ const Point = require('../../models/Point');
 const Unit = require('../../models/Unit');
 const { insertStandardUnits, insertStandardConversions, insertUnits, insertConversions } = require('../../util/insertData')
 const { redoCik } = require('../../services/graph/redoCik');
+const util = require('util');
 const fs = require('fs');
 const csv = require('csv');
-const promisify = require('es6-promisify');
 const moment = require('moment');
 
-const parseCsv = promisify(csv.parse);
+const parseCsv = util.promisify(csv.parse);
 
 const UPLOAD_METERS_ROUTE = '/api/csv/meters';
 const UPLOAD_READINGS_ROUTE = '/api/csv/readings';
@@ -27,9 +27,9 @@ const CHAI_METERS_REQUEST = `chai.request(app).post('${UPLOAD_METERS_ROUTE}').fi
 // but all other keys are arrays of length number of uploads in test.
 // Note the use of double quotes for strings because some have single quotes within.
 
-/** 
+/**
  * description, what the tests aims to test
- * chaiRequest, makes a string of the parameters 
+ * chaiRequest, makes a string of the parameters
  * fileName, the input files used for the test
  * responseCode, the expected response code from the request
  * responseString, the expected response string from the request

--- a/src/server/util/userRoles.js
+++ b/src/server/util/userRoles.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const util = require('util');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
-const promisify = require('es6-promisify');
-const jwtVerify = promisify(jwt.verify);
+const jwtVerify = util.promisify(jwt.verify);
 const { getConnection } = require('../db');
 const secretToken = require('../config').secretToken;
 
 /**
- * Checks if a role has the authorization capabilities as the requested role. 
+ * Checks if a role has the authorization capabilities as the requested role.
  * @param {User.role} role is a role listed in User.role
  * @param {User.role} requestedRole is a role listed in User.role
  * @returns {boolean} true if role has the permissions of the requestedRole. Returns false otherwise.
@@ -24,7 +24,7 @@ function isRoleAuthorized(role, requestedRole) {
 }
 
 /**
- * Checks if a token (assumed to be verified) has the authorization capabilities as the requested role. 
+ * Checks if a token (assumed to be verified) has the authorization capabilities as the requested role.
  * @param token is a jwt token
  * @param {User.role} requestedRole is a role listed in User.role
  * @returns {Promise<boolean>} true if the token has the permissions of the requestedRole. Returns false otherwise.
@@ -43,7 +43,7 @@ async function isTokenAuthorized(token, requestedRole) {
 
 /**
  * Checks if a user is authorized by role.
- * @param {User} user 
+ * @param {User} user
  * @param {User.role} requestedRole is a role listed in User.role
  * @returns {boolean} true if the user object has permissions of the requestedRole. Returns false otherwise.
  */


### PR DESCRIPTION
# Description

As noted generically in #858, this removed the use of a dependency that can be replaced with a built-in NodeJS function: `util.promisify`. It was added in NodeJS v8.0.0.

## Type of change

- [x] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

N/A