### PR TITLE
fix quark warning

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -2,19 +2,25 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
+<!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <base id="base" href="SUBDIR" target="_blank">
     <link rel="icon" type="image/png" href="favicon.ico">
     <title>Open Energy Dashboard</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 </head>
+
 <body>
     <div id="root"></div>
-	<script src="app/bundle.js"></script>
-    <noscript><h1>OED requires JavaScript to run correctly. Please enable JavaScript.</h1></noscript>
+    <script src="app/bundle.js"></script>
+    <noscript>
+        <h1>OED requires JavaScript to run correctly. Please enable JavaScript.</h1>
+    </noscript>
 </body>
 </script>
+
 </html>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
+
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<!DOCTYPE html>
 <html>
 
 <head>


### PR DESCRIPTION
# Description

In Firefox, there was a console warning about using Quark mode. The issue is described [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode?utm_source=mozilla&utm_medium=firefox-console-errors&utm_campaign=default). By adding DOCTYPE to the index page, the warning is now gone. This was never shown in Chrome (others not checked). Testing did not find any issues.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known
