### PR TITLE
Use jsdoc rules recommended for typescript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,7 +71,7 @@
     },
     "overrides": [
         {
-            // also possible in the future to limit to src/client/app/components/**/*.tsx files, where we make sure {} is only used for props.
+            // TODO: Remove this override once these components have been converted to use hooks
             "files": [
                 "src/client/app/components/UIModalComponent.tsx",
                 "src/client/app/containers/admin/CreateUserContainer.tsx",
@@ -147,6 +147,31 @@
                     "error",
                     "as-needed"
                 ]
+            }
+        },
+        {
+            // disable jsdoc requirement for reducers and actions
+            "files": [
+                "src/client/app/reducers/*.ts",
+                "src/client/app/actions/*.ts"
+            ],
+            "rules": {
+                "jsdoc/require-jsdoc": "off",
+                "jsdoc/require-returns": "off"
+            }
+        },
+        {
+            // disable jsdoc for containers separately
+            // jsdoc makes sense for containers but we are working on removing them from the codebase
+            // TODO: Remove this override once containers have been converted
+            "files": [
+                "src/client/app/containers/*/*",
+                "src/client/app/containers/*"
+            ],
+            "rules": {
+                "jsdoc/require-jsdoc": "off",
+                "jsdoc/require-returns": "off",
+                "jsdoc/require-param": "off"
             }
         }
     ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended", 
-        "plugin:jsdoc/recommended"
+        "plugin:jsdoc/recommended-typescript"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -30,7 +30,6 @@
         "indent": [
             "off"
         ],
