### PR TITLE
Hide Rate dropdown menu when not applicable

### DIFF
--- a/src/client/app/components/GraphicRateMenuComponent.tsx
+++ b/src/client/app/components/GraphicRateMenuComponent.tsx
@@ -30,14 +30,19 @@ export default function GraphicRateMenuComponent() {
 	// Unit data by Id
 	const selectedUnitData = unitDataById[graphState.selectedUnit];
 
+	// Should the rate drop down menu be rendered.
+	let shouldRender = true;
 	// Compare the value of name to be 'kW' or 'kWh' or unitRepresent type to be 'raw' and update the visibility of the Rate menu
 	if (selectedUnitData) {
 		const { name, unitRepresent } = selectedUnitData;
-		if(unitRepresent === UnitRepresentType.raw || name === 'kW' || name === 'kWh'){
-			return null;
+		if (unitRepresent === UnitRepresentType.raw || name === 'kW' || name === 'kWh') {
+			shouldRender = false;
 		}
 	}
-
+	// Also don't show if not the line graphic.
+	if (graphState.chartToRender !== 'line'){
+		shouldRender = false;
+	}
 	// Array of select options created from the rates
 	const rateOptions: SelectOption[] = [];
 
@@ -58,7 +63,7 @@ export default function GraphicRateMenuComponent() {
 	return (
 		<div>
 			{
-				graphState.chartToRender == 'line' &&
+				shouldRender &&
 				<div>
 					<p style={labelStyle}>
 						<FormattedMessage id='rate' />:

--- a/src/client/app/components/GraphicRateMenuComponent.tsx
+++ b/src/client/app/components/GraphicRateMenuComponent.tsx
@@ -12,6 +12,7 @@ import translate from '../utils/translate';
 import { updateLineGraphRate } from '../actions/graph'
 import { LineGraphRate, LineGraphRates } from '../types/redux/graph';
 import TooltipMarkerComponent from './TooltipMarkerComponent';
+import { UnitRepresentType } from '../types/redux/units'
 
 /**
  * React component that controls the line graph rate menu
@@ -22,6 +23,20 @@ export default function GraphicRateMenuComponent() {
 
 	// Graph state
 	const graphState = useSelector((state: State) => state.graph);
+
+	// Unit state
+	const unitDataById = useSelector((state: State) => state.units.units);
+
+	// Unit data by Id
+	const selectedUnitData = unitDataById[graphState.selectedUnit];
+
+	// Compare the value of name to be 'kW' or 'kWh' or unitRepresent type to be 'raw' and update the visibility of the Rate menu
+	if (selectedUnitData) {
+		const { name, unitRepresent } = selectedUnitData;
+		if(unitRepresent === UnitRepresentType.raw || name === 'kW' || name === 'kWh'){
+			return null;
+		}
+	}
 
 	// Array of select options created from the rates
 	const rateOptions: SelectOption[] = [];

--- a/src/client/app/components/TooltipMarkerComponent.tsx
+++ b/src/client/app/components/TooltipMarkerComponent.tsx
@@ -26,5 +26,3 @@ export default function TooltipMarkerComponent(props: TooltipMarker) {
 		<i data-for={props.page} data-tip={props.helpTextId} className='fa fa-question-circle' onClick={handleClick}/>
 	);
 }
-
-

--- a/src/client/app/components/TooltipMarkerComponent.tsx
+++ b/src/client/app/components/TooltipMarkerComponent.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react';
+import ReactTooltip from 'react-tooltip';
 
 interface TooltipMarker {
 	page: string; // Specifies page the marker is in.
@@ -15,7 +16,15 @@ interface TooltipMarker {
  * @returns Tooltip Marker element
  */
 export default function TooltipMarkerComponent(props: TooltipMarker) {
+
+	// Handle click event after the component is toggled between hidden and visible (e.g GraphicRateMenuComponent)
+	const handleClick = () => {
+		ReactTooltip.rebuild();
+	};
+
 	return (
-		<i data-for={props.page} data-tip={props.helpTextId} className='fa fa-question-circle' />
+		<i data-for={props.page} data-tip={props.helpTextId} className='fa fa-question-circle' onClick={handleClick}/>
 	);
 }
+
+

--- a/src/client/app/components/TooltipMarkerComponent.tsx
+++ b/src/client/app/components/TooltipMarkerComponent.tsx
@@ -17,7 +17,11 @@ interface TooltipMarker {
  */
 export default function TooltipMarkerComponent(props: TooltipMarker) {
 
-	// Handle click event after the component is toggled between hidden and visible (e.g GraphicRateMenuComponent)
+	// TODO This is trying to fix the fact that when the rate menu appears and disappears and you don't go to a new page
+	// then the help pop up does not occur. This works reasonably well but you have to click the help icon twice
+	// to see the pop up in this case. A better fix would be desirable in the long term since there have been issues with
+	// tooltips in multiple places.
+	// Handle click event after the component is toggled between hidden and visible (e.g GraphicRateMenuComponent).
 	const handleClick = () => {
 		ReactTooltip.rebuild();
 	};


### PR DESCRIPTION
# Description

Set the Rate dropdown menu in Line Graph to be hidden away when either kW appears on y axis or raw unit type is selected.  

Fixes #899 

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [ ] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations