### PR TITLE
properly update moment locale based on selectedLanguage

### DIFF
--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -95,9 +95,11 @@ function fetchPreferences(): Thunk {
 					dispatch2(toggleAreaNormalization());
 				}
 				if (preferences.defaultLanguage !== state.options.selectedLanguage) {
+					// if the site default differs from the selected language, update the selected language and the locale
 					dispatch2(updateSelectedLanguage(preferences.defaultLanguage));
 					moment.locale(preferences.defaultLanguage);
 				} else {
+					// else set moment locale to site default
 					moment.locale(getState().admin.defaultLanguage);
 				}
 			});

--- a/src/client/app/actions/admin.ts
+++ b/src/client/app/actions/admin.ts
@@ -45,7 +45,6 @@ export function updateDefaultAreaUnit(defaultAreaUnit: AreaUnitType): t.UpdateDe
 }
 
 export function updateDefaultLanguage(defaultLanguage: LanguageTypes): t.UpdateDefaultLanguageAction {
-	moment.locale(defaultLanguage);
 	return { type: ActionType.UpdateDefaultLanguage, defaultLanguage };
 }
 
@@ -85,7 +84,6 @@ function fetchPreferences(): Thunk {
 		dispatch(requestPreferences());
 		const preferences = await preferencesApi.getPreferences();
 		dispatch(receivePreferences(preferences));
-		moment.locale(getState().admin.defaultLanguage);
 		if (!getState().graph.hotlinked) {
 			dispatch((dispatch2: Dispatch) => {
 				const state = getState();
@@ -98,6 +96,9 @@ function fetchPreferences(): Thunk {
 				}
 				if (preferences.defaultLanguage !== state.options.selectedLanguage) {
 					dispatch2(updateSelectedLanguage(preferences.defaultLanguage));
+					moment.locale(preferences.defaultLanguage);
+				} else {
+					moment.locale(getState().admin.defaultLanguage);
 				}
 			});
 		}

--- a/src/client/app/actions/options.ts
+++ b/src/client/app/actions/options.ts
@@ -2,10 +2,12 @@
   * License, v. 2.0. If a copy of the MPL was not distributed with this
   * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import * as moment from 'moment';
 import { ActionType } from '../types/redux/actions';
 import { LanguageTypes } from '../types/redux/i18n';
 import * as t from '../types/redux/options';
 
 export function updateSelectedLanguage(selectedLanguage: LanguageTypes): t.UpdateSelectedLanguageAction {
+	moment.locale(selectedLanguage);
 	return {type: ActionType.UpdateSelectedLanguage, selectedLanguage };
 }


### PR DESCRIPTION
# Description

Updates moment locale based on selectedLanguage instead of defaultLanguage. This was an oversight in the reactstrap PR.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