-        "jsdoc/newline-after-description": 0,
         "@typescript-eslint/indent": [
             "error",
             "tab",

--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -136,16 +136,16 @@ export function submitPreferences() {
 }
 
 /**
- * @param {State} state The redux state.
- * @returns {boolean} Whether preferences are fetching
+ * @param state The redux state.
+ * @returns Whether preferences are fetching
  */
 function shouldFetchPreferenceData(state: State): boolean {
 	return !state.admin.isFetching;
 }
 
 /**
- * @param {State} state The redux state.
- * @returns {boolean} Whether preferences are submitted
+ * @param state The redux state.
+ * @returns Whether preferences are submitted
  */
 function shouldSubmitPreferenceData(state: State): boolean {
 	return !state.admin.submitted;
@@ -176,8 +176,8 @@ function toggleWaitForCikAndDB(): t.ToggleWaitForCikAndDB {
 }
 
 /**
- * @param {State} state The redux state.
- * @returns {boolean} Whether or not the Cik and views are updating
+ * @param state The redux state.
+ * @returns Whether or not the Cik and views are updating
  */
 function shouldUpdateCikAndDBViews(state: State): boolean {
 	return !state.admin.isUpdatingCikAndDBViews;
@@ -186,8 +186,8 @@ function shouldUpdateCikAndDBViews(state: State): boolean {
 /**
  * Redo Cik and/or refresh reading views.
  * This function is called when some changes in units/conversions affect the Cik table or reading views.
- * @param {boolean} shouldRedoCik Whether to refresh Cik.
- * @param {boolean} shouldRefreshReadingViews Whether to refresh reading views.
+ * @param shouldRedoCik Whether to refresh Cik.
+ * @param shouldRefreshReadingViews Whether to refresh reading views.
  */
 export function updateCikAndDBViewsIfNeeded(shouldRedoCik: boolean, shouldRefreshReadingViews: boolean): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -15,8 +15,6 @@ import { LanguageTypes } from '../types/redux/i18n';
 import * as moment from 'moment';
 import { AreaUnitType } from '../utils/getAreaUnitConversion';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export function updateSelectedMeter(meterID: number): t.UpdateImportMeterAction {
 	return { type: ActionType.UpdateImportMeter, meterID };
 }
@@ -79,7 +77,6 @@ function markPreferencesSubmitted(defaultMeterReadingFrequency: string): t.MarkP
 }
 
 /* eslint-enable */
-/* eslint-disable jsdoc/require-returns*/
 
 /**
  * Dispatches a fetch for admin preferences and sets the state based upon the result
@@ -150,8 +147,6 @@ function shouldFetchPreferenceData(state: State): boolean {
 function shouldSubmitPreferenceData(state: State): boolean {
 	return !state.admin.submitted;
 }
-
-/* eslint-disable jsdoc/require-jsdoc */
 
 export function fetchPreferencesIfNeeded(): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -76,8 +76,6 @@ function markPreferencesSubmitted(defaultMeterReadingFrequency: string): t.MarkP
 	return { type: ActionType.MarkPreferencesSubmitted, defaultMeterReadingFrequency };
 }
 
-/* eslint-enable */
-
 /**
  * Dispatches a fetch for admin preferences and sets the state based upon the result
  */

--- a/src/client/app/actions/barReadings.ts
+++ b/src/client/app/actions/barReadings.ts
@@ -11,12 +11,12 @@ import { readingsApi } from '../utils/api';
 import { BarReadings } from '../types/readings';
 
 /**
- * @param {State} state the Redux state
- * @param {number} meterID the ID of the meter to check
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} barDuration the duration of each bar for which to check
- * @param {number} unitID the ID of the unit for which to check
- * @returns {boolean} True if the readings for the given meter, time duration, bar length and unit are missing; false otherwise.
+ * @param state the Redux state
+ * @param meterID the ID of the meter to check
+ * @param timeInterval the interval over which to check
+ * @param barDuration the duration of each bar for which to check
+ * @param unitID the ID of the unit for which to check
+ * @returns True if the readings for the given meter, time duration, bar length and unit are missing; false otherwise.
  */
 export function shouldFetchMeterBarReadings(state: State, meterID: number, timeInterval: TimeInterval,
 	barDuration: moment.Duration, unitID: number): boolean {
@@ -47,12 +47,12 @@ export function shouldFetchMeterBarReadings(state: State, meterID: number, timeI
 }
 
 /**
- * @param {State} state the Redux state
- * @param {number} groupID the ID of the group to check
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} barDuration the duration of each bar for which to check
- * @param {number} unitID the ID of the unit for which to check
- * @returns {boolean} True if the readings for the given group, time duration, bar length and unit are missing; false otherwise.
+ * @param state the Redux state
+ * @param groupID the ID of the group to check
+ * @param timeInterval the interval over which to check
+ * @param barDuration the duration of each bar for which to check
+ * @param unitID the ID of the unit for which to check
+ * @returns True if the readings for the given group, time duration, bar length and unit are missing; false otherwise.
  */
 export function shouldFetchGroupBarReadings(state: State, groupID: number, timeInterval: TimeInterval,
 	barDuration: moment.Duration, unitID: number): boolean {
@@ -85,10 +85,10 @@ export function shouldFetchGroupBarReadings(state: State, groupID: number, timeI
 /* eslint-disable jsdoc/require-returns */
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} barDuration the duration of each bar for which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param meterIDs the IDs of the meters to get readings
+ * @param timeInterval the interval over which to check
+ * @param barDuration the duration of each bar for which to check
+ * @param unitID the ID of the unit for which to check
  */
 export function requestMeterBarReadings(meterIDs: number[], timeInterval: TimeInterval, barDuration: moment.Duration,
 	unitID: number): t.RequestMeterBarReadingsAction {
@@ -96,10 +96,10 @@ export function requestMeterBarReadings(meterIDs: number[], timeInterval: TimeIn
 }
 
 /**
- * @param {number} groupIDs the IDs of the groups to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} barDuration the duration of each bar for which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param groupIDs the IDs of the groups to get readings
+ * @param timeInterval the interval over which to check
+ * @param barDuration the duration of each bar for which to check
+ * @param unitID the ID of the unit for which to check
  */
 export function requestGroupBarReadings(groupIDs: number[], timeInterval: TimeInterval, barDuration: moment.Duration,
 	unitID: number): t.RequestGroupBarReadingsAction {
@@ -107,11 +107,11 @@ export function requestGroupBarReadings(groupIDs: number[], timeInterval: TimeIn
 }
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} barDuration the duration of each bar for which to check
- * @param {number} unitID the ID of the unit for which to check
- * @param {BarReadings} readings the readings for the given meters
+ * @param meterIDs the IDs of the meters to get readings
+ * @param timeInterval the interval over which to check
+ * @param barDuration the duration of each bar for which to check
+ * @param unitID the ID of the unit for which to check
+ * @param readings the readings for the given meters
  */
 export function receiveMeterBarReadings(meterIDs: number[], timeInterval: TimeInterval, barDuration: moment.Duration,
 	unitID: number, readings: BarReadings): t.ReceiveMeterBarReadingsAction {
@@ -119,11 +119,11 @@ export function receiveMeterBarReadings(meterIDs: number[], timeInterval: TimeIn
 }
 
 /**
- * @param {number} groupIDs the IDs of the groups to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} barDuration the duration of each bar for which to check
- * @param {number} unitID the ID of the unit for which to check
- * @param {BarReadings} readings the readings for the given groups
+ * @param groupIDs the IDs of the groups to get readings
+ * @param timeInterval the interval over which to check
+ * @param barDuration the duration of each bar for which to check
+ * @param unitID the ID of the unit for which to check
+ * @param readings the readings for the given groups
  */
 export function receiveGroupBarReadings(groupIDs: number[], timeInterval: TimeInterval, barDuration: moment.Duration,
 	unitID: number, readings: BarReadings): t.ReceiveGroupBarReadingsAction {
@@ -131,9 +131,9 @@ export function receiveGroupBarReadings(groupIDs: number[], timeInterval: TimeIn
 }
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param meterIDs the IDs of the meters to get readings
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 function fetchMeterBarReadings(meterIDs: number[], timeInterval: TimeInterval, unitID: number): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {
@@ -145,9 +145,9 @@ function fetchMeterBarReadings(meterIDs: number[], timeInterval: TimeInterval, u
 }
 
 /**
- * @param {number} groupIDs the IDs of the groups to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param groupIDs the IDs of the groups to get readings
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 function fetchGroupBarReadings(groupIDs: number[], timeInterval: TimeInterval, unitID: number): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {
@@ -160,8 +160,8 @@ function fetchGroupBarReadings(groupIDs: number[], timeInterval: TimeInterval, u
 
 /**
  * Fetches readings for the bar chart of all selected meters and groups, if needed.
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 export function fetchNeededBarReadings(timeInterval: TimeInterval, unitID: number): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/barReadings.ts
+++ b/src/client/app/actions/barReadings.ts
@@ -82,7 +82,6 @@ export function shouldFetchGroupBarReadings(state: State, groupID: number, timeI
 	return !readingsForUnit.isFetching;
 }
 
-/* eslint-disable jsdoc/require-returns */
 
 /**
  * @param meterIDs the IDs of the meters to get readings

--- a/src/client/app/actions/compareReadings.ts
+++ b/src/client/app/actions/compareReadings.ts
@@ -12,12 +12,12 @@ import { metersApi, groupsApi } from '../utils/api';
 import { ComparePeriod, calculateCompareShift } from '../utils/calculateCompare';
 
 /**
- * @param {State} state the Redux state
- * @param {number} meterID the ID of the meter to check
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {compareShift} compareShift The time shift between curr and prev
- * @param {number} unitID the ID of the unit for which to check
- * @returns {boolean} True if the readings for the given meter, time and unit are missing; false otherwise.
+ * @param state the Redux state
+ * @param meterID the ID of the meter to check
+ * @param timeInterval the interval over which to check
+ * @param compareShift The time shift between curr and prev
+ * @param unitID the ID of the unit for which to check
+ * @returns True if the readings for the given meter, time and unit are missing; false otherwise.
  */
 function shouldFetchMeterCompareReadings(state: State, meterID: number, timeInterval: TimeInterval,
 	compareShift: moment.Duration, unitID: number): boolean {
@@ -43,12 +43,12 @@ function shouldFetchMeterCompareReadings(state: State, meterID: number, timeInte
 }
 
 /**
- * @param {State} state the Redux state
- * @param {number} groupID the ID of the group to check
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {compareShift} compareShift The time shift between curr and prev
- * @param {number} unitID the ID of the unit for which to check
- * @returns {boolean} True if the readings for the given group, and time are missing; false otherwise.
+ * @param state the Redux state
+ * @param groupID the ID of the group to check
+ * @param timeInterval the interval over which to check
+ * @param compareShift The time shift between curr and prev
+ * @param unitID the ID of the unit for which to check
+ * @returns True if the readings for the given group, and time are missing; false otherwise.
  */
 function shouldFetchGroupCompareReadings(state: State, groupID: number, timeInterval: TimeInterval,
 	compareShift: moment.Duration, unitID: number): boolean {
@@ -76,10 +76,10 @@ function shouldFetchGroupCompareReadings(state: State, groupID: number, timeInte
 /* eslint-disable jsdoc/require-returns */
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} compareShift time to shift the timeInterval to get previous interval
- * @param {number} unitID the ID of the unit for which to check
+ * @param meterIDs the IDs of the meters to get readings
+ * @param timeInterval the interval over which to check
+ * @param compareShift time to shift the timeInterval to get previous interval
+ * @param unitID the ID of the unit for which to check
  */
 function requestMeterCompareReadings(meterIDs: number[], timeInterval: TimeInterval,
 	compareShift: moment.Duration, unitID: number):
@@ -88,10 +88,10 @@ function requestMeterCompareReadings(meterIDs: number[], timeInterval: TimeInter
 }
 
 /**
- * @param {number} groupIDs the IDs of the groups to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} compareShift time to shift the timeInterval to get previous interval
- * @param {number} unitID the ID of the unit for which to check
+ * @param groupIDs the IDs of the groups to get readings
+ * @param timeInterval the interval over which to check
+ * @param compareShift time to shift the timeInterval to get previous interval
+ * @param unitID the ID of the unit for which to check
  */
 function requestGroupCompareReadings(groupIDs: number[], timeInterval: TimeInterval,
 	compareShift: moment.Duration, unitID: number):
@@ -100,11 +100,11 @@ function requestGroupCompareReadings(groupIDs: number[], timeInterval: TimeInter
 }
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} compareShift time to shift the timeInterval to get previous interval
- * @param {number} unitID the ID of the unit for which to check
- * @param {CompareReadings} readings the readings for the given meters
+ * @param meterIDs the IDs of the meters to get readings
+ * @param timeInterval the interval over which to check
+ * @param compareShift time to shift the timeInterval to get previous interval
+ * @param unitID the ID of the unit for which to check
+ * @param readings the readings for the given meters
  */
 function receiveMeterCompareReadings(meterIDs: number[], timeInterval: TimeInterval, compareShift: moment.Duration,
 	unitID: number, readings: CompareReadings): t.ReceiveMeterCompareReadingsAction {
@@ -112,11 +112,11 @@ function receiveMeterCompareReadings(meterIDs: number[], timeInterval: TimeInter
 }
 
 /**
- * @param {number} groupIDs the IDs of the groups to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {moment.Duration} compareShift time to shift the timeInterval to get previous interval
- * @param {number} unitID the ID of the unit for which to check
- * @param {CompareReadings} readings the readings for the given meters
+ * @param groupIDs the IDs of the groups to get readings
+ * @param timeInterval the interval over which to check
+ * @param compareShift time to shift the timeInterval to get previous interval
+ * @param unitID the ID of the unit for which to check
+ * @param readings the readings for the given meters
  */
 function receiveGroupCompareReadings(groupIDs: number[], timeInterval: TimeInterval, compareShift: moment.Duration,
 	unitID: number, readings: CompareReadings): t.ReceiveGroupCompareReadingsAction {
@@ -124,9 +124,9 @@ function receiveGroupCompareReadings(groupIDs: number[], timeInterval: TimeInter
 }
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {ComparePeriod} comparePeriod the period over which to check
- * @param {number} unitID the ID of the unit to get readings in
+ * @param meterIDs the IDs of the meters to get readings
+ * @param comparePeriod the period over which to check
+ * @param unitID the ID of the unit to get readings in
  */
 function fetchMeterCompareReadings(meterIDs: number[], comparePeriod: ComparePeriod, unitID: number): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {
@@ -140,9 +140,9 @@ function fetchMeterCompareReadings(meterIDs: number[], comparePeriod: ComparePer
 
 /**
  * Fetch the data for the given groups over the given interval. Fully manages the Redux lifecycle.
- * @param {[number]} groupIDs The IDs of the groups whose data should be fetched
- * @param {ComparePeriod} comparePeriod enum to represent a kind of time shift between curr and prev
- * @param {number} unitID the ID of the unit for which to check
+ * @param groupIDs The IDs of the groups whose data should be fetched
+ * @param comparePeriod enum to represent a kind of time shift between curr and prev
+ * @param unitID the ID of the unit for which to check
  */
 function fetchGroupCompareReadings(groupIDs: number[], comparePeriod: ComparePeriod, unitID: number): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {
@@ -157,9 +157,9 @@ function fetchGroupCompareReadings(groupIDs: number[], comparePeriod: ComparePer
 
 /**
  * Fetches readings for the compare chart of all selected meterIDs if they are not already fetched or being fetched
- * @param {ComparePeriod} comparePeriod The period to fetch readings for on the compare chart
- * @param {number} unitID the ID of the unit for which to check
- * @returns {*} An action to fetch the needed readings
+ * @param comparePeriod The period to fetch readings for on the compare chart
+ * @param unitID the ID of the unit for which to check
+ * @returns An action to fetch the needed readings
  */
 export function fetchNeededCompareReadings(comparePeriod: ComparePeriod, unitID: number): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/compareReadings.ts
+++ b/src/client/app/actions/compareReadings.ts
@@ -73,8 +73,6 @@ function shouldFetchGroupCompareReadings(state: State, groupID: number, timeInte
 	return !readingsForUnit.isFetching;
 }
 
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * @param meterIDs the IDs of the meters to get readings
  * @param timeInterval the interval over which to check

--- a/src/client/app/actions/conversions.ts
+++ b/src/client/app/actions/conversions.ts
@@ -9,10 +9,6 @@ import * as t from '../types/redux/conversions';
 import { conversionsApi } from '../utils/api';
 import { updateCikAndDBViewsIfNeeded } from './admin';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-param */
-/* eslint-disable jsdoc/require-returns */
-
 export function requestConversionsDetails(): t.RequestConversionsDetailsAction {
 	return { type: ActionType.RequestConversionsDetails };
 }
@@ -45,6 +41,7 @@ export function changeDisplayedConversions(conversions: number[]): t.ChangeDispl
 
 /**
  * Pushes ConversionData onto submitting conversions state array
+ * @param conversionData data to push
  */
 export function submitConversionEdits(conversionData: t.ConversionData): t.SubmitEditedConversionAction {
 	return { type: ActionType.SubmitEditedConversion, conversionData};
@@ -56,6 +53,7 @@ export function confirmConversionEdits(editedConversion: t.ConversionData): t.Co
 
 /**
  * Removes ConversionData from submitting state array
+ * @param conversionData data to remove
  */
 export function deleteSubmittedConversion(conversionData: t.ConversionData): t.DeleteSubmittedConversionAction {
 	return {type: ActionType.DeleteSubmittedConversion, conversionData}
@@ -67,6 +65,7 @@ export function confirmConversionsFetchedOnce(): t.ConfirmConversionsFetchedOnce
 
 /**
  * Removes the passed ConversionData from the store
+ * @param conversionData data to remove
  */
 export function confirmDeletedConversion(conversionData: t.ConversionData): t.DeleteConversionAction {
 	return { type: ActionType.DeleteConversion, conversionData }

--- a/src/client/app/actions/currentUser.ts
+++ b/src/client/app/actions/currentUser.ts
@@ -21,8 +21,8 @@ export function receiveCurrentUser(data: User): t.ReceiveCurrentUser {
 
 /**
  * Check if we should fetch the current user's data. This function has the side effect of deleting an invalid token from local storage.
- * @param {State} state The redux state
- * @returns {boolean} Return true if we should fetch the current user's data. Returns false otherwise.
+ * @param state The redux state
+ * @returns Return true if we should fetch the current user's data. Returns false otherwise.
  */
 async function shouldFetchCurrentUser(state: State): Promise<boolean> {
 	// If we are currently fetching the current user, we should not fetch the data again.

--- a/src/client/app/actions/currentUser.ts
+++ b/src/client/app/actions/currentUser.ts
@@ -9,8 +9,6 @@ import * as t from '../types/redux/currentUser';
 import { User } from '../types/items';
 import { deleteToken, hasToken } from '../utils/token';
 
-/* eslint-disable jsdoc/require-jsdoc*/
-
 export function requestCurrentUser(): t.RequestCurrentUser {
 	return { type: ActionType.RequestCurrentUser };
 }

--- a/src/client/app/actions/graph.ts
+++ b/src/client/app/actions/graph.ts
@@ -19,9 +19,6 @@ import { changeSelectedMap, fetchMapsDetails } from './map';
 import { fetchUnitsDetailsIfNeeded } from './units';
 import { AreaUnitType } from '../utils/getAreaUnitConversion';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-returns */
-
 export function changeRenderOnce() {
 	return { type: ActionType.ConfirmGraphRenderOnce };
 }

--- a/src/client/app/actions/graph.ts
+++ b/src/client/app/actions/graph.ts
@@ -225,7 +225,7 @@ export interface LinkOptions {
 
 /**
  * Update graph options from a link
- * @param {LinkOptions} options - Object of possible values to dispatch with keys: meterIDs, groupIDs, chartType, barDuration, toggleBarStacking, ...
+ * @param options - Object of possible values to dispatch with keys: meterIDs, groupIDs, chartType, barDuration, toggleBarStacking, ...
  */
 export function changeOptionsFromLink(options: LinkOptions) {
 	const dispatchFirst: Thunk[] = [setHotlinkedAsync(true)];

--- a/src/client/app/actions/groups.ts
+++ b/src/client/app/actions/groups.ts
@@ -9,10 +9,6 @@ import * as t from '../types/redux/groups';
 import { groupsApi } from '../utils/api';
 import translate from '../utils/translate';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-returns */
-/* eslint-disable jsdoc/require-returns-description */
-
 function requestGroupsDetails(): t.RequestGroupsDetailsAction {
 	return { type: ActionType.RequestGroupsDetails };
 }

--- a/src/client/app/actions/groups.ts
+++ b/src/client/app/actions/groups.ts
@@ -166,9 +166,9 @@ export function confirmGroupEdits(editedGroup: t.GroupEditData): t.ConfirmEdited
 
 /**
  * Pushes group changes out to DB.
- * @param {t.GroupEditData} group The group to update
- * @param {boolean} reload If true, the window is reloaded to reset everything on change
- * @returns {*} Function to do this for an action
+ * @param group The group to update
+ * @param reload If true, the window is reloaded to reset everything on change
+ * @returns Function to do this for an action
  */
 export function submitGroupEdits(group: t.GroupEditData, reload: boolean = true): Thunk {
 	return async (dispatch: Dispatch) => {

--- a/src/client/app/actions/lineReadings.ts
+++ b/src/client/app/actions/lineReadings.ts
@@ -10,11 +10,11 @@ import { readingsApi } from '../utils/api';
 import { LineReadings } from '../types/readings';
 
 /**
- * @param {State} state the Redux state
- * @param {number} meterID the ID of the meter to check
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
- * @returns {boolean} True if the readings for the given meter, time duration and unit are missing; false otherwise.
+ * @param state the Redux state
+ * @param meterID the ID of the meter to check
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
+ * @returns True if the readings for the given meter, time duration and unit are missing; false otherwise.
  */
 function shouldFetchMeterLineReadings(state: State, meterID: number, timeInterval: TimeInterval, unitID: number): boolean {
 	const timeIntervalIndex = timeInterval.toString();
@@ -38,11 +38,11 @@ function shouldFetchMeterLineReadings(state: State, meterID: number, timeInterva
 }
 
 /**
- * @param {State} state the Redux state
- * @param {number} groupID the ID of the group to check
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
- * @returns {boolean} True if the readings for the given group, time duration and unit are missing; false otherwise.
+ * @param state the Redux state
+ * @param groupID the ID of the group to check
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
+ * @returns True if the readings for the given group, time duration and unit are missing; false otherwise.
  */
 function shouldFetchGroupLineReadings(state: State, groupID: number, timeInterval: TimeInterval, unitID: number): boolean {
 	const timeIntervalIndex = timeInterval.toString();
@@ -68,28 +68,28 @@ function shouldFetchGroupLineReadings(state: State, groupID: number, timeInterva
 /* eslint-disable jsdoc/require-returns */
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param meterIDs the IDs of the meters to get readings
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 function requestMeterLineReadings(meterIDs: number[], timeInterval: TimeInterval, unitID: number): t.RequestMeterLineReadingsAction {
 	return { type: ActionType.RequestMeterLineReadings, meterIDs, timeInterval, unitID };
 }
 
 /**
- * @param {number} groupIDs the IDs of the groups to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param groupIDs the IDs of the groups to get readings
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 function requestGroupLineReadings(groupIDs: number[], timeInterval: TimeInterval, unitID: number): t.RequestGroupLineReadingsAction {
 	return { type: ActionType.RequestGroupLineReadings, groupIDs, timeInterval, unitID };
 }
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
- * @param {LineReadings} readings the readings for the given meters
+ * @param meterIDs the IDs of the meters to get readings
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
+ * @param readings the readings for the given meters
  */
 function receiveMeterLineReadings(
 	meterIDs: number[], timeInterval: TimeInterval, unitID: number, readings: LineReadings): t.ReceiveMeterLineReadingsAction {
@@ -97,10 +97,10 @@ function receiveMeterLineReadings(
 }
 
 /**
- * @param {number} groupIDs the IDs of the groups to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
- * @param {LineReadings} readings the readings for the given groups
+ * @param groupIDs the IDs of the groups to get readings
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
+ * @param readings the readings for the given groups
  */
 function receiveGroupLineReadings(
 	groupIDs: number[], timeInterval: TimeInterval, unitID: number, readings: LineReadings): t.ReceiveGroupLineReadingsAction {
@@ -108,9 +108,9 @@ function receiveGroupLineReadings(
 }
 
 /**
- * @param {number} meterIDs the IDs of the meters to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param meterIDs the IDs of the meters to get readings
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 function fetchMeterLineReadings(meterIDs: number[], timeInterval: TimeInterval, unitID: number): Thunk {
 	return async (dispatch: Dispatch) => {
@@ -121,9 +121,9 @@ function fetchMeterLineReadings(meterIDs: number[], timeInterval: TimeInterval, 
 }
 
 /**
- * @param {number} groupIDs the IDs of the groups to get readings
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param groupIDs the IDs of the groups to get readings
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 function fetchGroupLineReadings(groupIDs: number[], timeInterval: TimeInterval, unitID: number): Thunk {
 	return async (dispatch: Dispatch) => {
@@ -135,8 +135,8 @@ function fetchGroupLineReadings(groupIDs: number[], timeInterval: TimeInterval, 
 
 /**
  * Fetches readings for the line chart of all selected meters and groups, if needed.
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 export function fetchNeededLineReadings(timeInterval: TimeInterval, unitID: number): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/lineReadings.ts
+++ b/src/client/app/actions/lineReadings.ts
@@ -65,8 +65,6 @@ function shouldFetchGroupLineReadings(state: State, groupID: number, timeInterva
 	return !readingsForUnit.isFetching;
 }
 
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * @param meterIDs the IDs of the meters to get readings
  * @param timeInterval the interval over which to check

--- a/src/client/app/actions/logs.ts
+++ b/src/client/app/actions/logs.ts
@@ -6,11 +6,11 @@ import { logsApi } from '../utils/api';
 
 /**
  * pass client-side information to server console using logsApi on server-side, mainly for debugging purposes
- * @param {string} level type of message being logged
- * @param {string} message message to log
- * @param {Error?} error An optional error object to provide a stacktrace
- * @param {boolean?} skipMail Don't e-mail this message even if we would normally emit an e-mail for this level.
- * @returns {undefined} logs to server based on level
+ * @param level type of message being logged
+ * @param message message to log
+ * @param error An optional error object to provide a stacktrace
+ * @param skipMail Don't e-mail this message even if we would normally emit an e-mail for this level.
+ * @returns logs to server based on level
  */
 export function logToServer(level: string, message: string, error?: Error, skipMail?: boolean) {
 	const log: LogData = {

--- a/src/client/app/actions/map.ts
+++ b/src/client/app/actions/map.ts
@@ -21,9 +21,6 @@ import * as moment from 'moment';
 import {browserHistory} from '../utils/history';
 import {logToServer} from './logs';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-returns */
-
 function requestMapsDetails(): t.RequestMapsDetailsAction {
 	return { type: ActionType.RequestMapsDetails };
 }

--- a/src/client/app/actions/map.ts
+++ b/src/client/app/actions/map.ts
@@ -69,8 +69,8 @@ export function setNewMap(): Thunk {
 
 /**
  * start a new calibration session
- * @param {CalibrationModeTypes} mode calibration modes
- * @param {number} mapID id of map being calibrated
+ * @param mode calibration modes
+ * @param mapID id of map being calibrated
  */
 export function setCalibration(mode: CalibrationModeTypes, mapID: number): Thunk {
 	return async (dispatch: Dispatch) => {
@@ -119,7 +119,7 @@ export function updateMapMode(nextMode: CalibrationModeTypes): t.ChangeMapModeAc
 
 /**
  * Changes the selected map ID
- * @param {number} newSelectedMapID new map ID
+ * @param newSelectedMapID new map ID
  */
 export function changeSelectedMap(newSelectedMapID: number): t.UpdateSelectedMapAction {
 	return { type: ActionType.UpdateSelectedMap, mapID: newSelectedMapID };
@@ -132,7 +132,7 @@ export function updateCurrentCartesian(currentCartesian: CartesianPoint): t.Upda
 /**
  * pair collected GPS coordinate with cartesian coordinate to form a complete data point,
  * append to calibration set and trigger calibration if needed
- * @param {GPSPoint} currentGPS GPS data, from user input
+ * @param currentGPS GPS data, from user input
  */
 export function offerCurrentGPS(currentGPS: GPSPoint): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {
@@ -171,8 +171,8 @@ function updateCalibrationSet(calibratedPoint: CalibratedPoint): t.AppendCalibra
 
 /**
  * use a default number as the threshold in determining if it's safe to call the calibration function
- * @param {State} state The redux state
- * @returns {boolean} Result of safety check
+ * @param state The redux state
+ * @returns Result of safety check
  */
 function isReadyForCalculation(state: State): boolean {
 	const calibrationThreshold = 3;
@@ -184,8 +184,8 @@ function isReadyForCalculation(state: State): boolean {
 
 /**
  *  prepare data to required formats to pass it to function calculating mapScales
- * @param {State} state The redux state
- * @returns {CalibrationResult} Result of map calibration
+ * @param state The redux state
+ * @returns Result of map calibration
  */
 function prepareDataToCalculation(state: State): CalibrationResult {
 	const mapID = state.maps.calibratingMap;
@@ -266,7 +266,7 @@ export function submitNewMap(): Thunk {
 
 /**
  * submit changes of an existing map to database at the end of a calibration session
- * @param {number} mapID the edited map being updated at database
+ * @param mapID the edited map being updated at database
  */
 export function submitEditedMap(mapID: number): Thunk {
 	return async (dispatch: Dispatch, getState: GetState) => {
@@ -307,7 +307,7 @@ export function submitEditedMap(mapID: number): Thunk {
 
 /**
  * permanently remove a map
- * @param {number} mapID map to be removed
+ * @param mapID map to be removed
  */
 export function removeMap(mapID: number): Thunk {
 	return async (dispatch: Dispatch) => {

--- a/src/client/app/actions/mapReadings.ts
+++ b/src/client/app/actions/mapReadings.ts
@@ -20,10 +20,10 @@ import {readingsApi} from '../utils/api';
 /**
  * Fetch the data for the given meters over the given interval. Fully manages the Redux lifecycle.
  * Reads bar duration from the state.
- * @param {[number]} meterIDs The IDs of the meters whose data should be fetched
- * @param {TimeInterval} timeInterval The time interval over which data should be fetched
- * @param {moment.Duration} duration The length of time covered in this timeInterval
- * @param {number} unitID the ID of the unit for which to check
+ * @param meterIDs The IDs of the meters whose data should be fetched
+ * @param timeInterval The time interval over which data should be fetched
+ * @param duration The length of time covered in this timeInterval
+ * @param unitID the ID of the unit for which to check
  */
 function fetchMeterMapReadings(meterIDs: number[], timeInterval: TimeInterval, duration: moment.Duration, unitID: number): Thunk {
 	return async (dispatch: Dispatch) => {
@@ -36,10 +36,10 @@ function fetchMeterMapReadings(meterIDs: number[], timeInterval: TimeInterval, d
 /**
  * Fetch the data for the given groups over the given interval. Fully manages the Redux lifecycle.
  * Reads bar duration from the state.
- * @param {[number]} groupIDs The IDs of the groups whose data should be fetched
- * @param {TimeInterval} timeInterval The time interval over which data should be fetched
- * @param {moment.Duration} duration The length of time covered in this timeInterval
- * @param {number} unitID the ID of the unit for which to check
+ * @param groupIDs The IDs of the groups whose data should be fetched
+ * @param timeInterval The time interval over which data should be fetched
+ * @param duration The length of time covered in this timeInterval
+ * @param unitID the ID of the unit for which to check
  */
 function fetchGroupMapReadings(groupIDs: number[], timeInterval: TimeInterval, duration: moment.Duration, unitID: number): Thunk {
 	return async (dispatch: Dispatch) => {
@@ -51,8 +51,8 @@ function fetchGroupMapReadings(groupIDs: number[], timeInterval: TimeInterval, d
 
 /**
  * Fetches readings for the map chart of all selected meters and groups, if needed.
- * @param {TimeInterval} timeInterval the interval over which to check
- * @param {number} unitID the ID of the unit for which to check
+ * @param timeInterval the interval over which to check
+ * @param unitID the ID of the unit for which to check
  */
 export function fetchNeededMapReadings(timeInterval: TimeInterval, unitID: number): Thunk {
 	return (dispatch: Dispatch, getState: GetState) => {

--- a/src/client/app/actions/mapReadings.ts
+++ b/src/client/app/actions/mapReadings.ts
@@ -15,8 +15,6 @@ import {
 } from './barReadings';
 import {readingsApi} from '../utils/api';
 
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * Fetch the data for the given meters over the given interval. Fully manages the Redux lifecycle.
  * Reads bar duration from the state.

--- a/src/client/app/actions/meters.ts
+++ b/src/client/app/actions/meters.ts
@@ -9,8 +9,6 @@ import * as t from '../types/redux/meters';
 import { metersApi } from '../utils/api';
 import { updateCikAndDBViewsIfNeeded } from './admin';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export function requestMetersDetails(): t.RequestMetersDetailsAction {
 	return { type: ActionType.RequestMetersDetails };
 }

--- a/src/client/app/actions/notifications.ts
+++ b/src/client/app/actions/notifications.ts
@@ -6,7 +6,6 @@ import { ActionType } from '../types/redux/actions';
 import * as t from '../types/redux/notifications';
 import { Notification } from 'react-notification-system';
 
-/* eslint-disable jsdoc/require-returns */
 /**
  * Shows notification to the user
  * @param notification Notification to display

--- a/src/client/app/actions/notifications.ts
+++ b/src/client/app/actions/notifications.ts
@@ -9,7 +9,7 @@ import { Notification } from 'react-notification-system';
 /* eslint-disable jsdoc/require-returns */
 /**
  * Shows notification to the user
- * @param {Notification} notification Notification to display
+ * @param notification Notification to display
  */
 export function showNotification(notification: Notification): t.ShowNotificationAction {
 	return { type: ActionType.ShowNotification, notification };

--- a/src/client/app/actions/units.ts
+++ b/src/client/app/actions/units.ts
@@ -9,8 +9,6 @@ import * as t from '../types/redux/units';
 import { unitsApi } from '../utils/api';
 import { updateCikAndDBViewsIfNeeded } from './admin';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export function requestUnitsDetails(): t.RequestUnitsDetailsAction {
 	return { type: ActionType.RequestUnitsDetails };
 }

--- a/src/client/app/actions/unsavedWarning.ts
+++ b/src/client/app/actions/unsavedWarning.ts
@@ -5,8 +5,6 @@
 import { ActionType } from '../types/redux/actions';
 import * as t from '../types/redux/unsavedWarning';
 
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * Notify that there are unsaved changes
  * @param removeFunction The function to remove local changes

--- a/src/client/app/actions/unsavedWarning.ts
+++ b/src/client/app/actions/unsavedWarning.ts
@@ -9,8 +9,8 @@ import * as t from '../types/redux/unsavedWarning';
 
 /**
  * Notify that there are unsaved changes
- * @param {*} removeFunction The function to remove local changes
- * @param {*} submitFunction The function to submit unsaved changes
+ * @param removeFunction The function to remove local changes
+ * @param submitFunction The function to submit unsaved changes
  */
 export function updateUnsavedChanges(removeFunction: any, submitFunction: any): t.UpdateUnsavedChangesAction {
 	return { type: ActionType.UpdateUnsavedChanges, removeFunction, submitFunction };

--- a/src/client/app/actions/version.ts
+++ b/src/client/app/actions/version.ts
@@ -7,7 +7,6 @@ import { Thunk, ActionType, Dispatch, GetState } from '../types/redux/actions';
 import { State } from '../types/redux/state';
 import * as t from '../types/redux/version';
 
-/* eslint-disable jsdoc/require-returns */
 /**
  * Request version action
  */

--- a/src/client/app/actions/version.ts
+++ b/src/client/app/actions/version.ts
@@ -17,15 +17,15 @@ export function requestVersion(): t.RequestVersion {
 
 /**
  * Receive version action
- * @param {string} data Received version
+ * @param data Received version
  */
 export function receiveVersion(data: string): t.ReceiveVersion {
 	return { type: ActionType.ReceiveVersion, data };
 }
 
 /**
- * @param {State} state The redux state.
- * @returns {boolean} Whether preferences are fetching
+ * @param state The redux state.
+ * @returns Whether preferences are fetching
  */
 function shouldFetchVersion(state: State): boolean {
 	return !state.version.isFetching;

--- a/src/client/app/components/AreaUnitSelectComponent.tsx
+++ b/src/client/app/components/AreaUnitSelectComponent.tsx
@@ -16,7 +16,7 @@ import TooltipMarkerComponent from './TooltipMarkerComponent';
 
 /**
  * React Component that creates the area unit selector dropdown
- * @returns {Element} JSX Element
+ * @returns JSX Element
  */
 export default function AreaUnitSelectComponent() {
 	const dispatch = useDispatch();

--- a/src/client/app/components/AreaUnitSelectComponent.tsx
+++ b/src/client/app/components/AreaUnitSelectComponent.tsx
@@ -16,7 +16,7 @@ import TooltipMarkerComponent from './TooltipMarkerComponent';
 
 /**
  * React Component that creates the area unit selector dropdown
- * @returns JSX Element
+ * @returns Area unit select element
  */
 export default function AreaUnitSelectComponent() {
 	const dispatch = useDispatch();

--- a/src/client/app/components/ChartDataSelectComponent.tsx
+++ b/src/client/app/components/ChartDataSelectComponent.tsx
@@ -30,7 +30,7 @@ import { AreaUnitType } from '../utils/getAreaUnitConversion';
 
 /**
  * A component which allows the user to select which data should be displayed on the chart.
- * @returns {Element} Chart Data Select JSX element
+ * @returns Chart Data Select JSX element
  */
 export default function ChartDataSelectComponent() {
 	const divBottomPadding: React.CSSProperties = {
@@ -383,8 +383,8 @@ export default function ChartDataSelectComponent() {
 
 /**
  * Determines the compatibility of units in the redux state for display in dropdown
- * @param {State} state - current redux state
- * @returns {SelectOption[]} an array of SelectOption
+ * @param state - current redux state
+ * @returns a list of compatible units
  */
 function getUnitCompatibilityForDropdown(state: State) {
 
@@ -446,8 +446,8 @@ function getUnitCompatibilityForDropdown(state: State) {
 
 /**
  * Determines the compatibility of meters in the redux state for display in dropdown
- * @param {State} state - current redux state
- * @returns {SelectOption[]} an array of SelectOption
+ * @param state - current redux state
+ * @returns a list of compatible meters
  */
 export function getMeterCompatibilityForDropdown(state: State) {
 	// Holds all meters visible to the user
@@ -521,8 +521,8 @@ export function getMeterCompatibilityForDropdown(state: State) {
 
 /**
  * Determines the compatibility of group in the redux state for display in dropdown
- * @param {State} state - current redux state
- * @returns {SelectOption[]} an array of SelectOption
+ * @param state - current redux state
+ * @returns a list of compatible groups
  */
 export function getGroupCompatibilityForDropdown(state: State) {
 	// Holds all groups visible to the user
@@ -597,8 +597,8 @@ export function getGroupCompatibilityForDropdown(state: State) {
 
 /**
  * Filters all units that are of type meter or displayable type none from the redux state, as well as admin only units if the user is not an admin.
- * @param {State} state - current redux state
- * @returns {UnitData[]} an array of UnitData
+ * @param state - current redux state
+ * @returns an array of UnitData
  */
 export function getVisibleUnitOrSuffixState(state: State) {
 	let visibleUnitsOrSuffixes;
@@ -620,10 +620,10 @@ export function getVisibleUnitOrSuffixState(state: State) {
 /**
  *  Returns a set of SelectOptions based on the type of state passed in and sets the visibility.
  * Visibility is determined by which set the items are contained in.
- * @param {Set<number>} compatibleItems - items that are compatible with current selected options
- * @param {Set<number>} incompatibleItems - units that are not compatible with current selected options
- * @param {UnitsState | MetersState | GroupsState} state - current redux state, must be one of UnitsState, MetersState, or GroupsState
- * @returns {SelectOption[]} an array of SelectOption
+ * @param compatibleItems - items that are compatible with current selected options
+ * @param incompatibleItems - units that are not compatible with current selected options
+ * @param state - current redux state, must be one of UnitsState, MetersState, or GroupsState
+ * @returns list of selectOptions of the given item
  */
 export function getSelectOptionsByItem(compatibleItems: Set<number>, incompatibleItems: Set<number>, state: UnitsState | MetersState | GroupsState) {
 	// Holds the label of the select item, set dynamically according to the type of item passed in
@@ -687,19 +687,19 @@ export function getSelectOptionsByItem(compatibleItems: Set<number>, incompatibl
 
 /**
  * Helper function to determine what type of state was passed in
- * @param {*} state The state to check
- * @returns {boolean} Whether or not this is a UnitsState
+ * @param state The state to check
+ * @returns Whether or not this is a UnitsState
  */
 function instanceOfUnitsState(state: any): state is UnitsState { return 'units' in state; }
 /**
  * Helper function to determine what type of state was passed in
- * @param {*} state The state to check
- * @returns {boolean} Whether or not this is a MetersState
+ * @param state The state to check
+ * @returns Whether or not this is a MetersState
  */
 function instanceOfMetersState(state: any): state is MetersState { return 'byMeterID' in state; }
 /**
  * Helper function to determine what type of state was passed in
- * @param {*} state The state to check
- * @returns {boolean} Whether or not this is a GroupsState
+ * @param state The state to check
+ * @returns Whether or not this is a GroupsState
  */
 function instanceOfGroupsState(state: any): state is GroupsState { return 'byGroupID' in state; }

--- a/src/client/app/components/ChartDataSelectComponent.tsx
+++ b/src/client/app/components/ChartDataSelectComponent.tsx
@@ -30,7 +30,7 @@ import { AreaUnitType } from '../utils/getAreaUnitConversion';
 
 /**
  * A component which allows the user to select which data should be displayed on the chart.
- * @returns Chart Data Select JSX element
+ * @returns Chart data select element
  */
 export default function ChartDataSelectComponent() {
 	const divBottomPadding: React.CSSProperties = {

--- a/src/client/app/components/ChartSelectComponent.tsx
+++ b/src/client/app/components/ChartSelectComponent.tsx
@@ -18,7 +18,7 @@ import { SelectOption } from '../types/items';
 
 /**
  *  A component that allows users to select which chart should be displayed.
- * @returns {Element} Chart select element
+ * @returns Chart select element
  */
 export default function ChartSelectComponent() {
 	const divBottomPadding: React.CSSProperties = {

--- a/src/client/app/components/ConfirmActionModalComponent.tsx
+++ b/src/client/app/components/ConfirmActionModalComponent.tsx
@@ -6,10 +6,6 @@ import { Modal, Button } from 'react-bootstrap';
 import '../styles/modal.css';
 import translate from '../utils/translate';
 
-// TODO consider commenting this better, as according to proper standards
-/* eslint-disable jsdoc/require-param-type */
-/* eslint-disable jsdoc/require-returns-type */
-
 interface ConfirmActionModalComponentProps {
 	// Control this through the parent component to open/close this modal
 	show: boolean;

--- a/src/client/app/components/DashboardComponent.tsx
+++ b/src/client/app/components/DashboardComponent.tsx
@@ -123,7 +123,7 @@ export default class DashboardComponent extends React.Component<DashboardProps> 
 
 /**
  * Determines the line graph's slider interval based after the slider is moved
- * @returns {string} The slider interval, either 'all' or a TimeInterval
+ * @returns The slider interval, either 'all' or a TimeInterval
  */
 export function getRangeSliderInterval(): string {
 	const sliderContainer: any = document.querySelector('.rangeslider-bg');

--- a/src/client/app/components/ExportComponent.tsx
+++ b/src/client/app/components/ExportComponent.tsx
@@ -22,7 +22,7 @@ import { AreaUnitType, getAreaUnitConversion } from '../utils/getAreaUnitConvers
 
 /**
  * Creates export buttons and does code for handling export to CSV files.
- * @returns {Element} HTML for export buttons
+ * @returns HTML for export buttons
  */
 export default function ExportComponent() {
 	// Meters state

--- a/src/client/app/components/FormFileUploaderComponent.tsx
+++ b/src/client/app/components/FormFileUploaderComponent.tsx
@@ -16,7 +16,7 @@ interface FileUploader {
 /**
  * Defines component used to upload files
  * @param props defined above
- * @returns File Uploader JSX element
+ * @returns File uploader element
  */
 export default function FileUploaderComponent(props: FileUploader) {
 	return (

--- a/src/client/app/components/FormFileUploaderComponent.tsx
+++ b/src/client/app/components/FormFileUploaderComponent.tsx
@@ -15,8 +15,8 @@ interface FileUploader {
 
 /**
  * Defines component used to upload files
- * @param {FileUploader} props defined above
- * @returns {Element} File Uploader JSX element
+ * @param props defined above
+ * @returns File Uploader JSX element
  */
 export default function FileUploaderComponent(props: FileUploader) {
 	return (

--- a/src/client/app/components/GraphicRateMenuComponent.tsx
+++ b/src/client/app/components/GraphicRateMenuComponent.tsx
@@ -14,7 +14,7 @@ import { LineGraphRate, LineGraphRates } from '../types/redux/graph';
 
 /**
  * React component that controls the line graph rate menu
- * @returns {Element} Rate selection element
+ * @returns Rate selection element
  */
 export default function GraphicRateMenuComponent() {
 	const dispatch = useDispatch();

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -22,10 +22,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 /**
  * React Component that defines the header buttons at the top of a page
- * @param {*} args arguments for modal displays
- * @param {boolean} args.showCollapsedMenuButton if the menu is collapsed
- * @param {boolean} args.isModal if the current page is a modal
- * @returns {Element} JSX Element
+ * @param args arguments for modal displays
+ * @param args.showCollapsedMenuButton if the menu is collapsed
+ * @param args.isModal if the current page is a modal
+ * @returns JSX Element
  */
 export default function HeaderButtonsComponent(args: { showCollapsedMenuButton: boolean, isModal: boolean }) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -25,7 +25,7 @@ import { useDispatch, useSelector } from 'react-redux';
  * @param args arguments for modal displays
  * @param args.showCollapsedMenuButton if the menu is collapsed
  * @param args.isModal if the current page is a modal
- * @returns JSX Element
+ * @returns Header buttons element
  */
 export default function HeaderButtonsComponent(args: { showCollapsedMenuButton: boolean, isModal: boolean }) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/HomeComponent.tsx
+++ b/src/client/app/components/HomeComponent.tsx
@@ -10,7 +10,7 @@ import TooltipHelpContainer from '../containers/TooltipHelpContainer';
 
 /**
  * Top-level React component that controls the home page
- * @returns {Element} JSX to create the home page
+ * @returns JSX to create the home page
  */
 export default function HomeComponent() {
 	return (

--- a/src/client/app/components/InitializationComponent.tsx
+++ b/src/client/app/components/InitializationComponent.tsx
@@ -20,7 +20,7 @@ import { fetchConversionsDetailsIfNeeded } from '../actions/conversions';
 
 /**
  * Initializes OED redux with needed details
- * @returns {Element} Initialization JSX element
+ * @returns Initialization JSX element
  */
 export default function InitializationComponent() {
 

--- a/src/client/app/components/ListDisplayComponent.tsx
+++ b/src/client/app/components/ListDisplayComponent.tsx
@@ -11,8 +11,8 @@ interface ListDisplayProps {
 
 /**
  * Defines a list wrapper used in OED
- * @param {ListDisplayProps} props defined above
- * @returns {Element} List Display JSX Element
+ * @param props defined above
+ * @returns List Display JSX Element
  */
 export default function ListDisplayComponent(props: ListDisplayProps) {
 	const defaultHeightItems = 8;

--- a/src/client/app/components/LoginComponent.tsx
+++ b/src/client/app/components/LoginComponent.tsx
@@ -90,8 +90,6 @@ class LoginComponent extends React.Component<LoginPropsWithIntl, LoginState> {
 		);
 	}
 
-	/* eslint-disable jsdoc/require-param-type */
-
 	/**
 	 * Sets the email state whenever the user changes the email input field
 	 * @param e The event fired

--- a/src/client/app/components/LoginComponent.tsx
+++ b/src/client/app/components/LoginComponent.tsx
@@ -37,7 +37,7 @@ class LoginComponent extends React.Component<LoginPropsWithIntl, LoginState> {
 	}
 
 	/**
-	 * @returns {Element} JSX to create the login panel
+	 * @returns JSX to create the login panel
 	 */
 	public render() {
 		const formStyle = {

--- a/src/client/app/components/LogoComponent.tsx
+++ b/src/client/app/components/LogoComponent.tsx
@@ -12,8 +12,8 @@ interface LogoProps {
 
 /**
  * React component that creates an logo image from a file path
- * @param {LogoProps} props defined above
- * @returns {HTMLImageElement} Logo Image element
+ * @param props defined above
+ * @returns Logo Image element
  */
 function LogoComponent(props: LogoProps) {
 	const imgStyle: React.CSSProperties = {

--- a/src/client/app/components/MapChartSelectComponent.tsx
+++ b/src/client/app/components/MapChartSelectComponent.tsx
@@ -13,7 +13,7 @@ import TooltipMarkerComponent from './TooltipMarkerComponent';
 
 /**
  * Component used to select the desired map
- * @returns {Element} Map Chart element
+ * @returns Map Chart element
  */
 export default function MapChartSelectComponent() {
 	const divBottomPadding: React.CSSProperties = {

--- a/src/client/app/components/MultiCompareChartComponent.tsx
+++ b/src/client/app/components/MultiCompareChartComponent.tsx
@@ -15,8 +15,8 @@ interface MultiCompareChartProps {
 
 /**
  * Component that defines compare chart
- * @param {MultiCompareChartProps} props defined above
- * @returns {Element} Multi Compare Chart element
+ * @param props defined above
+ * @returns Multi Compare Chart element
  */
 export default function MultiCompareChartComponent(props: MultiCompareChartProps) {
 	// Compute how much space should be used in the bootstrap grid system

--- a/src/client/app/components/RouteComponent.tsx
+++ b/src/client/app/components/RouteComponent.tsx
@@ -64,9 +64,9 @@ export default class RouteComponent extends React.Component<RouteProps> {
 
 	/**
 	 * Generates middleware that requires proper role and authentication for a page route
-	 * @param {UserRole} requiredRole The role that is necessary to access a page route
-	 * @param {Element} component The component of the page redirecting
-	 * @returns {Element} The page route to continue to (component or home)
+	 * @param requiredRole The role that is necessary to access a page route
+	 * @param component The component of the page redirecting
+	 * @returns The page route to continue to (component or home)
 	 */
 	public requireRole(requiredRole: UserRole, component: JSX.Element) {
 		// Redirect route to login page if the auth token does not exist or if the user is not the required role
@@ -94,8 +94,8 @@ export default class RouteComponent extends React.Component<RouteProps> {
 
 	/**
 	 * Middleware function that requires proper authentication for a page route
-	 * @param {Element} component The component of the page redirecting
-	 * @returns {Element} The page route to continue to (component or home)
+	 * @param component The component of the page redirecting
+	 * @returns The page route to continue to (component or home)
 	 */
 	public requireAuth(component: JSX.Element) {
 		// Redirect route to home page if the auth token does not exist or if the user is not an admin
@@ -122,8 +122,8 @@ export default class RouteComponent extends React.Component<RouteProps> {
 
 	/**
 	 * Middleware function that checks proper authentication for a page route
-	 * @param {Element} component The component of the page redirecting
-	 * @returns {Element} component
+	 * @param component The component of the page redirecting
+	 * @returns component
 	 */
 	public checkAuth(component: JSX.Element) {
 		// Only check the token if the auth token exists
@@ -147,9 +147,9 @@ export default class RouteComponent extends React.Component<RouteProps> {
 
 	/**
 	 * Middleware function that allows hotlinking to a graph with options
-	 * @param {Element} component The component of the page redirecting
-	 * @param {string} search The string of queries in the path
-	 * @returns {Element} component
+	 * @param component The component of the page redirecting
+	 * @param search The string of queries in the path
+	 * @returns component
 	 */
 	public linkToGraph(component: JSX.Element, search: string) {
 		/*
@@ -263,7 +263,7 @@ export default class RouteComponent extends React.Component<RouteProps> {
 	/**
 	 * React component that controls the app's routes
 	 * Note that '/admin', '/editGroup', and '/createGroup' requires authentication
-	 * @returns {Element} JSX to create the RouteComponent
+	 * @returns JSX to create the RouteComponent
 	 */
 	public render() {
 		const lang = this.props.defaultLanguage;

--- a/src/client/app/components/SpinnerComponent.tsx
+++ b/src/client/app/components/SpinnerComponent.tsx
@@ -14,8 +14,8 @@ interface SpinnerProps {
 
 /**
  * Spinner/loading React component
- * @param {SpinnerProps} props defined above
- * @returns {Element} Spinner element
+ * @param props defined above
+ * @returns Spinner element
  */
 function SpinnerComponent(props: SpinnerProps) {
 	const spinnerStyle = {

--- a/src/client/app/components/TooltipHelpComponent.tsx
+++ b/src/client/app/components/TooltipHelpComponent.tsx
@@ -20,7 +20,7 @@ export default class TooltipHelpComponent extends React.Component<TooltipHelpPro
 	}
 
 	/**
-	 * @returns {Element} JSX to create the help icons with links
+	 * @returns JSX to create the help icons with links
 	 */
 	public render() {
 		const divStyle = {

--- a/src/client/app/components/TooltipMarkerComponent.tsx
+++ b/src/client/app/components/TooltipMarkerComponent.tsx
@@ -11,8 +11,8 @@ interface TooltipMarker {
 
 /**
  * Component that renders a help icon that shows a tooltip on hover
- * @param {TooltipMarker} props defined above
- * @returns {Element} Tooltip Marker element
+ * @param props defined above
+ * @returns Tooltip Marker element
  */
 export default function TooltipMarkerComponent(props: TooltipMarker) {
 	return (

--- a/src/client/app/components/TooltipTextComponent.tsx
+++ b/src/client/app/components/TooltipTextComponent.tsx
@@ -12,8 +12,8 @@ interface TooltipTextProps {
 
 /**
  * Component that renders text that shows a tooltip on hover
- * @param {TooltipTextProps} props defined above
- * @returns {Element} Tooltip text element
+ * @param props defined above
+ * @returns Tooltip text element
  */
 export default function TooltipTextComponent(props: TooltipTextProps) {
 	const divStyle = {

--- a/src/client/app/components/UIOptionsComponent.tsx
+++ b/src/client/app/components/UIOptionsComponent.tsx
@@ -291,7 +291,7 @@ class UIOptionsComponent extends React.Component<UIOptionsPropsWithIntl, UIOptio
 
 	/**
 	 * Stores temporary barDuration until slider is released, used to update the UI of the slider
-	 * @param {number} value Bar duration to be stored
+	 * @param value Bar duration to be stored
 	 */
 	private handleBarDurationChange(value: number) {
 		this.setState({ barDurationDays: value });

--- a/src/client/app/components/admin/AdminComponent.tsx
+++ b/src/client/app/components/admin/AdminComponent.tsx
@@ -12,8 +12,10 @@ import { FormattedMessage } from 'react-intl';
 import TooltipHelpContainer from '../../containers/TooltipHelpContainer';
 import UnsavedWarningContainer from '../../containers/UnsavedWarningContainer';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
+/**
+ * React component that defines the admin page
+ * @returns Admin page element
+ */
 export default function AdminComponent() {
 
 	const bottomPaddingStyle: React.CSSProperties = {

--- a/src/client/app/components/admin/CreateUserComponent.tsx
+++ b/src/client/app/components/admin/CreateUserComponent.tsx
@@ -23,8 +23,8 @@ interface CreateUserFormProps {
 
 /**
  * Component that defines the form to create a new user
- * @param {CreateUserFormProps} props defined above
- * @returns {Element} Create User element
+ * @param props defined above
+ * @returns Create User element
  */
 export default function CreateUserFormComponent(props: CreateUserFormProps) {
 

--- a/src/client/app/components/admin/UsersDetailComponent.tsx
+++ b/src/client/app/components/admin/UsersDetailComponent.tsx
@@ -23,8 +23,8 @@ interface UserDisplayComponentProps {
 
 /**
  * Component which shows user details
- * @param {UserDisplayComponentProps} props defined above
- * @returns {Element} User Detail element
+ * @param props defined above
+ * @returns User Detail element
  */
 export default function UserDetailComponent(props: UserDisplayComponentProps) {
 	const titleStyle: React.CSSProperties = {

--- a/src/client/app/components/admin/users/CreateUserLinkButtonComponent.tsx
+++ b/src/client/app/components/admin/users/CreateUserLinkButtonComponent.tsx
@@ -13,8 +13,8 @@ interface CreateUserLinkButtonComponentProps {
 
 /**
  * Component which links a button to the create user form
- * @param {CreateUserLinkButtonComponentProps} props defined above
- * @returns {Element} Create User button element
+ * @param props defined above
+ * @returns Create User button element
  */
 export default function CreateUserLinkButtonComponent(props: CreateUserLinkButtonComponentProps) {
 	const inlineButtonStyle: React.CSSProperties = {

--- a/src/client/app/components/admin/users/ManageUsersLinkButtonComponent.tsx
+++ b/src/client/app/components/admin/users/ManageUsersLinkButtonComponent.tsx
@@ -13,8 +13,8 @@ interface ManageUserLinkButtonComponentProps {
 
 /**
  * Component which creates a button link to the manage users page
- * @param {ManageUserLinkButtonComponentProps} props defined above
- * @returns {Element} Manage user button component
+ * @param props defined above
+ * @returns Manage user button component
  */
 export default function ManageUsersLinkButtonComponent(props: ManageUserLinkButtonComponentProps) {
 	const inlineButtonStyle: React.CSSProperties = {

--- a/src/client/app/components/conversion/ConversionViewComponent.tsx
+++ b/src/client/app/components/conversion/ConversionViewComponent.tsx
@@ -20,8 +20,8 @@ interface ConversionViewComponentProps {
 
 /**
  * Defines the conversion info card
- * @param {ConversionViewComponentProps} props defined above
- * @returns {Element} Single conversion element
+ * @param props defined above
+ * @returns Single conversion element
  */
 export default function ConversionViewComponent(props: ConversionViewComponentProps) {
 	// Don't check if admin since only an admin is allow to route to this page.

--- a/src/client/app/components/conversion/ConversionsDetailComponent.tsx
+++ b/src/client/app/components/conversion/ConversionsDetailComponent.tsx
@@ -19,7 +19,7 @@ import SpinnerComponent from '../../components/SpinnerComponent';
 
 /**
  * Defines the conversions page card view
- * @returns {Element} Conversion page element
+ * @returns Conversion page element
  */
 export default function ConversionsDetailComponent() {
 	// The route stops you from getting to this page if not an admin.

--- a/src/client/app/components/conversion/CreateConversionModalComponent.tsx
+++ b/src/client/app/components/conversion/CreateConversionModalComponent.tsx
@@ -27,8 +27,8 @@ interface CreateConversionModalComponentProps {
 }
 /**
  * Defines the create conversion modal form
- * @param {object} props Props for the component
- * @returns {Element} Conversion element
+ * @param props Props for the component
+ * @returns Conversion element
  */
 export default function CreateConversionModalComponent(props: CreateConversionModalComponentProps) {
 
@@ -84,10 +84,10 @@ export default function CreateConversionModalComponent(props: CreateConversionMo
 
 	/**
 	 * Checks if conversion is valid
-	 * @param {number} sourceId New conversion sourceId
-	 * @param {number} destinationId New conversion destinationId
-	 * @param {boolean} bidirectional New conversion bidirectional status
-	 * @returns {boolean} representing if new conversion is valid or not
+	 * @param sourceId New conversion sourceId
+	 * @param destinationId New conversion destinationId
+	 * @param bidirectional New conversion bidirectional status
+	 * @returns representing if new conversion is valid or not
 	 */
 	const isValidConversion = (sourceId: number, destinationId: number, bidirectional: boolean) => {
 		/*

--- a/src/client/app/components/conversion/CreateConversionModalComponent.tsx
+++ b/src/client/app/components/conversion/CreateConversionModalComponent.tsx
@@ -28,7 +28,7 @@ interface CreateConversionModalComponentProps {
 /**
  * Defines the create conversion modal form
  * @param props Props for the component
- * @returns Conversion element
+ * @returns Conversion create element
  */
 export default function CreateConversionModalComponent(props: CreateConversionModalComponentProps) {
 
@@ -87,7 +87,7 @@ export default function CreateConversionModalComponent(props: CreateConversionMo
 	 * @param sourceId New conversion sourceId
 	 * @param destinationId New conversion destinationId
 	 * @param bidirectional New conversion bidirectional status
-	 * @returns representing if new conversion is valid or not
+	 * @returns boolean representing if new conversion is valid or not
 	 */
 	const isValidConversion = (sourceId: number, destinationId: number, bidirectional: boolean) => {
 		/*

--- a/src/client/app/components/conversion/EditConversionModalComponent.tsx
+++ b/src/client/app/components/conversion/EditConversionModalComponent.tsx
@@ -34,7 +34,7 @@ interface EditConversionModalComponentProps {
 /**
  * Defines the edit conversion modal form
  * @param props Props for the component
- * @returns The edit menu
+ * @returns Conversion edit element
  */
 export default function EditConversionModalComponent(props: EditConversionModalComponentProps) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/conversion/EditConversionModalComponent.tsx
+++ b/src/client/app/components/conversion/EditConversionModalComponent.tsx
@@ -33,8 +33,8 @@ interface EditConversionModalComponentProps {
 
 /**
  * Defines the edit conversion modal form
- * @param {object} props Props for the component
- * @returns {Element} The edit menu
+ * @param props Props for the component
+ * @returns The edit menu
  */
 export default function EditConversionModalComponent(props: EditConversionModalComponentProps) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/csv/ReadingsCSVUploadComponent.tsx
+++ b/src/client/app/components/csv/ReadingsCSVUploadComponent.tsx
@@ -13,9 +13,9 @@ import translate from '../../utils/translate';
 
 /**
  * Returns a range of values between the specified lower and upper bounds.
- * @param {number} lower The lower bound, which will be included in the range.
- * @param {number} upper The upper bound, which will be excluded from the range.
- * @returns {number[]} An array of values between starting from the lower bound and up to and excluding the upper bound.
+ * @param lower The lower bound, which will be included in the range.
+ * @param upper The upper bound, which will be excluded from the range.
+ * @returns An array of values between starting from the lower bound and up to and excluding the upper bound.
  */
 function range(lower: number, upper: number): number[] {
 	const arr = [];

--- a/src/client/app/components/groups/CreateGroupModalComponent.tsx
+++ b/src/client/app/components/groups/CreateGroupModalComponent.tsx
@@ -35,8 +35,8 @@ interface CreateGroupModalComponentProps {
 
 /**
  * Defines the create group modal form
- * @param {CreateGroupModalComponentProps} props pass in graphic units
- * @returns {Element} JSX Element
+ * @param props pass in graphic units
+ * @returns JSX Element
  */
 export default function CreateGroupModalComponent(props: CreateGroupModalComponentProps) {
 	const dispatch = useDispatch();
@@ -502,7 +502,7 @@ export default function CreateGroupModalComponent(props: CreateGroupModalCompone
 
 	/**
 	 * Converts the child meters of this group to options for menu sorted by identifier
-	 * @returns {SelectOption} sorted for child meters of group creating.
+	 * @returns SelectOptions sorted for child meters of group creating.
 	 */
 	function metersToSelectOptions(): SelectOption[] {
 		// In format for the display component for menu.
@@ -521,7 +521,7 @@ export default function CreateGroupModalComponent(props: CreateGroupModalCompone
 
 	/**
 	 * Converts the child groups of this group to options for menu sorted by name
-	 * @returns {SelectOption} sorted for child groups of group editing.
+	 * @returns SelectOptions sorted for child groups of group editing.
 	 */
 	function groupsToSelectOptions(): SelectOption[] {
 		// In format for the display component for menu.
@@ -540,7 +540,7 @@ export default function CreateGroupModalComponent(props: CreateGroupModalCompone
 
 	/**
 	 * Converts the deep meters of this group to list options sorted by identifier.
-	 * @returns {string[]} names of all child meters in sorted order.
+	 * @returns names of all child meters in sorted order.
 	 */
 	function deepMetersToList() {
 		// Create list of meter identifiers.

--- a/src/client/app/components/groups/CreateGroupModalComponent.tsx
+++ b/src/client/app/components/groups/CreateGroupModalComponent.tsx
@@ -36,7 +36,7 @@ interface CreateGroupModalComponentProps {
 /**
  * Defines the create group modal form
  * @param props pass in graphic units
- * @returns JSX Element
+ * @returns Group create element
  */
 export default function CreateGroupModalComponent(props: CreateGroupModalComponentProps) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/groups/EditGroupModalComponent.tsx
+++ b/src/client/app/components/groups/EditGroupModalComponent.tsx
@@ -49,8 +49,8 @@ interface EditGroupModalComponentProps {
 
 /**
  * Defines the edit group modal form
- * @param {EditGroupModalComponentProps} props state variables needed to define the component
- * @returns {Element} JSX Element
+ * @param props state variables needed to define the component
+ * @returns JSX Element
  */
 export default function EditGroupModalComponent(props: EditGroupModalComponentProps) {
 	const dispatch = useDispatch();
@@ -673,9 +673,9 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 	/**
 	 * Validates and warns user when adding a child group/meter to a specific group.
 	 * If the check pass, update the edited group and related groups.
-	 * @param {number} childId The group/meter's id to add to the parent group.
-	 * @param {DataType} childType Can be group or meter.
-	 * @returns {boolean} true if the child was assigned and false otherwise
+	 * @param childId The group/meter's id to add to the parent group.
+	 * @param childType Can be group or meter.
+	 * @returns true if the child was assigned and false otherwise
 	 */
 	async function assignChildToGroup(childId: number, childType: DataType): Promise<boolean> {
 		// Create a deep copy of the edit state before adding the child. We only need some of the state but this is easier.
@@ -735,10 +735,10 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 	/**
 	 * Determines if the change in compatible units of one group are okay with another group.
 	 * Warns admin of changes and returns true if the changes should happen.
-	 * @param {number} gid The group that has a change in compatible units.
-	 * @param {number[]} parentGroupIds The parent groups' ids of that group.
-	 * @param {*} groupsState The local group state to use.
-	 * @returns {boolean} true if change fine or if admin agreed. false if admin does not or the change is an issue.
+	 * @param gid The group that has a change in compatible units.
+	 * @param parentGroupIds The parent groups' ids of that group.
+	 * @param groupsState The local group state to use.
+	 * @returns true if change fine or if admin agreed. false if admin does not or the change is an issue.
 	 */
 	function validateGroupPostAddChild(gid: number, parentGroupIds: number[], groupsState: any): boolean {
 		// This will hold the overall message for the admin alert.
@@ -793,9 +793,9 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 
 	/**
 	 * Handles removing child from a group.
-	 * @param {number} childId The group/meter's id to add to the parent group.
-	 * @param {DataType} childType Can be group or meter.
-	 * @returns {boolean} true if change fine or if admin agreed. false if admin does not or the change is an issue.
+	 * @param childId The group/meter's id to add to the parent group.
+	 * @param childType Can be group or meter.
+	 * @returns true if change fine or if admin agreed. false if admin does not or the change is an issue.
 	 */
 	function removeChildFromGroup(childId: number, childType: DataType): boolean {
 		// Unlike adding, you do not change the default graphic unit by removing. Thus, you only need to recalculate the
@@ -878,7 +878,7 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 
 	/**
 	 * Converts the child meters of this group to options for menu sorted by identifier
-	 * @returns {SelectOption[]} sorted SelectOption for child meters of group editing.
+	 * @returns sorted SelectOption for child meters of group editing.
 	 */
 	function metersToSelectOptions(): SelectOption[] {
 		// In format for the display component for menu.
@@ -897,7 +897,7 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 
 	/**
 	 * Converts the child groups of this group to options for menu sorted by name
-	 * @returns {SelectOption[]} sorted SelectOption for child groups of group editing.
+	 * @returns sorted SelectOption for child groups of group editing.
 	 */
 	function groupsToSelectOptions(): SelectOption[] {
 		// In format for the display component for menu.
@@ -919,7 +919,7 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 	/**
 	 * Converts the child meters of this group to list options sorted by name.
 	 * This is needed for non-admins. Hidden items are not shown but noted in list.
-	 * @returns {string[]} names of all child meters in sorted order.
+	 * @returns names of all child meters in sorted order.
 	 */
 	function metersToList(): string[] {
 		// Hold the list for display.
@@ -948,7 +948,7 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 	/**
 	 * Converts the child meters of this group to list options sorted by name.
 	 * This is needed for non-admins. Hidden items are not shown but noted in list.
-	 * @returns {string[]} names of all child meters in sorted order.
+	 * @returns names of all child meters in sorted order.
 	 */
 	function groupsToList(): string[] {
 		const listedGroups: string[] = [];
@@ -979,7 +979,7 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 	/**
 	 * Converts the deep meters of this group to list options sorted by identifier.
 	 * Hidden items are not shown but noted in list; admins should never see that.
-	 * @returns {string[]} names of all child meters in sorted order.
+	 * @returns names of all child meters in sorted order.
 	 */
 	function deepMetersToList() {
 		// Unlike child meter/group, these are lists for all users.
@@ -1011,11 +1011,10 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
  * only uses the direct meter and group children. It uses a store passed to it so it can
  * be changed without changing the Redux group store. Thus, it directly and recursively gets
  * the deep meters of a group.
- *
- * @param {number} groupId The groupId.
- * @param {GroupDefinition[]} groupState The group state to use in the calculation.
- * @param {number} times The number of times the function has been recursively called. Not passed on first call and only used internally.
- * @returns {number[]} Array of deep children ids of this group or empty array if none/circular dependency.
+ * @param groupId The groupId.
+ * @param groupState The group state to use in the calculation.
+ * @param times The number of times the function has been recursively called. Not passed on first call and only used internally.
+ * @returns Array of deep children ids of this group or empty array if none/circular dependency.
  */
 function calculateMetersInGroup(groupId: number, groupState: any, times: number = 0): number[] {
 	// The number of times should be set to zero on the first call. Each time add one and assume

--- a/src/client/app/components/groups/EditGroupModalComponent.tsx
+++ b/src/client/app/components/groups/EditGroupModalComponent.tsx
@@ -50,7 +50,7 @@ interface EditGroupModalComponentProps {
 /**
  * Defines the edit group modal form
  * @param props state variables needed to define the component
- * @returns JSX Element
+ * @returns Group edit element
  */
 export default function EditGroupModalComponent(props: EditGroupModalComponentProps) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/groups/GroupViewComponent.tsx
+++ b/src/client/app/components/groups/GroupViewComponent.tsx
@@ -27,7 +27,7 @@ interface GroupViewComponentProps {
 /**
  * Defines the group info card
  * @param props variables passed in to define
- * @returns JSX Element
+ * @returns Group info card element
  */
 export default function GroupViewComponent(props: GroupViewComponentProps) {
 	// Don't check if admin since only an admin is allowed to route to this page.

--- a/src/client/app/components/groups/GroupViewComponent.tsx
+++ b/src/client/app/components/groups/GroupViewComponent.tsx
@@ -26,8 +26,8 @@ interface GroupViewComponentProps {
 
 /**
  * Defines the group info card
- * @param {GroupViewComponentProps} props variables passed in to define
- * @returns {Element} JSX Element
+ * @param props variables passed in to define
+ * @returns JSX Element
  */
 export default function GroupViewComponent(props: GroupViewComponentProps) {
 	// Don't check if admin since only an admin is allowed to route to this page.

--- a/src/client/app/components/groups/GroupsDetailComponent.tsx
+++ b/src/client/app/components/groups/GroupsDetailComponent.tsx
@@ -22,7 +22,7 @@ import * as _ from 'lodash';
 
 /**
  * Defines the groups page card view
- * @returns {Element} Groups page element
+ * @returns Groups page element
  */
 export default function GroupsDetailComponent() {
 	const dispatch = useDispatch();

--- a/src/client/app/components/meters/CreateMeterModalComponent.tsx
+++ b/src/client/app/components/meters/CreateMeterModalComponent.tsx
@@ -37,7 +37,7 @@ interface CreateMeterModalComponentProps {
 /**
  * Defines the create meter modal form
  * @param props Component props
- * @returns JSX of the create meter page
+ * @returns Meter create element
  */
 export default function CreateMeterModalComponent(props: CreateMeterModalComponentProps) {
 

--- a/src/client/app/components/meters/CreateMeterModalComponent.tsx
+++ b/src/client/app/components/meters/CreateMeterModalComponent.tsx
@@ -36,8 +36,8 @@ interface CreateMeterModalComponentProps {
 
 /**
  * Defines the create meter modal form
- * @param {object} props Component props
- * @returns {Element} JSX of the create meter page
+ * @param props Component props
+ * @returns JSX of the create meter page
  */
 export default function CreateMeterModalComponent(props: CreateMeterModalComponentProps) {
 

--- a/src/client/app/components/meters/EditMeterModalComponent.tsx
+++ b/src/client/app/components/meters/EditMeterModalComponent.tsx
@@ -38,8 +38,8 @@ interface EditMeterModalComponentProps {
 }
 /**
  * Defines the edit meter modal form
- * @param {object} props for the edit component
- * @returns {Element} Edit meter menu
+ * @param props for the edit component
+ * @returns Edit meter menu
  */
 export default function EditMeterModalComponent(props: EditMeterModalComponentProps) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/meters/EditMeterModalComponent.tsx
+++ b/src/client/app/components/meters/EditMeterModalComponent.tsx
@@ -39,7 +39,7 @@ interface EditMeterModalComponentProps {
 /**
  * Defines the edit meter modal form
  * @param props for the edit component
- * @returns Edit meter menu
+ * @returns Meter edit element
  */
 export default function EditMeterModalComponent(props: EditMeterModalComponentProps) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/meters/MeterViewComponent.tsx
+++ b/src/client/app/components/meters/MeterViewComponent.tsx
@@ -29,7 +29,7 @@ interface MeterViewComponentProps {
 /**
  * Defines the meter info card
  * @param props component props
- * @returns Meter info card
+ * @returns Meter info card element
  */
 export default function MeterViewComponent(props: MeterViewComponentProps) {
 	// Edit Modal Show

--- a/src/client/app/components/meters/MeterViewComponent.tsx
+++ b/src/client/app/components/meters/MeterViewComponent.tsx
@@ -28,8 +28,8 @@ interface MeterViewComponentProps {
 
 /**
  * Defines the meter info card
- * @param {object} props component props
- * @returns {Element} Meter info card
+ * @param props component props
+ * @returns Meter info card
  */
 export default function MeterViewComponent(props: MeterViewComponentProps) {
 	// Edit Modal Show

--- a/src/client/app/components/meters/MetersDetailComponent.tsx
+++ b/src/client/app/components/meters/MetersDetailComponent.tsx
@@ -23,7 +23,7 @@ import { potentialGraphicUnits, noUnitTranslated } from '../../utils/input';
 
 /**
  * Defines the meters page card view
- * @returns {Element} Meters page element
+ * @returns Meters page element
  */
 export default function MetersDetailComponent() {
 

--- a/src/client/app/components/unit/CreateUnitModalComponent.tsx
+++ b/src/client/app/components/unit/CreateUnitModalComponent.tsx
@@ -19,7 +19,7 @@ import { formInputStyle, tableStyle, requiredStyle, tooltipBaseStyle } from '../
 
 /**
  * Defines the create unit modal form
- * @returns {Element} Unit creation menu
+ * @returns Unit creation menu
  */
 export default function CreateUnitModalComponent() {
 	const dispatch = useDispatch();

--- a/src/client/app/components/unit/CreateUnitModalComponent.tsx
+++ b/src/client/app/components/unit/CreateUnitModalComponent.tsx
@@ -19,7 +19,7 @@ import { formInputStyle, tableStyle, requiredStyle, tooltipBaseStyle } from '../
 
 /**
  * Defines the create unit modal form
- * @returns Unit creation menu
+ * @returns Unit create element
  */
 export default function CreateUnitModalComponent() {
 	const dispatch = useDispatch();

--- a/src/client/app/components/unit/EditUnitModalComponent.tsx
+++ b/src/client/app/components/unit/EditUnitModalComponent.tsx
@@ -29,8 +29,8 @@ interface EditUnitModalComponentProps {
 
 /**
  * Defines the edit unit modal form
- * @param {object} props props for component
- * @returns {Element} Meter edit menu element
+ * @param props props for component
+ * @returns Meter edit menu element
  */
 export default function EditUnitModalComponent(props: EditUnitModalComponentProps) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/unit/EditUnitModalComponent.tsx
+++ b/src/client/app/components/unit/EditUnitModalComponent.tsx
@@ -30,7 +30,7 @@ interface EditUnitModalComponentProps {
 /**
  * Defines the edit unit modal form
  * @param props props for component
- * @returns Meter edit menu element
+ * @returns Unit edit element
  */
 export default function EditUnitModalComponent(props: EditUnitModalComponentProps) {
 	const dispatch = useDispatch();

--- a/src/client/app/components/unit/UnitViewComponent.tsx
+++ b/src/client/app/components/unit/UnitViewComponent.tsx
@@ -18,8 +18,8 @@ interface UnitViewComponentProps {
 
 /**
  * Defines the unit info card
- * @param {UnitViewComponentProps} props variables passed in to define
- * @returns {Element} JSX Element
+ * @param props variables passed in to define
+ * @returns JSX Element
  */
 export default function UnitViewComponent(props: UnitViewComponentProps) {
 	// Don't check if admin since only an admin is allow to route to this page.

--- a/src/client/app/components/unit/UnitViewComponent.tsx
+++ b/src/client/app/components/unit/UnitViewComponent.tsx
@@ -19,7 +19,7 @@ interface UnitViewComponentProps {
 /**
  * Defines the unit info card
  * @param props variables passed in to define
- * @returns JSX Element
+ * @returns Unit info card element
  */
 export default function UnitViewComponent(props: UnitViewComponentProps) {
 	// Don't check if admin since only an admin is allow to route to this page.

--- a/src/client/app/components/unit/UnitsDetailComponent.tsx
+++ b/src/client/app/components/unit/UnitsDetailComponent.tsx
@@ -18,7 +18,7 @@ import SpinnerComponent from '../../components/SpinnerComponent';
 
 /**
  * Defines the units page card view
- * @returns {Element} Units page element
+ * @returns Units page element
  */
 export default function UnitsDetailComponent() {
 	// The route stops you from getting to this page if not an admin.

--- a/src/client/app/containers/BarChartContainer.ts
+++ b/src/client/app/containers/BarChartContainer.ts
@@ -13,9 +13,6 @@ import { DataType } from '../types/Datasources';
 import { barUnitLabel } from '../utils/graphics';
 import { AreaUnitType, getAreaUnitConversion } from '../utils/getAreaUnitConversion';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-param */
-/* eslint-disable jsdoc/require-returns */
 /**
  * Passes the current redux state of the barchart, and turns it into props for the React
  * component, which is what will be visible on the page. Makes it possible to access

--- a/src/client/app/containers/ChartLinkContainer.ts
+++ b/src/client/app/containers/ChartLinkContainer.ts
@@ -6,10 +6,6 @@ import { connect } from 'react-redux';
 import ChartLinkComponent from '../components/ChartLinkComponent';
 import { State } from '../types/redux/state';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-param */
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * Passes the current redux state of the chart link text, and turns it into props for the React
  * component, which is what will be visible on the page. Makes it possible to access

--- a/src/client/app/containers/CompareChartContainer.ts
+++ b/src/client/app/containers/CompareChartContainer.ts
@@ -23,9 +23,9 @@ interface CompareChartContainerProps {
  * Passes the current redux state of the of the chart container and it's props, and turns it into props for the React
  * component, which is what will be visible on the page. Makes it possible to access
  * your reducer state objects from within your React components.
- * @param {State} state The redux state
- * @param {CompareChartContainerProps} ownProps Chart container props
- * @returns {*} The props object
+ * @param state The redux state
+ * @param ownProps Chart container props
+ * @returns The props object
  */
 function mapStateToProps(state: State, ownProps: CompareChartContainerProps): any {
 	const comparePeriod = state.graph.comparePeriod;

--- a/src/client/app/containers/DashboardContainer.ts
+++ b/src/client/app/containers/DashboardContainer.ts
@@ -9,10 +9,6 @@ import { Dispatch } from '../types/redux/actions';
 import { TimeInterval } from '../../../common/TimeInterval';
 import { changeGraphZoomIfNeeded } from '../actions/graph';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-param */
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * Passes the current redux state of the dashboard, and turns it into props for the React
  * component, which is what will be visible on the page. Makes it possible to access

--- a/src/client/app/containers/FooterContainer.ts
+++ b/src/client/app/containers/FooterContainer.ts
@@ -8,10 +8,6 @@ import FooterComponent from '../components/FooterComponent';
 import { State } from '../types/redux/state';
 import { Dispatch } from '../types/redux/actions';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-param */
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * A container that does data fetching for FooterComponent and connects it to the redux store.
  */

--- a/src/client/app/containers/HeaderContainer.ts
+++ b/src/client/app/containers/HeaderContainer.ts
@@ -6,8 +6,6 @@ import { connect } from 'react-redux';
 import HeaderComponent from '../components/HeaderComponent';
 import { State } from '../types/redux/state';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 
 	return {

--- a/src/client/app/containers/LanguageSelectorContainer.ts
+++ b/src/client/app/containers/LanguageSelectorContainer.ts
@@ -9,10 +9,6 @@ import { Dispatch } from '../types/redux/actions';
 import { updateDefaultLanguage } from '../actions/admin';
 import { LanguageTypes } from '../types/redux/i18n';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-param */
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * Passes the current redux state of the language selection, and turns it into props for the React
  * component, which is what will be visible on the page. Makes it possible to access

--- a/src/client/app/containers/LineChartContainer.ts
+++ b/src/client/app/containers/LineChartContainer.ts
@@ -13,8 +13,6 @@ import { DataType } from '../types/Datasources';
 import { lineUnitLabel } from '../utils/graphics';
 import { AreaUnitType, getAreaUnitConversion } from '../utils/getAreaUnitConversion';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	const timeInterval = state.graph.timeInterval;
 	const unitID = state.graph.selectedUnit;

--- a/src/client/app/containers/LoginContainer.tsx
+++ b/src/client/app/containers/LoginContainer.tsx
@@ -8,10 +8,6 @@ import { receiveCurrentUser } from '../actions/currentUser'
 import LoginComponent from '../components/LoginComponent';
 import { Dispatch } from '../types/redux/actions';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-param */
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * A container that does data fetching for FooterComponent and connects it to the redux store.
  */

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -18,8 +18,6 @@ import { UnitRepresentType } from '../types/redux/units';
 import { AreaUnitType, getAreaUnitConversion } from '../utils/getAreaUnitConversion';
 import translate from '../utils/translate';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	const unitID = state.graph.selectedUnit;
 	// Map to use.

--- a/src/client/app/containers/MeterDropdownContainer.ts
+++ b/src/client/app/containers/MeterDropdownContainer.ts
@@ -9,8 +9,6 @@ import MeterDropdownComponent from '../components/MeterDropDownComponent';
 import { State } from '../types/redux/state';
 import { Dispatch } from '../types/redux/actions';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	return {
 		meters: _.sortBy(_.values(state.meters.byMeterID).map(meter => ({ id: meter.id, name: meter.name })), 'name')

--- a/src/client/app/containers/MultiCompareChartContainer.ts
+++ b/src/client/app/containers/MultiCompareChartContainer.ts
@@ -11,8 +11,6 @@ import { TimeInterval } from '../../../common/TimeInterval';
 import * as moment from 'moment';
 import { AreaUnitType } from '../utils/getAreaUnitConversion';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export interface CompareEntity {
 	id: number;
 	isGroup: boolean;

--- a/src/client/app/containers/RouteContainer.ts
+++ b/src/client/app/containers/RouteContainer.ts
@@ -11,8 +11,6 @@ import { clearCurrentUser } from '../actions/currentUser';
 import { isRoleAdmin } from '../utils/hasPermissions';
 import { UserRole } from '../types/items';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	const currentUser = state.currentUser.profile;
 	let loggedInAsAdmin = false;

--- a/src/client/app/containers/TooltipHelpContainer.ts
+++ b/src/client/app/containers/TooltipHelpContainer.ts
@@ -8,10 +8,6 @@ import TooltipHelpComponent from '../components/TooltipHelpComponent';
 import { State } from '../types/redux/state';
 import { Dispatch } from '../types/redux/actions';
 
-/* eslint-disable jsdoc/require-jsdoc */
-/* eslint-disable jsdoc/require-param */
-/* eslint-disable jsdoc/require-returns */
-
 /**
  * A container that does data fetching for TooltipHelpComponent and connects it to the redux store.
  */

--- a/src/client/app/containers/UIOptionsContainer.ts
+++ b/src/client/app/containers/UIOptionsContainer.ts
@@ -16,8 +16,6 @@ import { Dispatch } from '../types/redux/actions';
 import { State } from '../types/redux/state';
 import {ComparePeriod, SortingOrder} from '../utils/calculateCompare';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	return {
 		chartToRender: state.graph.chartToRender,

--- a/src/client/app/containers/UnsavedWarningContainer.ts
+++ b/src/client/app/containers/UnsavedWarningContainer.ts
@@ -8,8 +8,6 @@ import UnsavedWarningComponent from '../components/UnsavedWarningComponent';
 import { State } from '../types/redux/state';
 import { Dispatch } from '../types/redux/actions';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	return {
 		hasUnsavedChanges: state.unsavedWarning.hasUnsavedChanges,

--- a/src/client/app/containers/admin/PreferencesContainer.ts
+++ b/src/client/app/containers/admin/PreferencesContainer.ts
@@ -23,8 +23,6 @@ import { ChartTypes } from '../../types/redux/graph';
 import { LanguageTypes } from '../../types/redux/i18n';
 import { AreaUnitType } from '../../utils/getAreaUnitConversion';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	return {
 		displayTitle: state.admin.displayTitle,

--- a/src/client/app/containers/maps/MapCalibrationChartDisplayContainer.ts
+++ b/src/client/app/containers/maps/MapCalibrationChartDisplayContainer.ts
@@ -104,9 +104,9 @@ function mapStateToProps(state: State) {
 /* eslint-enable */
 /**
  * use a transparent heatmap to capture which point the user clicked on the map
- * @param {Dimensions} imageDimensions Normalized dimensions of the image
- * @param {CalibrationSettings} settings Settings for calibration displays
- * @returns {object} point and data
+ * @param imageDimensions Normalized dimensions of the image
+ * @param settings Settings for calibration displays
+ * @returns point and data
  */
 function createBackgroundTrace(imageDimensions: Dimensions, settings: CalibrationSettings) {
 	// define the grid of heatmap

--- a/src/client/app/containers/maps/MapCalibrationChartDisplayContainer.ts
+++ b/src/client/app/containers/maps/MapCalibrationChartDisplayContainer.ts
@@ -12,8 +12,6 @@ import store from '../../index';
 import { CalibrationSettings } from '../../types/redux/map';
 import Locales from '../../types/locales'
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	const x: number[] = [];
 	const y: number[] = [];
@@ -142,8 +140,6 @@ function createBackgroundTrace(imageDimensions: Dimensions, settings: Calibratio
 	};
 	return trace;
 }
-
-/* eslint-disable jsdoc/require-jsdoc */
 
 function handlePointClick(event: plotly.PlotMouseEvent) {
 	event.event.preventDefault();

--- a/src/client/app/containers/maps/MapCalibrationChartDisplayContainer.ts
+++ b/src/client/app/containers/maps/MapCalibrationChartDisplayContainer.ts
@@ -99,7 +99,6 @@ function mapStateToProps(state: State) {
 	return props;
 }
 
-/* eslint-enable */
 /**
  * use a transparent heatmap to capture which point the user clicked on the map
  * @param imageDimensions Normalized dimensions of the image

--- a/src/client/app/containers/maps/MapCalibrationContainer.ts
+++ b/src/client/app/containers/maps/MapCalibrationContainer.ts
@@ -7,8 +7,6 @@ import {State} from '../../types/redux/state';
 import MapCalibrationComponent from '../../components/maps/MapCalibrationComponent';
 import {CalibrationModeTypes} from '../../types/redux/map';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	const mapID = state.maps.calibratingMap;
 	return {

--- a/src/client/app/containers/maps/MapCalibrationInfoDisplayContainer.ts
+++ b/src/client/app/containers/maps/MapCalibrationInfoDisplayContainer.ts
@@ -11,8 +11,6 @@ import {GPSPoint} from '../../utils/calibration';
 import {logToServer} from '../../actions/logs';
 import translate from '../../utils/translate';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	const mapID = state.maps.calibratingMap;
 	const map = state.maps.editedMaps[mapID];

--- a/src/client/app/containers/maps/MapCalibrationInitiateContainer.ts
+++ b/src/client/app/containers/maps/MapCalibrationInitiateContainer.ts
@@ -9,8 +9,6 @@ import {updateMapMode, updateMapSource} from '../../actions/map';
 import {CalibrationModeTypes, MapMetadata} from '../../types/redux/map';
 import {State} from '../../types/redux/state';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	return {
 		map: state.maps.editedMaps[state.maps.calibratingMap]

--- a/src/client/app/containers/maps/MapViewContainer.tsx
+++ b/src/client/app/containers/maps/MapViewContainer.tsx
@@ -9,8 +9,6 @@ import { State } from '../../types/redux/state';
 import {CalibrationModeTypes, MapMetadata} from '../../types/redux/map';
 import {editMapDetails, removeMap, setCalibration} from '../../actions/map';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State, ownProps: {id: number}) {
 	let map = state.maps.byMapID[ownProps.id];
 	if (state.maps.editedMaps[ownProps.id]) {

--- a/src/client/app/containers/maps/MapsDetailContainer.tsx
+++ b/src/client/app/containers/maps/MapsDetailContainer.tsx
@@ -8,8 +8,6 @@ import {Dispatch} from '../../types/redux/actions';
 import {fetchMapsDetails, setNewMap, submitEditedMaps} from '../../actions/map';
 import MapsDetailComponent from '../../components/maps/MapsDetailComponent';
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 function mapStateToProps(state: State) {
 	return {
 		maps: Object.keys(state.maps.byMapID)

--- a/src/client/app/reducers/admin.ts
+++ b/src/client/app/reducers/admin.ts
@@ -26,8 +26,6 @@ const defaultState: AdminState = {
 	defaultMeterReadingFrequency: '00:15:00'
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function admin(state = defaultState, action: AdminAction) {
 	switch (action.type) {
 		case ActionType.UpdateImportMeter:

--- a/src/client/app/reducers/barReadings.ts
+++ b/src/client/app/reducers/barReadings.ts
@@ -13,8 +13,6 @@ const defaultState: BarReadingsState = {
 	groupsFetching: false
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function readings(state = defaultState, action: BarReadingsAction) {
 	switch (action.type) {
 		case ActionType.RequestMeterBarReadings: {

--- a/src/client/app/reducers/compareReadings.ts
+++ b/src/client/app/reducers/compareReadings.ts
@@ -13,8 +13,6 @@ const defaultState: CompareReadingsState = {
 	groupsFetching: false
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function readings(state = defaultState, action: CompareReadingsAction) {
 	switch (action.type) {
 		case ActionType.RequestMeterCompareReadings: {

--- a/src/client/app/reducers/conversions.ts
+++ b/src/client/app/reducers/conversions.ts
@@ -13,8 +13,6 @@ const defaultState: ConversionsState = {
 	conversions: []
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function conversions(state = defaultState, action: ConversionsAction) {
 	switch (action.type) {
 		case ActionType.ConfirmConversionsFetchedOnce:

--- a/src/client/app/reducers/currentUser.ts
+++ b/src/client/app/reducers/currentUser.ts
@@ -10,8 +10,6 @@ import { ActionType } from '../types/redux/actions';
 */
 const defaultState: CurrentUserState = { isFetching: false, profile: null  };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function profile(state = defaultState, action: CurrentUserAction): CurrentUserState {
 	switch (action.type) {
 		case ActionType.RequestCurrentUser:

--- a/src/client/app/reducers/graph.ts
+++ b/src/client/app/reducers/graph.ts
@@ -29,8 +29,6 @@ const defaultState: GraphState = {
 	renderOnce: false
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function graph(state = defaultState, action: GraphAction) {
 	switch (action.type) {
 		case ActionType.ConfirmGraphRenderOnce: {

--- a/src/client/app/reducers/groups.ts
+++ b/src/client/app/reducers/groups.ts
@@ -21,8 +21,6 @@ const defaultState: GroupsState = {
 	displayMode: DisplayMode.View
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function groups(state = defaultState, action: GroupsAction) {
 	switch (action.type) {
 		// Records if group details have been fetched at least once

--- a/src/client/app/reducers/lineReadings.ts
+++ b/src/client/app/reducers/lineReadings.ts
@@ -13,8 +13,6 @@ const defaultState: LineReadingsState = {
 	groupsFetching: false
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function readings(state = defaultState, action: LineReadingsAction) {
 	switch (action.type) {
 		case ActionType.RequestMeterLineReadings: {

--- a/src/client/app/reducers/maps.ts
+++ b/src/client/app/reducers/maps.ts
@@ -18,8 +18,6 @@ const defaultState: MapState = {
 	calibrationSettings: {showGrid: false}
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function maps(state = defaultState, action: MapsAction) {
 	let submitting;
 	let editedMaps;

--- a/src/client/app/reducers/meters.ts
+++ b/src/client/app/reducers/meters.ts
@@ -14,8 +14,6 @@ const defaultState: MetersState = {
 	submitting: []
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function meters(state = defaultState, action: MetersAction) {
 	switch (action.type) {
 		case ActionType.ConfirmMetersFetchedOnce: {

--- a/src/client/app/reducers/notifications.ts
+++ b/src/client/app/reducers/notifications.ts
@@ -9,8 +9,6 @@ const defaultState: NotificationsState = {
 	notification: {}
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function topLevel(state = defaultState, action: NotificationAction) {
 	switch (action.type) {
 		case ActionType.ShowNotification:

--- a/src/client/app/reducers/units.ts
+++ b/src/client/app/reducers/units.ts
@@ -13,8 +13,6 @@ const defaultState: UnitsState = {
 	units: {}
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function units(state = defaultState, action: UnitsAction) {
 	switch (action.type) {
 		case ActionType.ConfirmUnitsFetchedOnce: {

--- a/src/client/app/reducers/unsavedWarning.ts
+++ b/src/client/app/reducers/unsavedWarning.ts
@@ -13,8 +13,6 @@ const defaultState: UnsavedWarningState = {
 	submitFunction: () => any
 };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function unsavedWarning(state = defaultState, action: UnsavedWarningAction) {
 	switch (action.type) {
 		case ActionType.UpdateUnsavedChanges:

--- a/src/client/app/reducers/version.ts
+++ b/src/client/app/reducers/version.ts
@@ -10,8 +10,6 @@ import { ActionType } from '../types/redux/actions';
 */
 const defaultState: VersionState = { isFetching: false, version: '' };
 
-/* eslint-disable jsdoc/require-jsdoc */
-
 export default function version(state = defaultState, action: VersionAction) {
 	switch (action.type) {
 		case ActionType.RequestVersion:

--- a/src/client/app/types/conversionArray.ts
+++ b/src/client/app/types/conversionArray.ts
@@ -20,7 +20,7 @@ export class ConversionArray {
 	}
 
 	/**
-	 * @returns {boolean} returns true if pik has values and false if not yet filled in.
+	 * @returns returns true if pik has values and false if not yet filled in.
 	 */
 	static pikAvailable() {
 		return this.available;

--- a/src/client/app/types/redux/map.ts
+++ b/src/client/app/types/redux/map.ts
@@ -5,6 +5,9 @@
 import {ActionType} from './actions';
 import {CalibratedPoint, CalibrationResult, CartesianPoint, GPSPoint} from '../../utils/calibration';
 
+/**
+ * 'initiate', 'calibrate' or 'unavailable'
+ */
 export enum CalibrationModeTypes {
 	initiate = 'initiate',
 	calibrate = 'calibrate',
@@ -114,7 +117,6 @@ export type MapsAction =
 
 /**
  * data format stored in the database
- *
  * @param id
  * @param name
  * @param note
@@ -139,7 +141,6 @@ export interface MapData{
 
 /**
  *  Data format used keep track of map's state
- *
  *  @param id {number} id <= -1 means it's a new map;
  *  @param name
  *  @param displayable

--- a/src/client/app/utils/Datasources.ts
+++ b/src/client/app/utils/Datasources.ts
@@ -11,10 +11,9 @@ export const DATA_TYPE_GROUP = DataType.Group;
 
 /**
  * Put item's id field in tgt if the item specifies a meter
- *
- * @param {number[]} tgt The array to perhaps insert an item into
- * @param {{String, number}} item The item being considered
- * @returns {Array} The modified tgt array
+ * @param tgt The array to perhaps insert an item into
+ * @param item The item being considered
+ * @returns The modified tgt array
  */
 export function metersFilterReduce(tgt: number[], item: DatasourceID) {
 	if (item.type === DATA_TYPE_METER) {
@@ -25,10 +24,9 @@ export function metersFilterReduce(tgt: number[], item: DatasourceID) {
 
 /**
  * Put item's id field in tgt if the item specifies a group
- *
- * @param {number[]} tgt The array to perhaps insert an item into
- * @param {{String, number}} item The item being considered
- * @returns {Array} The modified tgt array
+ * @param tgt The array to perhaps insert an item into
+ * @param item The item being considered
+ * @returns The modified tgt array
  */
 export function groupsFilterReduce(tgt: number[], item: DatasourceID) {
 	if (item.type === DATA_TYPE_GROUP) {

--- a/src/client/app/utils/api/GroupsApi.ts
+++ b/src/client/app/utils/api/GroupsApi.ts
@@ -48,11 +48,11 @@ export default class GroupsApi {
 
 	/**
 	 * Gets compare readings for groups for the given current time range and a shift for previous time range
-	 * @param {number[]} groupIDs The group IDs to get readings for
-	 * @param {TimeInterval} timeInterval  start and end of current/this compare period
-	 * @param {moment.Duration} shift how far to shift back in time from current period to previous period
-	 * @param {number} unitID The unit id that the reading should be returned in, i.e., the graphic unit
-	 * @returns {Promise<Object<number, Array<{curr_use: number, prev_use: number}>>>} in sorted order
+	 * @param groupIDs The group IDs to get readings for
+	 * @param timeInterval  start and end of current/this compare period
+	 * @param shift how far to shift back in time from current period to previous period
+	 * @param unitID The unit id that the reading should be returned in, i.e., the graphic unit
+	 * @returns CompareReadings in sorted order
 	 */
 	public async groupCompareReadings(groupIDs: number[], timeInterval: TimeInterval, shift: moment.Duration,
 		unitID: number): Promise<CompareReadings> {

--- a/src/client/app/utils/api/MetersApi.ts
+++ b/src/client/app/utils/api/MetersApi.ts
@@ -53,11 +53,11 @@ export default class MetersApi {
 
 	/**
 	 * Gets compare readings for meters for the given current time range and a shift for previous time range
-	 * @param {number[]} meterIDs The meter IDs to get readings for
-	 * @param {TimeInterval} timeInterval  start and end of current/this compare period
-	 * @param {moment.Duration} shift how far to shift back in time from current period to previous period
-	 * @param {number} unitID The unit id that the reading should be returned in, i.e., the graphic unit
-	 * @returns {Promise<Object<number, Array<{curr_use: number, prev_use: number}>>>} in sorted order
+	 * @param meterIDs The meter IDs to get readings for
+	 * @param timeInterval  start and end of current/this compare period
+	 * @param shift how far to shift back in time from current period to previous period
+	 * @param unitID The unit id that the reading should be returned in, i.e., the graphic unit
+	 * @returns CompareReadings in sorted order
 	 */
 	public async meterCompareReadings(meterIDs: number[], timeInterval: TimeInterval, shift: moment.Duration,
 		unitID: number): Promise<CompareReadings> {

--- a/src/client/app/utils/api/ReadingsApi.ts
+++ b/src/client/app/utils/api/ReadingsApi.ts
@@ -60,7 +60,7 @@ export default class ReadingsApi {
 	 * @param timeInterval The range of time to get readings for
 	 * @param barWidthDays The width of the bar in days
 	 * @param unitID The unit id that the reading should be returned in, i.e., the graphic unit
-	 * @returns LineReadings in sorted order
+	 * @returns BarReadings in sorted order
 	 */
 	public async meterBarReadings(meterIDs: number[], timeInterval: TimeInterval, barWidthDays: number, unitID: number): Promise<BarReadings> {
 		const stringifiedIDs = meterIDs.join(',');
@@ -76,7 +76,7 @@ export default class ReadingsApi {
 	 * @param timeInterval The range of time to get readings for
 	 * @param barWidthDays The width of the bar in days
 	 * @param unitID The unit id that the reading should be returned in, i.e., the graphic unit
-	 * @returns LineReadings in sorted order
+	 * @returns BarReadings in sorted order
 	 */
 	public async groupBarReadings(groupIDs: number[], timeInterval: TimeInterval, barWidthDays: number, unitID: number): Promise<BarReadings> {
 		const stringifiedIDs = groupIDs.join(',');

--- a/src/client/app/utils/api/ReadingsApi.ts
+++ b/src/client/app/utils/api/ReadingsApi.ts
@@ -18,10 +18,10 @@ export default class ReadingsApi {
 
 	/**
 	 * Gets line readings for meters for the given time range
-	 * @param {number[]} meterIDs The meter IDs to get readings for
-	 * @param {TimeInterval} timeInterval The range of time to get readings for
-	 * @param {number} unitID The unit id that the reading should be returned in, i.e., the graphic unit
-	 * @returns {Promise<Object<number, Array<{reading: number, start_timestamp: number, end_timestamp: number}>>>} in sorted order
+	 * @param meterIDs The meter IDs to get readings for
+	 * @param timeInterval The range of time to get readings for
+	 * @param unitID The unit id that the reading should be returned in, i.e., the graphic unit
+	 * @returns lineReadings in sorted order
 	 */
 	public async meterLineReadings(meterIDs: number[], timeInterval: TimeInterval, unitID: number): Promise<LineReadings> {
 		const stringifiedIDs = meterIDs.join(',');
@@ -37,10 +37,10 @@ export default class ReadingsApi {
 
 	/**
 	 * Gets line readings for groups for the given time range
-	 * @param {number[]} groupIDs The group IDs to get readings for
-	 * @param {TimeInterval} timeInterval The range of time to get readings for
-	 * @param {number} unitID The unit id that the reading should be returned in, i.e., the graphic unit
-	 * @returns {Promise<Object<number, Array<{reading: number, start_timestamp: number, end_timestamp: number}>>>} in sorted order
+	 * @param groupIDs The group IDs to get readings for
+	 * @param timeInterval The range of time to get readings for
+	 * @param unitID The unit id that the reading should be returned in, i.e., the graphic unit
+	 * @returns LineReadings in sorted order
 	 */
 	public async groupLineReadings(groupIDs: number[], timeInterval: TimeInterval, unitID: number): Promise<LineReadings> {
 		const stringifiedIDs = groupIDs.join(',');
@@ -56,11 +56,11 @@ export default class ReadingsApi {
 
 	/**
 	 * Gets bar readings for meters for the given time range
-	 * @param {number[]} meterIDs The meter IDs to get readings for
-	 * @param {TimeInterval} timeInterval The range of time to get readings for
-	 * @param {number} barWidthDays The width of the bar in days
-	 * @param {number} unitID The unit id that the reading should be returned in, i.e., the graphic unit
-	 * @returns {Promise<Object<number, Array<{reading: number, start_timestamp: number, end_timestamp: number}>>>} in sorted order
+	 * @param meterIDs The meter IDs to get readings for
+	 * @param timeInterval The range of time to get readings for
+	 * @param barWidthDays The width of the bar in days
+	 * @param unitID The unit id that the reading should be returned in, i.e., the graphic unit
+	 * @returns LineReadings in sorted order
 	 */
 	public async meterBarReadings(meterIDs: number[], timeInterval: TimeInterval, barWidthDays: number, unitID: number): Promise<BarReadings> {
 		const stringifiedIDs = meterIDs.join(',');
@@ -72,11 +72,11 @@ export default class ReadingsApi {
 
 	/**
 	 * Gets bar readings for groups for the given time range
-	 * @param {number[]} groupIDs The group IDs to get readings for
-	 * @param {TimeInterval} timeInterval The range of time to get readings for
-	 * @param {number} barWidthDays The width of the bar in days
-	 * @param {number} unitID The unit id that the reading should be returned in, i.e., the graphic unit
-	 * @returns {Promise<Object<number, Array<{reading: number, start_timestamp: number, end_timestamp: number}>>>} in sorted order
+	 * @param groupIDs The group IDs to get readings for
+	 * @param timeInterval The range of time to get readings for
+	 * @param barWidthDays The width of the bar in days
+	 * @param unitID The unit id that the reading should be returned in, i.e., the graphic unit
+	 * @returns LineReadings in sorted order
 	 */
 	public async groupBarReadings(groupIDs: number[], timeInterval: TimeInterval, barWidthDays: number, unitID: number): Promise<BarReadings> {
 		const stringifiedIDs = groupIDs.join(',');

--- a/src/client/app/utils/calculateCompare.ts
+++ b/src/client/app/utils/calculateCompare.ts
@@ -156,7 +156,7 @@ export interface ComparePeriodLabels {
 /**
  * Determines the human-readable names of a comparison period.
  * @param comparePeriod the machine-readable name of the period
- * @returns human-readable names for the compare period
+ * @returns human-readable names for the compare period as {{prev: string, current: string}}
  */
 export function getComparePeriodLabels(comparePeriod: ComparePeriod): ComparePeriodLabels {
 	switch (comparePeriod) {
@@ -176,7 +176,7 @@ export function getComparePeriodLabels(comparePeriod: ComparePeriod): ComparePer
  * Composes a label to summarize compare chart data.
  * @param change the ratio of change between the current and previous period
  * @param name the name of the entity being measured
- * @param labels the names of the periods in question
+ * @param labels the names of the periods in question as {{prev: string, current: string}}
  * @returns The label summary
  */
 export function getCompareChangeSummary(change: number, name: string, labels: ComparePeriodLabels): string {

--- a/src/client/app/utils/calculateCompare.ts
+++ b/src/client/app/utils/calculateCompare.ts
@@ -7,7 +7,7 @@ import * as moment from 'moment';
 import translate from '../utils/translate';
 
 /**
- * @enum {ComparePeriod} 'Day', 'Week' or 'FourWeeks'
+ * 'Day', 'Week' or 'FourWeeks'
  */
 export enum ComparePeriod {
 	Day = 'Day',
@@ -16,7 +16,7 @@ export enum ComparePeriod {
 }
 
 /**
- * @enum {SortingOrder} 'Alphabetical', 'Ascending' or 'Descending'
+ * 'Alphabetical', 'Ascending' or 'Descending'
  */
 export enum SortingOrder {
 	Alphabetical = 'Alphabetical',
@@ -25,8 +25,8 @@ export enum SortingOrder {
 }
 
 /**
- * @param {string} comparePeriod A string to validate as a comparePeriod
- * @returns {ComparePeriod} Validated enum
+ * @param comparePeriod A string to validate as a comparePeriod
+ * @returns Validated enum
  */
 export function validateComparePeriod(comparePeriod: string): ComparePeriod {
 	switch (comparePeriod) {
@@ -42,8 +42,8 @@ export function validateComparePeriod(comparePeriod: string): ComparePeriod {
 }
 
 /**
- * @param {string} sortingOrder A string to validate as a SortingOrder
- * @returns {SortingOrder} Validated enum
+ * @param sortingOrder A string to validate as a SortingOrder
+ * @returns Validated enum
  */
 export function validateSortingOrder(sortingOrder: string): SortingOrder {
 	switch (sortingOrder) {
@@ -60,9 +60,9 @@ export function validateSortingOrder(sortingOrder: string): SortingOrder {
 
 /**
  * Calculates a time interval for compare based on a period and moment
- * @param {ComparePeriod} comparePeriod The compare length
- * @param {moment.Moment} currentTime The current time as a moment
- * @returns {TimeInterval} The time interval for compare
+ * @param comparePeriod The compare length
+ * @param currentTime The current time as a moment
+ * @returns The time interval for compare
  */
 export function calculateCompareTimeInterval(comparePeriod: ComparePeriod, currentTime: moment.Moment): TimeInterval {
 	// begin will be the start of the compare time and end will be the end of the compare time.
@@ -102,8 +102,8 @@ export function calculateCompareTimeInterval(comparePeriod: ComparePeriod, curre
 // TODO This function does not appear to be used - should it be removed?
 /**
  * Converts a comparePeriod into a moment duration for the quality of the readings to use.
- * @param {ComparePeriod} comparePeriod The compare length
- * @returns {moment.Duration} The duration to compare
+ * @param comparePeriod The compare length
+ * @returns The duration to compare
  */
 export function calculateCompareDuration(comparePeriod: ComparePeriod): moment.Duration {
 	let compareDuration;
@@ -126,8 +126,8 @@ export function calculateCompareDuration(comparePeriod: ComparePeriod): moment.D
 
 /**
  * Calculates amount of time to shift as a moment duration
- * @param {ComparePeriod} comparePeriod The compare length
- * @returns {moment.Duration} The shift as a moment duration
+ * @param comparePeriod The compare length
+ * @returns The shift as a moment duration
  */
 export function calculateCompareShift(comparePeriod: ComparePeriod): moment.Duration {
 	let compareShift;
@@ -155,8 +155,8 @@ export interface ComparePeriodLabels {
 
 /**
  * Determines the human-readable names of a comparison period.
- * @param {ComparePeriod} comparePeriod the machine-readable name of the period
- * @returns {{prev: string, current: string}} human-readable names for the compare period
+ * @param comparePeriod the machine-readable name of the period
+ * @returns human-readable names for the compare period
  */
 export function getComparePeriodLabels(comparePeriod: ComparePeriod): ComparePeriodLabels {
 	switch (comparePeriod) {
@@ -174,10 +174,10 @@ export function getComparePeriodLabels(comparePeriod: ComparePeriod): ComparePer
 
 /**
  * Composes a label to summarize compare chart data.
- * @param {number} change the ratio of change between the current and previous period
- * @param {string} name the name of the entity being measured
- * @param {{prev: string, current: string}} labels the names of the periods in question
- * @returns {string} The label summary
+ * @param change the ratio of change between the current and previous period
+ * @param name the name of the entity being measured
+ * @param labels the names of the periods in question
+ * @returns The label summary
  */
 export function getCompareChangeSummary(change: number, name: string, labels: ComparePeriodLabels): string {
 	if (isNaN(change)) {

--- a/src/client/app/utils/calibration.ts
+++ b/src/client/app/utils/calibration.ts
@@ -68,11 +68,11 @@ export interface Dimensions {
 
 /**
  * Returns true if item (meter or group) and map and reasonably defined and false otherwise.
- * @param {number} itemID ID to be used for logging errors
- * @param {DataType} type DataType to distinguish between meter and group
- * @param {MapMetadata} map map info to check
- * @param {GPSPoint} gps GPS Point to check
- * @returns {boolean} True if map is defined with origin & opposite and meter with valid GPS
+ * @param itemID ID to be used for logging errors
+ * @param type DataType to distinguish between meter and group
+ * @param map map info to check
+ * @param gps GPS Point to check
+ * @returns True if map is defined with origin & opposite and meter with valid GPS
  */
 export function itemMapInfoOk(itemID: number, type: DataType, map: MapMetadata, gps?: GPSPoint): boolean {
 	if (map === undefined) { return false; }
@@ -86,9 +86,9 @@ export function itemMapInfoOk(itemID: number, type: DataType, map: MapMetadata, 
 
 /**
  * Returns true if point lies within the map to display on.
- * @param {Dimensions} size The map size that is being used.
- * @param {CartesianPoint} point The point being considered for display in user map grid coordinates.
- * @returns {boolean} true if within map and false otherwise.
+ * @param size The map size that is being used.
+ * @param point The point being considered for display in user map grid coordinates.
+ * @returns true if within map and false otherwise.
  */
 export function itemDisplayableOnMap(size: Dimensions, point: CartesianPoint): boolean {
 	// The user map is a rectangle that is parallel to the Plotly grid. Thus, the point
@@ -102,8 +102,8 @@ export function itemDisplayableOnMap(size: Dimensions, point: CartesianPoint): b
  * Checks if the string is a valid GPS representation. This requires it to be two numbers
  * separated by a comma and the GPS values to be within allowed values.
  * Note it causes a popup if the GPS values are not valid.
- * @param {string} input The string to check for GPS values
- * @returns {boolean} true if string is GPS and false otherwise.
+ * @param input The string to check for GPS values
+ * @returns true if string is GPS and false otherwise.
  */
 export function isValidGPSInput(input: string): boolean {
 	if (input.indexOf(',') === -1) { // if there is no comma
@@ -128,13 +128,13 @@ export function isValidGPSInput(input: string): boolean {
 
 /**
  * Calculates the GPS unit per coordinate unit.
- * @param {GPSPoint} origin The GPS value for the origin that was computed during calibration.
+ * @param origin The GPS value for the origin that was computed during calibration.
  * 	This is the bottom, left corner of the user map.
- * @param {GPSPoint} opposite The GPS value for the opposite that was computed during calibration.
+ * @param opposite The GPS value for the opposite that was computed during calibration.
  * 	This is the top, right corner of the user map.
- * @param {Dimensions} size This is the size of the normalized map image.
- * @param {number} northAngle The angle between true north and straight up on the map image.
- * @returns {MapScale} a pair {deltaX, deltaY} representing the GPS degree per unit (x, y)
+ * @param size This is the size of the normalized map image.
+ * @param northAngle The angle between true north and straight up on the map image.
+ * @returns a pair {deltaX, deltaY} representing the GPS degree per unit (x, y)
  * 	on true north map grid.
  */
 export function calculateScaleFromEndpoints(origin: GPSPoint, opposite: GPSPoint, size: Dimensions, northAngle: number): MapScale {
@@ -148,12 +148,12 @@ export function calculateScaleFromEndpoints(origin: GPSPoint, opposite: GPSPoint
 
 /**
  * Convert the gps value to the equivalent Plotly grid coordinates on user map.
- * @param {Dimensions} size The normalized size of the map
- * @param {GPSPoint} gps The GPS coordinate to convert
- * @param {GPSPoint} originGPS The GPS value of the origin on the true north map.
- * @param {MapScale} scaleOfMap The GPS degree per unit x, y on the true north map.
- * @param {number} northAngle The angle between true north and straight up on the map image.
- * @returns {CartesianPoint} x, y value of the gps point on the user map.
+ * @param size The normalized size of the map
+ * @param gps The GPS coordinate to convert
+ * @param originGPS The GPS value of the origin on the true north map.
+ * @param scaleOfMap The GPS degree per unit x, y on the true north map.
+ * @param northAngle The angle between true north and straight up on the map image.
+ * @returns x, y value of the gps point on the user map.
  */
 export function gpsToUserGrid(size: Dimensions, gps: GPSPoint, originGPS: GPSPoint, scaleOfMap: MapScale, northAngle: number): CartesianPoint {
 	// We need the origin x, y value by starting from 0, 0 on the user map and
@@ -176,10 +176,10 @@ export function gpsToUserGrid(size: Dimensions, gps: GPSPoint, originGPS: GPSPoi
  * origin and opposite points. It also calculates the relative error for this
  * scale by finding the maximum difference between the calculated scale and the
  * one from each pair of calibration points. It returns all three of these values.
- * @param {CalibratedPoint[]} calibrationSet All the points clicked by the user for calibration.
- * @param {Dimensions} imageDimensions The dimensions of the original map to use from the user.
- * @param {number} northAngle The angle between true north and straight up on the map image.
- * @returns {CalibrationResult} The error and the origin & opposite point in GPS to use for mapping.
+ * @param calibrationSet All the points clicked by the user for calibration.
+ * @param imageDimensions The dimensions of the original map to use from the user.
+ * @param northAngle The angle between true north and straight up on the map image.
+ * @returns The error and the origin & opposite point in GPS to use for mapping.
  */
 export function calibrate(calibrationSet: CalibratedPoint[], imageDimensions: Dimensions, northAngle: number): CalibrationResult {
 	// Normalize dimensions to grid used in Plotly
@@ -291,9 +291,9 @@ export function calibrate(calibrationSet: CalibratedPoint[], imageDimensions: Di
 
 /**
  * Return the change in GPS degree per unit on map grid.
- * @param {CalibratedPoint} p1 First point to use in calculation.
- * @param {CalibratedPoint} p2 Second point to use in calculation.
- * @returns {{number, number}} a pair {deltaX, deltaY} representing the GPS degree per unit (x, y) on map grid.
+ * @param p1 First point to use in calculation.
+ * @param p2 Second point to use in calculation.
+ * @returns a pair {deltaX, deltaY} representing the GPS degree per unit (x, y) on map grid.
  */
 function calculateScale(p1: CalibratedPoint, p2: CalibratedPoint) {
 	// Calculate the change in GPS longitude and x point and then use to get the GPS degree
@@ -313,8 +313,8 @@ function calculateScale(p1: CalibratedPoint, p2: CalibratedPoint) {
 
 /**
  * Normalize image dimensions to fit within the default 500*500 pixel-sized graph.
- * @param {Dimensions} dimensions The size (width, height) of the map loaded into OED
- * @returns {Dimensions} Normalized size of map so no more than 500 on either side.
+ * @param dimensions The size (width, height) of the map loaded into OED
+ * @returns Normalized size of map so no more than 500 on either side.
  */
 export function normalizeImageDimensions(dimensions: Dimensions): Dimensions {
 	let width;
@@ -337,10 +337,10 @@ export function normalizeImageDimensions(dimensions: Dimensions): Dimensions {
 
 /**
  * Shifts point by 1/2 size dimensions.
- * @param {Dimensions} size The size of the image (normally normalized map size)
- * @param {CartesianPoint} point The (x,y) pair for the point to be shifted
- * @param {number} direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
- * @returns {CartesianPoint} (x,y) pair shifted by 1/2 the width and height of map image
+ * @param size The size of the image (normally normalized map size)
+ * @param point The (x,y) pair for the point to be shifted
+ * @param direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
+ * @returns (x,y) pair shifted by 1/2 the width and height of map image
  */
 export function shift(size: Dimensions, point: CartesianPoint, direction: number): CartesianPoint {
 	// 1/2 the image sizes that will be used in shift.
@@ -356,9 +356,9 @@ export function shift(size: Dimensions, point: CartesianPoint, direction: number
 
 /**
  * Rotates point counterclockwise through angle.
- * @param {number} angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
- * @param {CartesianPoint} point (x,y) pair to rotate.
- * @returns {CartesianPoint} Rotated (x,y) pair.
+ * @param angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
+ * @param point (x,y) pair to rotate.
+ * @returns Rotated (x,y) pair.
  */
 export function rotate(angleDeg: number, point: CartesianPoint): CartesianPoint {
 	// Convert angle to radians.
@@ -373,11 +373,11 @@ export function rotate(angleDeg: number, point: CartesianPoint): CartesianPoint 
 
 /**
  * This shifts the point and then rotates by the angle. Typically used to go from user map to true north.
- * @param {Dimensions} size The size of the image (normally normalized map size)
- * @param {CartesianPoint} point The (x,y) pair for the point to be shifted & rotated
- * @param {number} direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
- * @param {number} angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
- * @returns {CartesianPoint} (x,y) pair shifted by 1/2 the width and height of map image and rotated by angleDeg
+ * @param size The size of the image (normally normalized map size)
+ * @param point The (x,y) pair for the point to be shifted & rotated
+ * @param direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
+ * @param angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
+ * @returns (x,y) pair shifted by 1/2 the width and height of map image and rotated by angleDeg
  */
 export function shiftRotate(size: Dimensions, point: CartesianPoint, direction: number, angleDeg: number): CartesianPoint {
 	// Note you typically shift because the rotation must occur around the center of the map but the plotly coordinates
@@ -390,11 +390,11 @@ export function shiftRotate(size: Dimensions, point: CartesianPoint, direction: 
 
 /**
  * This rotates the point by the angle and then shifts. Typically used to go from true north to user map.
- * @param {Dimensions} size The size of the image (normally normalized map size)
- * @param {CartesianPoint} point The (x,y) pair for the point to be rotated & shifted
- * @param {number} direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
- * @param {number} angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
- * @returns {CartesianPoint} (x,y) pair shifted by 1/2 the width and height of map image
+ * @param size The size of the image (normally normalized map size)
+ * @param point The (x,y) pair for the point to be rotated & shifted
+ * @param direction The factor to scale the shift by. Normally either +1 to add the shift or -1 to subtract.
+ * @param angleDeg Angle in degrees to rotate by. Note that positive means counterclockwise.
+ * @returns (x,y) pair shifted by 1/2 the width and height of map image
  */
 export function rotateShift(size: Dimensions, point: CartesianPoint, direction: number, angleDeg: number): CartesianPoint {
 	// Now rotate the centered image by the angle given.
@@ -409,9 +409,9 @@ export function rotateShift(size: Dimensions, point: CartesianPoint, direction: 
 /**
  * Returns the origin of the user map converted to the true north map. Note that it is in
  * in the bottom, left on the user map but in the center on the true north map.
- * @param {Dimensions} size the normalized map dimensions
- * @param {number} northAngle The angle between true north and straight up on the map image.
- * @returns {CartesianPoint} The origin coordinates on the true north map
+ * @param size the normalized map dimensions
+ * @param northAngle The angle between true north and straight up on the map image.
+ * @returns The origin coordinates on the true north map
  */
 export function trueNorthOrigin(size: Dimensions, northAngle: number): CartesianPoint {
 	// Origin coordinate on user map is (0, 0).
@@ -424,9 +424,9 @@ export function trueNorthOrigin(size: Dimensions, northAngle: number): Cartesian
  * Similar to trueNorthOrigin function but returns the opposite corner of the user map converted
  * to the true north map. Note that it is in the top, right of the user map but
  * relative to the center on the true north map.
- * @param {Dimensions} size the normalized map dimensions
- * @param {number} northAngle The angle between true north and straight up on the map image.
- * @returns {CartesianPoint} The opposite coordinates on the true north map
+ * @param size the normalized map dimensions
+ * @param northAngle The angle between true north and straight up on the map image.
+ * @returns The opposite coordinates on the true north map
  */
 export function trueNorthOpposite(size: Dimensions, northAngle: number): CartesianPoint {
 	// The opposite coordinate is the size since it is in the top, right corner

--- a/src/client/app/utils/determineCompatibleUnits.ts
+++ b/src/client/app/utils/determineCompatibleUnits.ts
@@ -15,9 +15,9 @@ import React from 'react';
 
 /**
  * The intersect operation of two sets.
- * @param {Set<number>} setA The first set.
- * @param {Set<number>} setB The second set.
- * @returns {Set<number>} The intersection of two sets.
+ * @param setA The first set.
+ * @param setB The second set.
+ * @returns The intersection of two sets.
  */
 export function setIntersect(setA: Set<number>, setB: Set<number>): Set<number> {
 	return new Set(Array.from(setA).filter(i => setB.has(i)));
@@ -25,9 +25,8 @@ export function setIntersect(setA: Set<number>, setB: Set<number>): Set<number> 
 
 /**
  * Takes a set of meter ids and returns the set of compatible unit ids.
- *
- * @param {Set<number>} meters The set of meter ids.
- * @returns {Set<number>} Set of compatible unit ids.
+ * @param meters The set of meter ids.
+ * @returns Set of compatible unit ids.
  */
 export function unitsCompatibleWithMeters(meters: Set<number>): Set<number> {
 	const state = store.getState();
@@ -63,9 +62,8 @@ export function unitsCompatibleWithMeters(meters: Set<number>): Set<number> {
 
 /**
  * Returns a set of units ids that are compatible with a specific unit id.
- *
- * @param {number} unitId The unit id.
- * @returns {Set<number>} Set of units ids that are compatible with specified unit id.
+ * @param unitId The unit id.
+ * @returns Set of units ids that are compatible with specified unit id.
  */
 export function unitsCompatibleWithUnit(unitId: number): Set<number> {
 	// unitSet starts as an empty set.
@@ -93,9 +91,8 @@ export function unitsCompatibleWithUnit(unitId: number): Set<number> {
 
 /**
  * Returns the row index in Pik for a meter unit.
- *
- * @param {number} unitId The unit id.
- * @returns {number} The row index in Pik for given meter unit.
+ * @param unitId The unit id.
+ * @returns The row index in Pik for given meter unit.
  */
 export function pRowFromUnit(unitId: number): number {
 	const state = store.getState();
@@ -108,9 +105,8 @@ export function pRowFromUnit(unitId: number): number {
 
 /**
  * Returns the unit id given the row in Pik.
- *
- * @param {number} row The row to find the associated unit.
- * @returns {number} The unit id given the row in Pik units.
+ * @param row The row to find the associated unit.
+ * @returns The unit id given the row in Pik units.
  */
 export function unitFromPRow(row: number): number {
 	const state = store.getState();
@@ -123,9 +119,8 @@ export function unitFromPRow(row: number): number {
 
 /**
  * Returns the unit id given the column in Pik.
- *
- * @param {number} column The column to find the associated unit.
- * @returns {number} The unit id given the column in Pik.
+ * @param column The column to find the associated unit.
+ * @returns The unit id given the column in Pik.
  */
 export function unitFromPColumn(column: number): number {
 	const state = store.getState();
@@ -139,9 +134,8 @@ export function unitFromPColumn(column: number): number {
 /**
  * Returns the set of meters's ids associated with the groupId used where Redux
  * state is accurate for all groups.
- *
- * @param {number} groupId The groupId.
- * @returns {Set<number>} The set of deep children of this group.
+ * @param groupId The groupId.
+ * @returns The set of deep children of this group.
  */
 export function metersInGroup(groupId: number): Set<number> {
 	const state = store.getState();
@@ -155,8 +149,8 @@ export function metersInGroup(groupId: number): Set<number> {
 /**
  * Returns array of deep meter ids of the changed group. This only works if all other groups in state
  * do not include this group.
- * @param {GroupEditData} changedGroupState The state for the changed group
- * @returns {number[]} returns array of deep meter ids of the changed group considering possible changes
+ * @param changedGroupState The state for the changed group
+ * @returns returns array of deep meter ids of the changed group considering possible changes
  */
 export function metersInChangedGroup(changedGroupState: GroupEditData): number[] {
 	const state = store.getState();
@@ -182,9 +176,9 @@ export function metersInChangedGroup(changedGroupState: GroupEditData): number[]
 
 /**
  * Get options for the meter menu on the group page.
- * @param {number} defaultGraphicUnit The groups current default graphic unit which may have been updated from what is in Redux state.
- * @param {number} deepMeters The groups current deep meters (all recursively) which may have been updated from what is in Redux state.
- * @returns {SelectOption} The current meter options for this group.
+ * @param defaultGraphicUnit The groups current default graphic unit which may have been updated from what is in Redux state.
+ * @param deepMeters The groups current deep meters (all recursively) which may have been updated from what is in Redux state.
+ * @returns The current meter options for this group.
  */
 export function getMeterMenuOptionsForGroup(defaultGraphicUnit: number, deepMeters: number[] = []): SelectOption[] {
 	// deepMeters has a default value since it is optional for the type of state but it should always be set in the code.
@@ -225,10 +219,10 @@ export function getMeterMenuOptionsForGroup(defaultGraphicUnit: number, deepMete
 
 /**
  * Get options for the group menu on the group page.
- * @param {number} groupId The id of the group being worked on.
- * @param {number} defaultGraphicUnit The group's current default graphic unit which may have been updated from what is in Redux state.
- * @param {number[]} deepMeters The group's current deep meters (all recursively) which may have been updated from what is in Redux state.
- * @returns {SelectOption} The current group options for this group.
+ * @param groupId The id of the group being worked on.
+ * @param defaultGraphicUnit The group's current default graphic unit which may have been updated from what is in Redux state.
+ * @param deepMeters The group's current deep meters (all recursively) which may have been updated from what is in Redux state.
+ * @returns The current group options for this group.
  */
 export function getGroupMenuOptionsForGroup(groupId: number, defaultGraphicUnit: number, deepMeters: number[] = []): SelectOption[] {
 	// deepMeters has a default value since it is optional for the type of state but it should always be set in the code.
@@ -285,12 +279,12 @@ export const enum GroupCase {
 
 /**
  * Return the case associated if we add the given meter/group to a group.
- * @param {Set<number>} currentUnits The current compatible units of the group.
- * @param {number} idToAdd The meter/group's id to add to the group.
- * @param {DataType} type Can be METER or GROUP.
- * @param {number} currentDefaultGraphicUnit The default graphic unit for group changing
- * @param {number[]} deepMeters The deep meters for the group, ignored if meter
- * @returns {GroupCase} the type of change this involves.
+ * @param currentUnits The current compatible units of the group.
+ * @param idToAdd The meter/group's id to add to the group.
+ * @param type Can be METER or GROUP.
+ * @param currentDefaultGraphicUnit The default graphic unit for group changing
+ * @param deepMeters The deep meters for the group, ignored if meter
+ * @returns the type of change this involves.
  */
 export function getCompatibilityChangeCase(currentUnits: Set<number>, idToAdd: number, type: DataType,
 	currentDefaultGraphicUnit: number, deepMeters: number[]): GroupCase {
@@ -302,10 +296,10 @@ export function getCompatibilityChangeCase(currentUnits: Set<number>, idToAdd: n
 
 /**
  * Given a meter or group's id, returns its compatible units.
- * @param {number} id The meter or group's id.
- * @param {DataType} type Can be Meter or Group.
- * @param {number[]} deepMeters The deep meter of the id if it is a group, ignored if meter.
- * @returns {Set<number>} Set of ids of compatible units.
+ * @param id The meter or group's id.
+ * @param type Can be Meter or Group.
+ * @param deepMeters The deep meter of the id if it is a group, ignored if meter.
+ * @returns Set of ids of compatible units.
  */
 function getCompatibleUnits(id: number, type: DataType, deepMeters: number[]): Set<number> {
 	if (type == DataType.Meter) {
@@ -322,10 +316,10 @@ function getCompatibleUnits(id: number, type: DataType, deepMeters: number[]): S
 
 /**
  * Returns the group case given current units and new units. See the enum GroupCase for the list of possible cases.
- * @param {Set<number>} currentUnits The current compatible units set.
- * @param {Set<number>} newUnits The new compatible units set.
- * @param {number} defaultGraphicUnit The default graphic unit.
- * @returns {GroupCase} of impact on units from current to new unit sets.
+ * @param currentUnits The current compatible units set.
+ * @param newUnits The new compatible units set.
+ * @param defaultGraphicUnit The default graphic unit.
+ * @returns of impact on units from current to new unit sets.
  */
 function groupCase(currentUnits: Set<number>, newUnits: Set<number>, defaultGraphicUnit: number): GroupCase {
 	// The compatible units of a set of meters or groups is the intersection of the compatible units for each.
@@ -349,8 +343,8 @@ function groupCase(currentUnits: Set<number>, newUnits: Set<number>, defaultGrap
 
 /**
  * Returns the styling for the menu for the type of change in in GroupCase
- * @param {GroupCase} compatibilityChangeCase Which GroupCase is involved.
- * @returns {React.CSSProperties} the desired color for styling.
+ * @param compatibilityChangeCase Which GroupCase is involved.
+ * @returns the desired color for styling.
  */
 function getMenuOptionFont(compatibilityChangeCase: GroupCase): React.CSSProperties {
 	switch (compatibilityChangeCase) {

--- a/src/client/app/utils/determineCompatibleUnits.ts
+++ b/src/client/app/utils/determineCompatibleUnits.ts
@@ -150,7 +150,7 @@ export function metersInGroup(groupId: number): Set<number> {
  * Returns array of deep meter ids of the changed group. This only works if all other groups in state
  * do not include this group.
  * @param changedGroupState The state for the changed group
- * @returns returns array of deep meter ids of the changed group considering possible changes
+ * @returns array of deep meter ids of the changed group considering possible changes
  */
 export function metersInChangedGroup(changedGroupState: GroupEditData): number[] {
 	const state = store.getState();

--- a/src/client/app/utils/durationFormat.ts
+++ b/src/client/app/utils/durationFormat.ts
@@ -7,8 +7,8 @@ import * as moment from 'moment';
 /**
  * Returns the string interval formatted for display. Normally this
  * is the interval returned by Postgres.
- * @param {string} durationPassed The moment duration to format
- * @returns {string} formatted with day(s) hh:mm:ss.
+ * @param durationPassed The moment duration to format
+ * @returns formatted with day(s) hh:mm:ss.
  */
 export function durationFormat(durationPassed: string): string {
 	// Convert the string to milliseconds via moment Duration.

--- a/src/client/app/utils/exportData.ts
+++ b/src/client/app/utils/exportData.ts
@@ -8,12 +8,11 @@ import { ChartTypes } from '../types/redux/graph';
 
 /**
  * Function to converts the meter readings into a CSV formatted string.
- *
- * @param {LineReading[]} readings The meter readings.
- * @param {string} meter the meter identifier for data being exported
- * @param {string} unitLabel the full y-axis label on the graphic
- * @param {number} scaling factor to scale readings by, normally the rate factor for line or 1
- * @returns {string} output A string containing the CSV formatted meter readings.
+ * @param readings The meter readings.
+ * @param meter the meter identifier for data being exported
+ * @param unitLabel the full y-axis label on the graphic
+ * @param scaling factor to scale readings by, normally the rate factor for line or 1
+ * @returns A string containing the CSV formatted meter readings.
  */
 function convertToCSV(readings: LineReading[], meter: string, unitLabel: string, scaling: number) {
 	let csvOutput = `Readings,Start Timestamp, End Timestamp, Meter name, ${meter}, Unit, ${unitLabel}\n`;
@@ -32,9 +31,8 @@ function convertToCSV(readings: LineReading[], meter: string, unitLabel: string,
 
 /**
  * Function to download the formatted CSV file to the users computer.
- *
- * @param {string} inputCSV A String containing the formatted CSV data.
- * @param {string} fileName A string representing the name of the file.
+ * @param inputCSV A String containing the formatted CSV data.
+ * @param fileName A string representing the name of the file.
  */
 function downloadCSV(inputCSV: string, fileName: string) {
 	const element = document.createElement('a');
@@ -51,13 +49,12 @@ function downloadCSV(inputCSV: string, fileName: string) {
 
 /**
  * Function to export readings from the graph currently displaying. May be used for routing if more export options are added
- *
- * @param {LineReading[]} readings The readings from the meter to export the graphic points.
- * @param {string} meter the meter identifier for data being exported
- * @param {string} unitLabel the full y-axis label on the graphic
- * @param {string} unitIdentifier the unit identifier for data being exported
- * @param {ChartTypes} chartName the name of the chart/graphic being exported
- * @param {number} scaling factor to scale readings by, normally the rate factor for line or 1
+ * @param readings The readings from the meter to export the graphic points.
+ * @param meter the meter identifier for data being exported
+ * @param unitLabel the full y-axis label on the graphic
+ * @param unitIdentifier the unit identifier for data being exported
+ * @param chartName the name of the chart/graphic being exported
+ * @param scaling factor to scale readings by, normally the rate factor for line or 1
  */
 export default function graphExport(readings: LineReading[], meter: string, unitLabel: string, unitIdentifier: string,
 	chartName: ChartTypes, scaling: number) {
@@ -83,10 +80,9 @@ export default function graphExport(readings: LineReading[], meter: string, unit
 
 /**
  * Function to export raw data that we request on button click
- *
- * @param {RawReadings[]} readings list of readings directly from the database
- * @param {string} meter the meter identifier for data being exported
- * @param {string} unit the unit identifier for data being exported
+ * @param readings list of readings directly from the database
+ * @param meter the meter identifier for data being exported
+ * @param unit the unit identifier for data being exported
  */
 export function downloadRawCSV(readings: RawReadings[], meter: string, unit: string) {
 	// It is possible that some meters have not readings so skip if do. This can happen if resize the range of dates (or no data).

--- a/src/client/app/utils/getAreaUnitConversion.ts
+++ b/src/client/app/utils/getAreaUnitConversion.ts
@@ -11,9 +11,9 @@ export enum AreaUnitType {
 /**
  * Gets the conversion between two area units
  * NOTE: See earlier version of this function for a way to support more units
- * @param {AreaUnitType} fromUnit unit to convert FROM
- * @param {AreaUnitType} toUnit unit to convert TO
- * @returns {number} conversion multiplier, or zero if conversion to none
+ * @param fromUnit unit to convert FROM
+ * @param toUnit unit to convert TO
+ * @returns conversion multiplier, or zero if conversion to none
  */
 export function getAreaUnitConversion(fromUnit: AreaUnitType, toUnit: AreaUnitType): number {
 	if (fromUnit === toUnit) {

--- a/src/client/app/utils/getGraphColor.ts
+++ b/src/client/app/utils/getGraphColor.ts
@@ -28,11 +28,10 @@ const graphColorsReversed = [...graphColors].reverse();
 
 /**
  * Selects a color from the graphColor array based based on the type of data to be graphed
- *
- * @param {number} colorID the number of the meter or group to be graphed. Starts at '1' for both meters and groups
+ * @param colorID the number of the meter or group to be graphed. Starts at '1' for both meters and groups
  * and increases as more meters or groups respectively need to be graphed.
- * @param {DataType} type either 'DataType.Meter' or 'DataType.Group' depending on the type of the data to be graphed
- * @returns {string} Hex color
+ * @param type either 'DataType.Meter' or 'DataType.Group' depending on the type of the data to be graphed
+ * @returns Hex color
  */
 export default function getGraphColor(colorID: number, type: DataType): string {
 	// Shifts indices of positive IDs down by 1 since expect IDs to start at 1, and additionally maps unlikely

--- a/src/client/app/utils/getPage.ts
+++ b/src/client/app/utils/getPage.ts
@@ -4,8 +4,7 @@
 
 /**
  * Returns the current page route
- *
- * @returns {string} return url
+ * @returns return url
  */
 export default function getPage(): string {
 	const urlArr = window.location.href.split('/');

--- a/src/client/app/utils/getPage.ts
+++ b/src/client/app/utils/getPage.ts
@@ -4,7 +4,7 @@
 
 /**
  * Returns the current page route
- * @returns return url
+ * @returns current page name as a string
  */
 export default function getPage(): string {
 	const urlArr = window.location.href.split('/');

--- a/src/client/app/utils/graphics.ts
+++ b/src/client/app/utils/graphics.ts
@@ -11,12 +11,11 @@ import { AreaUnitType } from './getAreaUnitConversion';
 
 /**
  * Returns the y-axis label for a line graph and whether the rate needs scaling
- *
- * @param {UnitData} selectUnitState The unit state for the selected unit for graphing
- * @param {LineGraphRate} currentSelectedRate The current selected rate
- * @param {boolean} areaNormalization Whether area normalization is enabled
- * @param {AreaUnitType} selectedAreaUnit The currently selected area unit to normalize to
- * @returns {{unitLabel: string, needsRateScaling: boolean}} y-axis label and boolean of whether rate needs to be scaled (true if does)
+ * @param selectUnitState The unit state for the selected unit for graphing
+ * @param currentSelectedRate The current selected rate
+ * @param areaNormalization Whether area normalization is enabled
+ * @param selectedAreaUnit The currently selected area unit to normalize to
+ * @returns y-axis label and boolean of whether rate needs to be scaled (true if does)
  */
 export function lineUnitLabel(selectUnitState: UnitData, currentSelectedRate: LineGraphRate, areaNormalization: boolean,
 	selectedAreaUnit: AreaUnitType): { unitLabel: string, needsRateScaling: boolean } {
@@ -55,11 +54,10 @@ export function lineUnitLabel(selectUnitState: UnitData, currentSelectedRate: Li
 
 /**
  * Returns the y-axis label for a bar graph
- *
- * @param {UnitData} selectUnitState The unit state for the selected unit for graphing
- * @param {boolean} areaNormalization Whether or not area normalization is enabled
- * @param {AreaUnitType} selectedAreaUnit The currently selected area unit
- * @returns {string} y-axis label
+ * @param selectUnitState The unit state for the selected unit for graphing
+ * @param areaNormalization Whether or not area normalization is enabled
+ * @param selectedAreaUnit The currently selected area unit
+ * @returns y-axis label
  */
 export function barUnitLabel(selectUnitState: UnitData, areaNormalization: boolean, selectedAreaUnit: AreaUnitType): string {
 	let unitLabel: string = '';

--- a/src/client/app/utils/hasPermissions.ts
+++ b/src/client/app/utils/hasPermissions.ts
@@ -6,10 +6,9 @@ import { UserRole } from '../types/items';
 
 /**
  * Checks if the user has the permissions of a given role.
- *
- * @param {UserRole} user User role to evaluate
- * @param {UserRole} compareTo User role to compare to
- * @returns {boolean} Whether or not the user has the compareTo role
+ * @param user User role to evaluate
+ * @param compareTo User role to compare to
+ * @returns Whether or not the user has the compareTo role
  */
 export function hasPermissions(user: UserRole, compareTo: UserRole): boolean {
 	// Admins always have any other role.
@@ -18,9 +17,8 @@ export function hasPermissions(user: UserRole, compareTo: UserRole): boolean {
 
 /**
  * Checks if user is an Admin.
- *
- * @param {UserRole} user User role to evaluate
- * @returns {boolean} Whether or not user is an admin
+ * @param user User role to evaluate
+ * @returns Whether or not user is an admin
  */
 export function isRoleAdmin(user: UserRole): boolean {
 	return user === UserRole.ADMIN;

--- a/src/client/app/utils/input.ts
+++ b/src/client/app/utils/input.ts
@@ -13,7 +13,7 @@ import * as _ from 'lodash';
 // Use a function so can easily change how it works.
 /**
  * Causes a window popup with msg
- * @param {string} msg message to display
+ * @param msg message to display
  */
 export function notifyUser(msg: string) {
 	window.alert(msg);
@@ -21,8 +21,8 @@ export function notifyUser(msg: string) {
 
 /**
  * get string value from GPSPoint or null.
- * @param {GPSPoint | null} gps GPS point to get value from and can be null
- * @returns {string} to represent the GPS value or empty string if null
+ * @param gps GPS point to get value from and can be null
+ * @returns to represent the GPS value or empty string if null
  */
 export function getGPSString(gps: GPSPoint | null) {
 	if (gps === null) {
@@ -45,8 +45,8 @@ export function getGPSString(gps: GPSPoint | null) {
  * Checks if the input is null and returns empty string if that is the case. Otherwise return input.
  * This is needed because React does not want values to be of type null for display and null is the
  * state for some of DB values. This only should change what is displayed and not the state or props.
- * @param {*} item item to check if null and convert to empty string
- * @returns {string} item if not null or empty string
+ * @param item item to check if null and convert to empty string
+ * @returns item if not null or empty string
  */
 export function nullToEmptyString(item: any) {
 	if (item === null) {
@@ -59,8 +59,8 @@ export function nullToEmptyString(item: any) {
 /**
  * Calculates the set of all possible graphic units for a meter/group.
  * This is any unit that is of type unit or suffix.
- * @param {UnitDataById} units candidate graphic units
- * @returns {Set<UnitData>} The set of all possible graphic units for a meter/group
+ * @param units candidate graphic units
+ * @returns The set of all possible graphic units for a meter/group
  */
 export function potentialGraphicUnits(units: UnitDataById) {
 	// Set of possible graphic units
@@ -97,7 +97,7 @@ export const NoUnit: UnitData = {
 
 /**
  * The enum is fine if don't want translation but this is dynamic so translation works.
- * @returns {UnitData} a unit to represent no unit with translated identifier
+ * @returns a unit to represent no unit with translated identifier
  */
 export function noUnitTranslated(): UnitData {
 	// Untranslated no unit.

--- a/src/client/app/utils/notifications.ts
+++ b/src/client/app/utils/notifications.ts
@@ -10,10 +10,9 @@ export type NotificationPosition = 'tr' | 'tl' | 'tc' | 'br' | 'bl' | 'bc';
 
 /**
  * Show user the success notification
- *
- * @param {TranslatedString} message translation identifier for message to display
- * @param {NotificationPosition} position screen position for notification where top, right is the default
- * @param {number} autoDismiss seconds until notification goes away with default of 3 seconds
+ * @param message translation identifier for message to display
+ * @param position screen position for notification where top, right is the default
+ * @param autoDismiss seconds until notification goes away with default of 3 seconds
  */
 export function showSuccessNotification(message: TranslatedString, position: NotificationPosition = 'tr', autoDismiss = 3) {
 	store.dispatch(showNotificationAction({
@@ -26,10 +25,9 @@ export function showSuccessNotification(message: TranslatedString, position: Not
 
 /**
  * Show user the error notification
- *
- * @param {TranslatedString} message translation identifier for message to display
- * @param {NotificationPosition} position screen position for notification where top, right is the default
- * @param {number} autoDismiss seconds until notification goes away with default of 3 seconds
+ * @param message translation identifier for message to display
+ * @param position screen position for notification where top, right is the default
+ * @param autoDismiss seconds until notification goes away with default of 3 seconds
  */
 export function showErrorNotification(message: TranslatedString, position: NotificationPosition = 'tr', autoDismiss = 15) {
 	store.dispatch(showNotificationAction({

--- a/src/client/app/utils/token.ts
+++ b/src/client/app/utils/token.ts
@@ -4,8 +4,7 @@
 
 /**
  * Get Token from local storage
- *
- * @returns {string} if found token, return it, otherwise, throw error
+ * @returns if found token, return it, otherwise, throw error
  */
 export function getToken(): string {
 	const token = localStorage.getItem('token');
@@ -17,8 +16,7 @@ export function getToken(): string {
 
 /**
  * Check if there is a Token in local storage
- *
- * @returns {boolean} If there is a Token, return True; otherwise return false
+ * @returns If there is a Token, return True; otherwise return false
  */
 export function hasToken(): boolean {
 	try {

--- a/src/client/app/utils/translate.ts
+++ b/src/client/app/utils/translate.ts
@@ -15,9 +15,8 @@ export type TranslatedString = string;
 
 /**
  * Translate a message
- *
- * @param {string} messageID identifier for a message
- * @returns {TranslatedString} get translated string from original string
+ * @param messageID identifier for a message
+ * @returns get translated string from original string
  */
 export default function translate(messageID: string): TranslatedString {
 


### PR DESCRIPTION
# Description

Merging #949 caused a few issues with jsdoc, and while resolving those I had a look through the package documentation. There is a specific recommended ruleset for typescript, which is different from what OED was using. This ruleset removes the need for types in jsdoc headers, as they are redundant since typescript is a typed language.
I also took the chance to use eslint overrides to disable jsdoc as a rule for actions, reducers, and containers, instead of disabling jsdoc on a per-file basis. This allows easier control over the rules for these files as a group.

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
