### PR TITLE
bug if no meter/group data on line

### DIFF
--- a/src/server/sql/reading/create_reading_views.sql
+++ b/src/server/sql/reading/create_reading_views.sql
@@ -415,7 +415,7 @@ DECLARE
 				-- Wanted to use the INTO syntax used above but could not get it to work so using the set syntax.
 				requested_interval_seconds := (SELECT * FROM EXTRACT(EPOCH FROM requested_interval));
 				-- Get the frequency that this meter reads at.
-				select reading_frequency into frequency FROM meters where id = current_meter_id;
+				SELECT reading_frequency INTO frequency FROM meters WHERE id = current_meter_id;
 				-- Get the seconds in the frequency.
 				frequency_seconds := (SELECT * FROM EXTRACT(EPOCH FROM frequency));
 


### PR DESCRIPTION
# Description

The query failed if there was no meter or group data for lines. This fixes it so it returns nothing so no graphic is shown.

Note bar does not have this issue unless there is no data at all so it seems okay for now.

## Type of change

- [ ] Note merging this changes the node modules
- [x] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

Note that the DB will automatically update on the next install because this only changed a function. Thus, the box is checked for DB change but it is not as important.
