### PR TITLE
add standard units/conversions for final production

### DIFF
--- a/src/server/data/automatedTestingData.js
+++ b/src/server/data/automatedTestingData.js
@@ -321,7 +321,17 @@ async function testData() {
 async function insertSpecialUnits(conn) {
 	// The table contains special units' data.
 	const specialUnits = [
+		// Some units must be redone so visible since not for standard units.
+		['BTU', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'special unit'],
+		['m³ gas', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, false, 'special unit'],
+		['kg', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, false, 'special unit'],
+		['metric ton', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, false, 'special unit'],
+		['gallon', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'special unit'],
+		['liter', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'special unit'],
+		['Fahrenheit', '', Unit.unitRepresentType.RAW, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, false, 'special unit'],
+		['Celsius', '', Unit.unitRepresentType.RAW, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, false, 'special unit'],
 		['Electric_Utility', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'special unit'],
+		['MJ', 'megaJoules', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, false, 'special unit'],
 		['Natural_Gas_BTU', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'special unit'],
 		['100 w bulb', '100 w bulb for 10 hrs', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, false, 'special unit'],
 		['Natural_Gas_M3', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'special unit'],
@@ -329,8 +339,6 @@ async function insertSpecialUnits(conn) {
 		['Water_Gallon', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'special unit'],
 		['US dollar', 'US $', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'special unit'],
 		['euro', '€', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'special unit'],
-		['gallon', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'special unit'],
-		['liter', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'special unit'],
 		['kg CO₂', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, 'CO₂', Unit.displayableType.ALL, false, 'special unit'],
 		['Trash', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'special unit'],
 		['Temperature_Fahrenheit', '', Unit.unitRepresentType.RAW, 3600, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'special unit'],
@@ -340,7 +348,8 @@ async function insertSpecialUnits(conn) {
 		['liter per hour', 'liter (rate)', Unit.unitRepresentType.FLOW, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'special unit'],
 		['Water_Gallon_Per_Minute', '', Unit.unitRepresentType.FLOW, 60, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'special unit']
 	];
-	await insertUnits(specialUnits, conn);
+	// For now it updates any units that exist since standard ones are changed for developers. This will wipe out any changes on restart.
+	await insertUnits(specialUnits, true, conn);
 }
 
 
@@ -351,6 +360,7 @@ async function insertSpecialConversions(conn) {
 	// The table contains special conversions' data.
 	const specialConversions = [
 		['kWh', '100 w bulb', false, 1, 0, 'kWh → 100 w bulb'],
+		['kWh', 'MJ', true, 3.6, 0, 'kWh → MJ'],
 		['Electric_Utility', 'kWh', false, 1, 0, 'Electric_Utility → kWh'],
 		['Electric_Utility', 'US dollar', false, 0.115, 0, 'Electric_Utility → US dollar'],
 		['Electric_Utility', 'kg CO₂', false, 0.709, 0, 'Electric_Utility → CO2'],

--- a/src/server/data/websiteData.js
+++ b/src/server/data/websiteData.js
@@ -374,8 +374,8 @@ async function insertWebsiteData() {
 	// It will skip ones that already there.
 	await insertStandardUnits(conn);
 	await insertStandardConversions(conn);
-	// Add desired units and conversions.
-	await insertUnits(units, conn);
+	// Add desired units and conversions where update as needed.
+	await insertUnits(units, true, conn);
 	await insertConversions(conversions, conn);
 	// Recreate the Cik entries since changed units/conversions.
 	// Do now since needed to insert meters with suffix units.

--- a/src/server/test/web/csvPipelineTest.js
+++ b/src/server/test/web/csvPipelineTest.js
@@ -485,7 +485,7 @@ for (let fileKey in testCases) {
 			const units = [
 				['Electric_Utility', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'for teting']
 			];
-			await insertUnits(units, conn);
+			await insertUnits(units, false, conn);
 			// Create conversions from meter units to standard units.
 			const conversions = [
 				['Electric_Utility', 'kWh', false, 1, 0, 'Electric_Utility → kWh'],
@@ -677,7 +677,7 @@ for (let fileKey in testMeters) {
 				['Electric_Utility', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.METER, '', Unit.displayableType.NONE, false, 'for teting'],
 				['kWh', '', Unit.unitRepresentType.QUANTITY, 3600, Unit.unitType.UNIT, '', Unit.displayableType.ALL, true, 'for testing']
 			];
-			await insertUnits(units, conn);
+			await insertUnits(units, false, conn);
 			// Get the value from the DB so can get the id.
 			meterUnit = await Unit.getByName('Electric_Utility', conn);
 			graphUnit = await Unit.getByName('kWh', conn);

--- a/src/server/test/web/readings.js
+++ b/src/server/test/web/readings.js
@@ -46,7 +46,7 @@ const HTTP_CODE = {
  */
 async function prepareTest(unitData, conversionData, meterData, groupData = []) {
 	const conn = testDB.getConnection();
-	await insertUnits(unitData, conn);
+	await insertUnits(unitData, false, conn);
 	await insertConversions(conversionData, conn);
 	await insertMeters(meterData, conn);
 	await insertGroups(groupData, conn);


### PR DESCRIPTION
# Description

Set the (hopefully) final standard units & conversions in OED. Most units are hidden so a site must make them visible.

This is believed to be the last item remaining on the resource generalization items that is not an open issue or involve testing.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known
