### PR TITLE
export, line & misc fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-energy-dashboard",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "private": false,
   "license": "MPL-2.0",
   "repository": "https://github.com/OpenEnergyDashboard/OED",

--- a/src/client/app/components/ExportComponent.tsx
+++ b/src/client/app/components/ExportComponent.tsx
@@ -15,7 +15,7 @@ import { hasToken } from '../utils/token';
 import { usersApi } from '../utils/api'
 import { UserRole } from '../types/items';
 import translate from '../utils/translate';
-import { ChartTypes } from '../types/redux/graph';
+import { ChartTypes, MeterOrGroup } from '../types/redux/graph';
 import { lineUnitLabel, barUnitLabel } from '../utils/graphics';
 import { ConversionData } from '../types/redux/conversions';
 import { AreaUnitType, getAreaUnitConversion } from '../utils/getAreaUnitConversion';
@@ -55,20 +55,22 @@ export default function ExportComponent() {
 			// Get the full y-axis unit label for a line
 			const returned = lineUnitLabel(unitsState[unitId], graphState.lineGraphRate, graphState.areaNormalization, graphState.selectedAreaUnit);
 			const unitLabel = returned.unitLabel
+			// The rate will be 1 if it is per hour (since state readings are per hour) or no rate scaling so no change.
+			const rateScaling = returned.needsRateScaling ? graphState.lineGraphRate.rate : 1;
 			// Loop over the displayed meters and export one-by-one.  Does nothing if no meters selected.
 			for (const meterId of graphState.selectedMeters) {
+				const meterArea = metersState[meterId].area;
 				// export if area normalization is off or the meter can be normalized
-				if (!graphState.areaNormalization || (metersState[meterId].area > 0 && metersState[meterId].areaUnit !== AreaUnitType.none)) {
+				if (!graphState.areaNormalization || (meterArea > 0 && metersState[meterId].areaUnit !== AreaUnitType.none)) {
 					// Line readings data for this meter.
 					const byMeterID = readingsState.line.byMeterID[meterId];
 					// Make sure it exists in case state is not there yet.
 					if (byMeterID !== undefined) {
-						// The selected rate for scaling
-						let scaling = graphState.lineGraphRate.rate;
-						if (graphState.areaNormalization) {
-							// convert the meter area into the proper unit, if needed
-							scaling *= getAreaUnitConversion(metersState[meterId].areaUnit, graphState.selectedAreaUnit);
-						}
+						// Convert the meter area into the proper unit if normalizing by area or use 1 if not so won't change reading values.
+						const areaScaling = graphState.areaNormalization ?
+							meterArea * getAreaUnitConversion(metersState[meterId].areaUnit, graphState.selectedAreaUnit) : 1;
+						// Divide areaScaling into the rate so have complete scaling factor for readings.
+						const scaling = rateScaling / areaScaling;
 						// Get the readings for the time range and unit graphed
 						const byTimeInterval = byMeterID[timeInterval.toString()];
 						if (byTimeInterval !== undefined) {
@@ -84,7 +86,7 @@ export default function ExportComponent() {
 								const sortedReadings = _.sortBy(readings, item => item.startTimestamp, 'asc');
 								// Identifier for current meter.
 								const meterIdentifier = metersState[meterId].identifier;
-								graphExport(sortedReadings, meterIdentifier, unitLabel, unitIdentifier, chartName, scaling);
+								graphExport(sortedReadings, meterIdentifier, unitLabel, unitIdentifier, chartName, scaling, MeterOrGroup.meter);
 							}
 						}
 					}
@@ -92,18 +94,19 @@ export default function ExportComponent() {
 			}
 			// Loop over the displayed groups and export one-by-one.  Does nothing if no groups selected.
 			for (const groupId of graphState.selectedGroups) {
+				const groupArea = groupsState[groupId].area;
 				// export if area normalization is off or the group can be normalized
-				if (!graphState.areaNormalization || (groupsState[groupId].area > 0 && groupsState[groupId].areaUnit !== AreaUnitType.none)) {
+				if (!graphState.areaNormalization || (groupArea > 0 && groupsState[groupId].areaUnit !== AreaUnitType.none)) {
 					// Line readings data for this group.
 					const byGroupID = readingsState.line.byGroupID[groupId];
 					// Make sure it exists in case state is not there yet.
 					if (byGroupID !== undefined) {
-						// The selected rate for scaling
-						let scaling = graphState.lineGraphRate.rate;
-						if (graphState.areaNormalization) {
-							// convert the meter area into the proper unit, if needed
-							scaling *= getAreaUnitConversion(groupsState[groupId].areaUnit, graphState.selectedAreaUnit);
-						}
+						// Convert the group area into the proper unit if normalizing by area or use 1 if not so won't change reading values.
+						const areaScaling = graphState.areaNormalization ?
+							groupArea * getAreaUnitConversion(groupsState[groupId].areaUnit, graphState.selectedAreaUnit) : 1;
+						// Divide areaScaling into the rate so have complete scaling factor for readings.
+						const scaling = rateScaling / areaScaling;
+
 						// Get the readings for the time range and unit graphed
 						const byTimeInterval = byGroupID[timeInterval.toString()];
 						if (byTimeInterval !== undefined) {
@@ -119,7 +122,7 @@ export default function ExportComponent() {
 								const sortedReadings = _.sortBy(readings, item => item.startTimestamp, 'asc');
 								// Identifier for current group.
 								const groupName = groupsState[groupId].name;
-								graphExport(sortedReadings, groupName, unitLabel, unitIdentifier, chartName, scaling);
+								graphExport(sortedReadings, groupName, unitLabel, unitIdentifier, chartName, scaling, MeterOrGroup.group);
 							}
 						}
 					}
@@ -162,7 +165,7 @@ export default function ExportComponent() {
 									const sortedReadings = _.sortBy(readings, item => item.startTimestamp, 'asc');
 									// Identifier for current meter.
 									const meterIdentifier = metersState[meterId].identifier;
-									graphExport(sortedReadings, meterIdentifier, unitLabel, unitIdentifier, chartName, scaling);
+									graphExport(sortedReadings, meterIdentifier, unitLabel, unitIdentifier, chartName, scaling, MeterOrGroup.meter);
 								}
 							}
 						}
@@ -200,7 +203,7 @@ export default function ExportComponent() {
 									const sortedReadings = _.sortBy(readings, item => item.startTimestamp, 'asc');
 									// Identifier for current group.
 									const groupName = groupsState[groupId].name;
-									graphExport(sortedReadings, groupName, unitLabel, unitIdentifier, chartName, scaling);
+									graphExport(sortedReadings, groupName, unitLabel, unitIdentifier, chartName, scaling, MeterOrGroup.group);
 								}
 							}
 						}

--- a/src/client/app/containers/LineChartContainer.ts
+++ b/src/client/app/containers/LineChartContainer.ts
@@ -70,8 +70,6 @@ function mapStateToProps(state: State) {
 					const yData: number[] = [];
 					const hoverText: string[] = [];
 					const readings = _.values(readingsData.readings);
-					// The scaling is the factor to change the reading by. It divides by the area while will be 1 if no scaling by area.
-					// const scaling = currentSelectedRate.rate / meterArea;
 					readings.forEach(reading => {
 						// As usual, we want to interpret the readings in UTC. We lose the timezone as this as the start/endTimestamp
 						// are equivalent to Unix timestamp in milliseconds.
@@ -128,12 +126,14 @@ function mapStateToProps(state: State) {
 		// may not yet be in state so verify with the second condition on the if.
 		// Note the second part may not be used based on next checks but do here since simple.
 		if (byGroupID !== undefined && byGroupID[timeInterval.toString()] !== undefined) {
-			let groupArea = state.groups.byGroupID[groupID].area;
+			const groupArea = state.groups.byGroupID[groupID].area;
+			// We either don't care about area, or we do in which case there needs to be a nonzero area.
 			if (!state.graph.areaNormalization || (groupArea > 0 && state.groups.byGroupID[groupID].areaUnit != AreaUnitType.none)) {
-				if (state.graph.areaNormalization) {
-					// convert the meter area into the proper unit, if needed
-					groupArea *= getAreaUnitConversion(state.groups.byGroupID[groupID].areaUnit, state.graph.selectedAreaUnit);
-				}
+				// Convert the group area into the proper unit if normalizing by area or use 1 if not so won't change reading values.
+				const areaScaling = state.graph.areaNormalization ?
+					groupArea * getAreaUnitConversion(state.groups.byGroupID[groupID].areaUnit, state.graph.selectedAreaUnit) : 1;
+				// Divide areaScaling into the rate so have complete scaling factor for readings.
+				const scaling = rateScaling / areaScaling;
 				const readingsData = byGroupID[timeInterval.toString()][unitID];
 				if (readingsData !== undefined && !readingsData.isFetching) {
 					const label = state.groups.byGroupID[groupID].name;
@@ -147,39 +147,19 @@ function mapStateToProps(state: State) {
 					const yData: number[] = [];
 					const hoverText: string[] = [];
 					const readings = _.values(readingsData.readings);
-					// Check if reading needs scaling outside of the loop so only one check is needed
-					// Results in more code but SLIGHTLY better efficiency :D
-					if (needsRateScaling) {
-						const rate = currentSelectedRate.rate;
-						readings.forEach(reading => {
-							// As usual, we want to interpret the readings in UTC. We lose the timezone as this as the start/endTimestamp
-							// are equivalent to Unix timestamp in milliseconds.
-							const st = moment.utc(reading.startTimestamp);
-							// Time reading is in the middle of the start and end timestamp
-							const timeReading = st.add(moment.utc(reading.endTimestamp).diff(st) / 2);
-							xData.push(timeReading.utc().format('YYYY-MM-DD HH:mm:ss'));
-							yData.push(reading.reading * rate);
-							hoverText.push(`<b> ${timeReading.format('ddd, ll LTS')} </b> <br> ${label}: ${(reading.reading * rate).toPrecision(6)} ${unitLabel}`);
-						});
-					}
-					else {
-						readings.forEach(reading => {
-							// As usual, we want to interpret the readings in UTC. We lose the timezone as this as the start/endTimestamp
-							// are equivalent to Unix timestamp in milliseconds.
-							const st = moment.utc(reading.startTimestamp);
-							// Time reading is in the middle of the start and end timestamp
-							const timeReading = st.add(moment.utc(reading.endTimestamp).diff(st) / 2);
-							xData.push(timeReading.utc().format('YYYY-MM-DD HH:mm:ss'));
-							let readingValue = reading.reading;
-							if (state.graph.areaNormalization) {
-								readingValue /= groupArea;
-							}
-							yData.push(readingValue);
-							hoverText.push(`<b> ${timeReading.format('ddd, ll LTS')} </b> <br> ${label}: ${readingValue.toPrecision(6)} ${unitLabel}`);
-						});
-					}
+					readings.forEach(reading => {
+						// As usual, we want to interpret the readings in UTC. We lose the timezone as this as the start/endTimestamp
+						// are equivalent to Unix timestamp in milliseconds.
+						const st = moment.utc(reading.startTimestamp);
+						// Time reading is in the middle of the start and end timestamp
+						const timeReading = st.add(moment.utc(reading.endTimestamp).diff(st) / 2);
+						xData.push(timeReading.utc().format('YYYY-MM-DD HH:mm:ss'));
+						const readingValue = reading.reading * scaling;
+						yData.push(readingValue);
+						hoverText.push(`<b> ${timeReading.format('ddd, ll LTS')} </b> <br> ${label}: ${readingValue.toPrecision(6)} ${unitLabel}`);
+					});
 
-					// get the min and max timestamp of the meter, and compare it to the global values
+					// get the min and max timestamp of the group, and compare it to the global values
 					if (readings.length > 0) {
 						if (minTimestamp == undefined || readings[0]['startTimestamp'] < minTimestamp) {
 							minTimestamp = readings[0]['startTimestamp'];

--- a/src/client/app/types/redux/graph.ts
+++ b/src/client/app/types/redux/graph.ts
@@ -15,6 +15,11 @@ export enum ChartTypes {
 	map = 'map'
 }
 
+export enum MeterOrGroup {
+	meter = 'meter',
+	group = 'group'
+}
+
 // Rates that can be graphed, only relevant to line graphs.
 export const LineGraphRates = {
 	'second': (1/3600),


### PR DESCRIPTION
# Description

- OED export now scales correctly for rate and area.
- The exported file header row now says group for that case.
- The line graphic now scales properly for rate and area in the case of groups. It does it in a similar way to meters.
- Exports now has “name” in the header row for meter and group. Removed “for” in the filename before the meter or group to be consistent with the non-raw case.
- Update package version of OED to 1.0.0.
- A few small changes.

The three 1.0.0 help already takes these changes into account in the documentation.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

None known
