### PR TITLE
chartlinks work for area normalization

### DIFF
--- a/src/client/app/actions/graph.ts
+++ b/src/client/app/actions/graph.ts
@@ -212,6 +212,7 @@ export interface LinkOptions {
 	serverRange?: TimeInterval;
 	sliderRange?: TimeInterval;
 	toggleAreaNormalization?: boolean;
+	areaUnit?: string;
 	toggleBarStacking?: boolean;
 	comparePeriod?: ComparePeriod;
 	compareSortingOrder?: SortingOrder;
@@ -230,7 +231,8 @@ export function changeOptionsFromLink(options: LinkOptions) {
 	/* eslint-disable @typescript-eslint/indent */
 	const dispatchSecond: Array<Thunk | t.ChangeChartToRenderAction | t.ChangeBarStackingAction |
 		t.ChangeGraphZoomAction | t.ChangeCompareSortingOrderAction | t.SetOptionsVisibility |
-		m.UpdateSelectedMapAction | t.UpdateLineGraphRate | t.ToggleAreaNormalizationAction> = [];
+		m.UpdateSelectedMapAction | t.UpdateLineGraphRate | t.ToggleAreaNormalizationAction |
+		t.UpdateSelectedAreaUnitAction> = [];
 	/* eslint-enable @typescript-eslint/indent */
 
 	if (options.meterIDs) {
@@ -262,6 +264,10 @@ export function changeOptionsFromLink(options: LinkOptions) {
 	}
 	if (options.toggleAreaNormalization) {
 		dispatchSecond.push(toggleAreaNormalization());
+	}
+	if (options.areaUnit) {
+		dispatchSecond.push(updateSelectedAreaUnit(options.areaUnit as AreaUnitType));
+
 	}
 	if (options.toggleBarStacking) {
 		dispatchSecond.push(changeBarStacking());

--- a/src/client/app/components/RouteComponent.tsx
+++ b/src/client/app/components/RouteComponent.tsx
@@ -210,6 +210,9 @@ export default class RouteComponent extends React.Component<RouteProps> {
 									options.toggleAreaNormalization = true;
 								}
 								break;
+							case 'areaUnit':
+								options.areaUnit = info;
+								break;
 							case 'comparePeriod':
 								options.comparePeriod = validateComparePeriod(info);
 								break;

--- a/src/client/app/containers/ChartLinkContainer.ts
+++ b/src/client/app/containers/ChartLinkContainer.ts
@@ -59,6 +59,7 @@ function mapStateToProps(state: State) {
 	const unitID = state.graph.selectedUnit;
 	linkText += `&unitID=${unitID.toString()}`;
 	linkText += `&rate=${state.graph.lineGraphRate.label.toString()},${state.graph.lineGraphRate.rate.toString()}`;
+	linkText += `&areaUnit=${state.graph.selectedAreaUnit}&areaNormalization=${state.graph.areaNormalization}`;
 	return {
 		linkText,
 		chartType


### PR DESCRIPTION
# Description

The chartlink for area normalization was not working. This should now work properly.

Note I decided that the area unit is always set in the chartlink, even if area normalization is false. This means that if the user then clicks to normalize by area then the unit will be what it was from the user who created the chartlink. This was easier and seemed best to me.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known
