### PR TITLE
Update conversion error notifications to show error details

### DIFF
--- a/src/client/app/actions/conversions.ts
+++ b/src/client/app/actions/conversions.ts
@@ -99,7 +99,7 @@ export function submitEditedConversion(editedConversion: t.ConversionData, shoul
 				showSuccessNotification(translate('conversion.successfully.edited.conversion'));
 			} catch (err) {
 				// Failure! ):
-				showErrorNotification(translate('conversion.failed.to.edit.conversion') + '"' + err.response.data + '"');
+				showErrorNotification(translate('conversion.failed.to.edit.conversion') + ' "' + err.response.data as string + '"');
 			}
 			// Clear conversionData object from submitting state array
 			dispatch(deleteSubmittedConversion(editedConversion));
@@ -121,7 +121,7 @@ export function addConversion(conversion: t.ConversionData): Thunk {
 			dispatch(fetchConversionsDetails());
 			showSuccessNotification(translate('conversion.successfully.create.conversion'));
 		} catch (err) {
-			showErrorNotification(translate('conversion.failed.to.create.conversion') + '"' + err.response.data + '"');
+			showErrorNotification(translate('conversion.failed.to.create.conversion') + ' "' + err.response.data as string + '"');
 		}
 	}
 }
@@ -150,7 +150,7 @@ export function deleteConversion(conversion: t.ConversionData): Thunk {
 				dispatch(confirmDeletedConversion(conversion));
 				showSuccessNotification(translate('conversion.successfully.delete.conversion'));
 			} catch (err) {
-				showErrorNotification(translate('conversion.failed.to.delete.conversion') + '"' + err.response.data + '"');
+				showErrorNotification(translate('conversion.failed.to.delete.conversion') + ' "' + err.response.data as string + '"');
 			}
 			// Inform the store we are done working with the conversion
 			dispatch(deleteSubmittedConversion(conversion));

--- a/src/client/app/actions/conversions.ts
+++ b/src/client/app/actions/conversions.ts
@@ -99,7 +99,7 @@ export function submitEditedConversion(editedConversion: t.ConversionData, shoul
 				showSuccessNotification(translate('conversion.successfully.edited.conversion'));
 			} catch (err) {
 				// Failure! ):
-				showErrorNotification(translate('conversion.failed.to.edit.conversion'));
+				showErrorNotification(translate('conversion.failed.to.edit.conversion') + '"' + err + '"');
 			}
 			// Clear conversionData object from submitting state array
 			dispatch(deleteSubmittedConversion(editedConversion));
@@ -121,7 +121,7 @@ export function addConversion(conversion: t.ConversionData): Thunk {
 			dispatch(fetchConversionsDetails());
 			showSuccessNotification(translate('conversion.successfully.create.conversion'));
 		} catch (err) {
-			showErrorNotification(translate('conversion.failed.to.create.conversion'));
+			showErrorNotification(translate('conversion.failed.to.create.conversion') + '"' + err + '"');
 		}
 	}
 }
@@ -150,7 +150,7 @@ export function deleteConversion(conversion: t.ConversionData): Thunk {
 				dispatch(confirmDeletedConversion(conversion));
 				showSuccessNotification(translate('conversion.successfully.delete.conversion'));
 			} catch (err) {
-				showErrorNotification(translate('conversion.failed.to.delete.conversion'));
+				showErrorNotification(translate('conversion.failed.to.delete.conversion') + '"' + err + '"');
 			}
 			// Inform the store we are done working with the conversion
 			dispatch(deleteSubmittedConversion(conversion));

--- a/src/client/app/actions/conversions.ts
+++ b/src/client/app/actions/conversions.ts
@@ -99,7 +99,7 @@ export function submitEditedConversion(editedConversion: t.ConversionData, shoul
 				showSuccessNotification(translate('conversion.successfully.edited.conversion'));
 			} catch (err) {
 				// Failure! ):
-				showErrorNotification(translate('conversion.failed.to.edit.conversion') + '"' + err + '"');
+				showErrorNotification(translate('conversion.failed.to.edit.conversion') + '"' + err.response.data + '"');
 			}
 			// Clear conversionData object from submitting state array
 			dispatch(deleteSubmittedConversion(editedConversion));
@@ -121,7 +121,7 @@ export function addConversion(conversion: t.ConversionData): Thunk {
 			dispatch(fetchConversionsDetails());
 			showSuccessNotification(translate('conversion.successfully.create.conversion'));
 		} catch (err) {
-			showErrorNotification(translate('conversion.failed.to.create.conversion') + '"' + err + '"');
+			showErrorNotification(translate('conversion.failed.to.create.conversion') + '"' + err.response.data + '"');
 		}
 	}
 }
@@ -150,7 +150,7 @@ export function deleteConversion(conversion: t.ConversionData): Thunk {
 				dispatch(confirmDeletedConversion(conversion));
 				showSuccessNotification(translate('conversion.successfully.delete.conversion'));
 			} catch (err) {
-				showErrorNotification(translate('conversion.failed.to.delete.conversion') + '"' + err + '"');
+				showErrorNotification(translate('conversion.failed.to.delete.conversion') + '"' + err.response.data + '"');
 			}
 			// Inform the store we are done working with the conversion
 			dispatch(deleteSubmittedConversion(conversion));

