### PR TITLE
fix enum bug in CSV upload

### DIFF
--- a/src/server/services/csvPipeline/validateCsvUploadParams.js
+++ b/src/server/services/csvPipeline/validateCsvUploadParams.js
@@ -169,7 +169,6 @@ function validateRequestParams(body, schema) {
  */
 function validateReadingsCsvUploadParams(req, res, next) {
 	// Validate the parameters of the request. Failure out if there are any unintended mistakes such as additional parameters and typos.
-	console.log('validateMetersCsvUploadParams: ', req.body);
 	const { responseMessage, success } = validateRequestParams(req.body, VALIDATION.readings);
 	if (!success) {
 		failure(req, res, new CSVPipelineError(responseMessage));

--- a/src/server/services/csvPipeline/validateCsvUploadParams.js
+++ b/src/server/services/csvPipeline/validateCsvUploadParams.js
@@ -37,8 +37,8 @@ MeterTimeSortTypesJS = Object.freeze({
  * @enum {string}
  */
 BooleanTypesJS = Object.freeze({
-	true: 'true',
-	false: 'false',
+	true: 'yes',
+	false: 'no',
 	// meter means to use value stored on meter or the default if not.
 	meter: 'meter value or default'
 });
@@ -169,6 +169,7 @@ function validateRequestParams(body, schema) {
  */
 function validateReadingsCsvUploadParams(req, res, next) {
 	// Validate the parameters of the request. Failure out if there are any unintended mistakes such as additional parameters and typos.
+	console.log('validateMetersCsvUploadParams: ', req.body);
 	const { responseMessage, success } = validateRequestParams(req.body, VALIDATION.readings);
 	if (!success) {
 		failure(req, res, new CSVPipelineError(responseMessage));


### PR DESCRIPTION
# Description

BooleanTypesJS differed from BooleanTypes in src/client/app/types/csvUploadForm.ts and per comment this is wrong. As a result, cumulative, cumulative reset and end only did not work if a menu value was changed on CSV upload. Thanks to @spearec for locating this issue.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

None known
