### PR TITLE
fix bug where pik size is wrong

### DIFF
--- a/src/server/models/Cik.js
+++ b/src/server/models/Cik.js
@@ -54,11 +54,11 @@ class Cik {
 	 * Returns Pik array based on Cik values in the database.
 	 */
 	static async getPik(conn) {
-		// Get the max index for Cik rows and columns. Length is one greater.
+		// Get the max index for pik rows and columns. Length is one greater.
 		let temp;
-		temp = await conn.one(sqlFile('cik/get_number_rows.sql'));
+		temp = await conn.one(sqlFile('unit/get_max_meter_row_index.sql'));
 		const numRows = temp.max + 1;
-		temp = await conn.one(sqlFile('cik/get_number_columns.sql'));
+		temp = await conn.one(sqlFile('unit/get_max_non_meter_row_index.sql'));
 		const numColumns = temp.max + 1;
 		// Fill the Pik with false values.
 		let pik = new Array(numRows).fill(0).map(() => new Array(numColumns).fill(false));

--- a/src/server/sql/cik/get_number_columns.sql
+++ b/src/server/sql/cik/get_number_columns.sql
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 -- Returns the maximum index for any column in cik (Cik).
--- Since columns start at 0 and increase by 1 each time this is the
--- number of columns in the cik table minus 1.
+-- See units/get_max_non_meter_row_index.sql on why this may not be the
+-- number of columns desired in pik.
+-- This is likely legacy code that will not be used in the future.
 SELECT MAX(column_index) FROM cik;

--- a/src/server/sql/cik/get_number_rows.sql
+++ b/src/server/sql/cik/get_number_rows.sql
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 -- Returns the maximum index for any row in cik (Cik).
--- Since rows start at 0 and increase by 1 each time this is the
--- number of rows in the cik table minus 1.
+-- See units/get_max_meter_row_index.sql on why this may not be the
+-- number of rows desired in pik.
+-- This is likely legacy code that will not be used in the future.
 SELECT MAX(row_index) FROM cik;

--- a/src/server/sql/unit/get_max_meter_row_index.sql
+++ b/src/server/sql/unit/get_max_meter_row_index.sql
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+-- Returns the maximum row index for any meter.
+-- Since rows start at 0 and increase by 1 each time this is the
+-- number of rows - 1 desired in the pik table.
+-- This can differ from the number of rows in cik if there is a unit
+-- that has no conversion that is a higher index than one with a conversion.
+SELECT MAX(unit_index) FROM units WHERE type_of_unit = 'meter'::unit_type;

--- a/src/server/sql/unit/get_max_non_meter_row_index.sql
+++ b/src/server/sql/unit/get_max_non_meter_row_index.sql
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+-- Returns the maximum column index for any non-meter.
+-- Since columns start at 0 and increase by 1 each time this is the
+-- number of columns - 1 desired in the pik table.
+-- This can differ from the number of columns in cik if there is a unit
+-- that has no conversion that is a higher index than one with a conversion.
+SELECT MAX(unit_index) FROM units WHERE type_of_unit <> 'meter'::unit_type;


### PR DESCRIPTION
# Description

This removes a bug where the size of pik was too small so the unit_index could cause an index out of bounds. The problem is that if a unit without any conversions has a higher row/column unit_index than ones that do then no entry is put in the cik table in the DB. Since the max meter/non-meter index was assumed to be the max unit_index it caused a failure. This is not common but can be reproduced as follows:

1. Create a unit of type meter and save.
2. Look at the database to see if the redo of cik caused this unit to have a unit_index that is the greatest. You can see this with ```select * from units where type_of_unit = 'meter';```. If not, redo the first step until this happens. (Doing an ```npm run updateCikAndViews``` can also cause the issue.)
3. Refresh OED in the web browser.
4. Login as an admin.
5. Go to the meters page. It will show a blank screen and there will be an error in the console about accessing pik with unknown as the index.

This will no longer happen after this fix because it checks the unit_index in the units table rather than using the cik table.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None but this should all go away once we put cik in Redux state so we are not using an array.