--- a/src/server/routes/conversions.js
+++ b/src/server/routes/conversions.js
@@ -122,7 +122,7 @@ router.post('/addConversion', async (req, res) => {
 	const validationResult = validate(req.body, validConversion);
 	if (!validationResult.valid) {
 		log.error(`Invalid input for conversion. ${validationResult.error}`);
-        failure(res, 400, 'Invalid input for conversion: ' + validationResult.error.toString());
+        failure(res, 400, 'Invalid input for conversion: ' + validationResult.errors.toString());
 	} else {
 		const conn = getConnection();
 		try {

--- a/src/server/routes/conversions.js
+++ b/src/server/routes/conversions.js
@@ -26,7 +26,7 @@ router.get('/', async (req, res) => {
 		const rows = await Conversion.getAll(conn);
 		res.json(rows.map(formatConversionForResponse));
 	} catch (err) {
-		log.error(`Error while performing GET conversions details query: ${err}`, err);
+		log.error(`Error while performing GET conversions details query: ${err}`);
 	}
 });
 
@@ -68,8 +68,8 @@ router.post('/edit', async (req, res) => {
 
 	const validatorResult = validate(req.body, validConversion);
 	if (!validatorResult.valid) {
-		log.warn(`Got request to edit conversions with invalid conversion data, errors:${validatorResult.errors}`);
-        failure(res, 400, "Got request to edit conversions with invalid conversion data. Error(s): " + validatorResult.errors.toString());
+		log.warn(`Got request to edit conversions with invalid conversion data, errors: ${validatorResult.errors}`);
+        failure(res, 400, `Got request to edit conversions with invalid conversion data, errors: ${validatorResult.errors}`);
 	} else {
 		const conn = getConnection();
 		try {
@@ -77,8 +77,8 @@ router.post('/edit', async (req, res) => {
 				req.body.slope, req.body.intercept, req.body.note);
 			await updatedConversion.update(conn);
 		} catch (err) {
-			log.error('Failed to edit conversion', err);
-			failure(res, 500, "Unable to edit conversions due to " + err.toString());
+			log.error(`Error while editing conversion with error(s): ${err}`);
+			failure(res, 500, `Error while editing conversion with error(s): ${err}`);
 		}
 		success(res);
 	}
@@ -119,10 +119,10 @@ router.post('/addConversion', async (req, res) => {
 			}
 		}
 	};
-	const validationResult = validate(req.body, validConversion);
-	if (!validationResult.valid) {
-		log.error(`Invalid input for conversion. ${validationResult.error}`);
-        failure(res, 400, 'Invalid input for conversion: ' + validationResult.errors.toString());
+	const validatorResult = validate(req.body, validConversion);
+	if (!validatorResult.valid) {
+		log.error(`Got request to insert conversion with invalid conversion data, errors: ${validatorResult.errors}`);
+        failure(res, 400, `Got request to insert conversion with invalid conversion data. Error(s): ${validatorResult.errors}`);
 	} else {
 		const conn = getConnection();
 		try {
@@ -139,8 +139,8 @@ router.post('/addConversion', async (req, res) => {
 			});
 			res.sendStatus(200);
 		} catch (err) {
-			log.error(`Error while inserting new conversion ${err}`, err);
-            failure(res, 500, 'Error while inserting new conversion: ' + err.toString());
+			log.error(`Error while inserting new conversion with error(s): ${err}`);
+            failure(res, 500, `Error while inserting new conversion with errors(s): ${err}`);
 		}
 	}
 });
@@ -170,8 +170,8 @@ router.post('/delete', async (req, res) => {
 	// Ensure conversion object is valid
 	const validatorResult = validate(req.body, validConversion);
 	if (!validatorResult.valid) {
-		log.warn(`Got request to delete conversions with invalid conversion data, errors:${validatorResult.errors}`);
-		res.status(400);
+		log.warn(`Got request to delete conversions with invalid conversion data, errors: ${validatorResult.errors}`);
+        failure(res, 400, `Got request to delete conversions with invalid conversion data. Error(s): ${validatorResult.errors}`);
 	} else {
 		const conn = getConnection();
 		try {
@@ -179,10 +179,10 @@ router.post('/delete', async (req, res) => {
 			// Just try to delete it to save the extra database call, since the database will return an error anyway if the row does not exist
 			await Conversion.delete(req.body.sourceId, req.body.destinationId, conn);
 		} catch (err) {
-			log.error('Failed to delete conversion', err);
-			res.status(500).json({ message: 'Unable to delete conversions.', err });
+			log.error(`Error while deleting conversion with error(s): ${err}`);
+            failure(res, 500, `Error while deleting conversion with errors(s): ${err}`);
 		}
-		res.status(200).json({ message: `Successfully deleted conversion ${req.body.sourceId} -> ${req.body.destinationId}` });
+		success(res, `Successfully deleted conversion ${req.body.sourceId} -> ${req.body.destinationId}`);
 	}
 });
 


### PR DESCRIPTION
# Description

Updated `addConversion`,  `submitEditedConversion`, and `deleteConversion` catch statements in conversions.ts to show error details.

Partly Addresses #869.

1. Add: ![image](https://user-images.githubusercontent.com/113533298/227423717-1d0786f4-4ab1-49c9-a297-7882834faf88.png)
2. Edit: ![image](https://user-images.githubusercontent.com/113533298/227423751-fa7358cd-3999-4601-ac17-4946523de22d.png)
3. Delete: ![image](https://user-images.githubusercontent.com/113533298/227423773-c6ccb87c-fcea-42fb-926f-6b716506236a.png)

All tests currently pass: 
![OED_Tests](https://user-images.githubusercontent.com/113533298/227425372-7e711c9a-fa9e-422f-872d-6fb41036a70d.png)



## Type of change

This PR should not require any major update.

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist


- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

1. The time components of `showSuccessNotification` and `showErrorNotification` don't seem to actually change how long the messages stay up as the webpage immediately reloads regardless of how long `autoDismiss` is set for. Another issue may need to be created to fix this. 
2. We were also unable to trigger the error notification naturally and instead forced it using a throw statement so we don't know exactly what the error messages look like.
