### PR TITLE
Fix meter your page layout and functions parameter name

### DIFF
--- a/src/client/app/components/meters/CreateMeterModalComponent.tsx
+++ b/src/client/app/components/meters/CreateMeterModalComponent.tsx
@@ -559,61 +559,59 @@ export default function CreateMeterModalComponent(props: CreateMeterModalCompone
 					</FormGroup>
 					<Row xs='1' lg='2'>
 						{/* cumulative input */}
-						<Col>
-							<FormGroup>
-								<Label for='cumulative'>{translate('meter.cumulative')}</Label>
-								<Input
-									id='cumulative'
-									name='cumulative'
-									type='select'
-									value={state.cumulative.toString()}
-									onChange={e => handleBooleanChange(e)}>
-									{Object.keys(TrueFalseType).map(key => {
-										return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>)
-									})}
-								</Input>
-							</FormGroup>
-							{/* cumulativeReset input */}
-							<FormGroup>
-								<Label for='cumulativeReset'>{translate('meter.cumulativeReset')}</Label>
-								<Input
-									id='cumulativeReset'
-									name='cumulativeReset'
-									type='select'
-									value={state.cumulativeReset.toString()}
-									onChange={e => handleBooleanChange(e)}>
-									{Object.keys(TrueFalseType).map(key => {
-										return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>)
-									})}
-								</Input>
-							</FormGroup>
-						</Col>
+						<Col><FormGroup>
+							<Label for='cumulative'>{translate('meter.cumulative')}</Label>
+							<Input
+								id='cumulative'
+								name='cumulative'
+								type='select'
+								value={state.cumulative.toString()}
+								onChange={e => handleBooleanChange(e)}>
+								{Object.keys(TrueFalseType).map(key => {
+									return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>)
+								})}
+							</Input>
+						</FormGroup></Col>
+						{/* cumulativeReset input */}
+						<Col><FormGroup>
+							<Label for='cumulativeReset'>{translate('meter.cumulativeReset')}</Label>
+							<Input
+								id='cumulativeReset'
+								name='cumulativeReset'
+								type='select'
+								value={state.cumulativeReset.toString()}
+								onChange={e => handleBooleanChange(e)}>
+								{Object.keys(TrueFalseType).map(key => {
+									return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>)
+								})}
+							</Input>
+						</FormGroup></Col>
+					</Row>
+					<Row xs='1' lg='2'>
 						{/* cumulativeResetStart input */}
-						<Col>
-							<FormGroup>
-								<Label for='cumulativeResetStart'>{translate('meter.cumulativeResetStart')}</Label>
-								<Input
-									id='cumulativeResetStart'
-									name='cumulativeResetStart'
-									type='text'
-									autoComplete='off'
-									onChange={e => handleStringChange(e)}
-									value={state.cumulativeResetStart}
-									placeholder='HH:MM:SS' />
-							</FormGroup>
-							{/* cumulativeResetEnd input */}
-							<FormGroup>
-								<Label for='cumulativeResetEnd'>{translate('meter.cumulativeResetEnd')}</Label>
-								<Input
-									id='cumulativeResetEnd'
-									name='cumulativeResetEnd'
-									type='text'
-									autoComplete='off'
-									onChange={e => handleStringChange(e)}
-									value={state.cumulativeResetEnd}
-									placeholder='HH:MM:SS' />
-							</FormGroup>
-						</Col>
+						<Col><FormGroup>
+							<Label for='cumulativeResetStart'>{translate('meter.cumulativeResetStart')}</Label>
+							<Input
+								id='cumulativeResetStart'
+								name='cumulativeResetStart'
+								type='text'
+								autoComplete='off'
+								onChange={e => handleStringChange(e)}
+								value={state.cumulativeResetStart}
+								placeholder='HH:MM:SS' />
+						</FormGroup></Col>
+						{/* cumulativeResetEnd input */}
+						<Col><FormGroup>
+							<Label for='cumulativeResetEnd'>{translate('meter.cumulativeResetEnd')}</Label>
+							<Input
+								id='cumulativeResetEnd'
+								name='cumulativeResetEnd'
+								type='text'
+								autoComplete='off'
+								onChange={e => handleStringChange(e)}
+								value={state.cumulativeResetEnd}
+								placeholder='HH:MM:SS' />
+						</FormGroup></Col>
 					</Row>
 					<Row xs='1' lg='2'>
 						{/* endOnlyTime input */}
@@ -682,76 +680,76 @@ export default function CreateMeterModalComponent(props: CreateMeterModalCompone
 					</Row>
 					<Row xs='1' lg='2'>
 						{/* timeSort input */}
-						<Col>
-							<FormGroup>
-								<Label for='timeSort'>{translate('meter.timeSort')}</Label>
-								<Input
-									id='timeSort'
-									name='timeSort'
-									type='select'
-									value={state.timeSort}
-									onChange={e => handleStringChange(e)}>
-									{Object.keys(MeterTimeSortType).map(key => {
-										// This is a bit of a hack but it should work fine. The TypeSortTypes and MeterTimeSortType should be in sync.
-										// The translation is on the former so we use that enum name there but loop on the other to get the value desired.
-										return (<option value={key} key={key}>{translate(`TimeSortTypes.${key}`)}</option>)
-									})}
-								</Input>
-							</FormGroup>
-							{/* Timezone input */}
-							<FormGroup>
-								<Label>{translate('meter.time.zone')}</Label>
-								<TimeZoneSelect current={timeZoneValue} handleClick={timeZone => handleTimeZoneChange(timeZone)} />
-							</FormGroup>
-							{/* reading input */}
-							<FormGroup>
-								<Label for='reading'>{translate('reading')}</Label>
-								<Input
-									id='reading'
-									name='reading'
-									type='number'
-									onChange={e => handleNumberChange(e)}
-									defaultValue={state.reading} />
-							</FormGroup>
-						</Col>
+						<Col><FormGroup>
+							<Label for='timeSort'>{translate('meter.timeSort')}</Label>
+							<Input
+								id='timeSort'
+								name='timeSort'
+								type='select'
+								value={state.timeSort}
+								onChange={e => handleStringChange(e)}>
+								{Object.keys(MeterTimeSortType).map(key => {
+									// This is a bit of a hack but it should work fine. The TypeSortTypes and MeterTimeSortType should be in sync.
+									// The translation is on the former so we use that enum name there but loop on the other to get the value desired.
+									return (<option value={key} key={key}>{translate(`TimeSortTypes.${key}`)}</option>)
+								})}
+							</Input>
+						</FormGroup></Col>
+						{/* Timezone input */}
+						<Col><FormGroup>
+							<Label>{translate('meter.time.zone')}</Label>
+							<TimeZoneSelect current={timeZoneValue} handleClick={timeZone => handleTimeZoneChange(timeZone)} />
+						</FormGroup></Col>
+					</Row>
+					<Row xs='1' lg='2'>
+						{/* reading input */}
+						<Col><FormGroup>
+							<Label for='reading'>{translate('reading')}</Label>
+							<Input
+								id='reading'
+								name='reading'
+								type='number'
+								onChange={e => handleNumberChange(e)}
+								defaultValue={state.reading} />
+						</FormGroup></Col>
 						{/* startTimestamp input */}
-						<Col>
-							<FormGroup>
-								<Label for='startTimestamp'>{translate('meter.startTimeStamp')}</Label>
-								<Input
-									id='startTimestamp'
-									name='startTimestamp'
-									type='text'
-									autoComplete='on'
-									onChange={e => handleStringChange(e)}
-									placeholder='YYYY-MM-DD HH:MM:SS'
-									value={state.startTimestamp} />
-							</FormGroup>
-							{/* endTimestamp input */}
-							<FormGroup>
-								<Label for='endTimestamp'>{translate('meter.endTimeStamp')}</Label>
-								<Input
-									id='endTimestamp'
-									name='endTimestamp'
-									type='text'
-									autoComplete='on'
-									onChange={e => handleStringChange(e)}
-									placeholder='YYYY-MM-DD HH:MM:SS'
-									value={state.endTimestamp} />
-							</FormGroup>
-							{/* endTimestamp input */}
-							<FormGroup>
-								<Label for='previousEnd'>{translate('meter.previousEnd')}</Label>
-								<Input
-									id='previousEnd'
-									name='previousEnd'
-									type='text'
-									autoComplete='on'
-									onChange={e => handleStringChange(e)}
-									placeholder='YYYY-MM-DD HH:MM:SS'
-									value={state.previousEnd} />
-							</FormGroup>
-						</Col>
+						<Col><FormGroup>
+							<Label for='startTimestamp'>{translate('meter.startTimeStamp')}</Label>
+							<Input
+								id='startTimestamp'
+								name='startTimestamp'
+								type='text'
+								autoComplete='on'
+								onChange={e => handleStringChange(e)}
+								placeholder='YYYY-MM-DD HH:MM:SS'
+								value={state.startTimestamp} />
+						</FormGroup></Col>
+					</Row>
+					<Row xs='1' lg='2'>
+						{/* endTimestamp input */}
+						<Col><FormGroup>
+							<Label for='endTimestamp'>{translate('meter.endTimeStamp')}</Label>
+							<Input
+								id='endTimestamp'
+								name='endTimestamp'
+								type='text'
+								autoComplete='on'
+								onChange={e => handleStringChange(e)}
+								placeholder='YYYY-MM-DD HH:MM:SS'
+								value={state.endTimestamp} />
+						</FormGroup></Col>
+						{/* endTimestamp input */}
+						<Col><FormGroup>
+							<Label for='previousEnd'>{translate('meter.previousEnd')}</Label>
+							<Input
+								id='previousEnd'
+								name='previousEnd'
+								type='text'
+								autoComplete='on'
+								onChange={e => handleStringChange(e)}
+								placeholder='YYYY-MM-DD HH:MM:SS'
+								value={state.previousEnd} />
+						</FormGroup></Col>
 					</Row>
 				</Container></ModalBody>
 				<ModalFooter>
@@ -764,7 +762,7 @@ export default function CreateMeterModalComponent(props: CreateMeterModalCompone
 						<FormattedMessage id="save.all" />
 					</Button>
 				</ModalFooter>
-			</Modal>
+			</Modal >
 		</>
 	);
 }

--- a/src/client/app/components/meters/EditMeterModalComponent.tsx
+++ b/src/client/app/components/meters/EditMeterModalComponent.tsx
@@ -565,59 +565,59 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 					</FormGroup>
 					<Row xs='1' lg='2'>
 						{/* cumulative input */}
-						<Col>
-							<FormGroup>
-								<Label for='cumulative'>{translate('meter.cumulative')}</Label>
-								<Input
-									id='cumulative'
-									name='cumulative'
-									type='select'
-									value={state.cumulative?.toString()}
-									onChange={e => handleBooleanChange(e)}>
-									{Object.keys(TrueFalseType).map(key => {
-										return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>)
-									})}
-								</Input>
-							</FormGroup>
-							{/* cumulativeReset input */}
-							<FormGroup>
-								<Label for='cumulativeReset'>{translate('meter.cumulativeReset')}</Label>
-								<Input
-									id='cumulativeReset'
-									name='cumulativeReset'
-									type='select'
-									value={state.cumulativeReset?.toString()}
-									onChange={e => handleBooleanChange(e)}>
-									{Object.keys(TrueFalseType).map(key => {
-										return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>)
-									})}
-								</Input>
-							</FormGroup></Col>
+						<Col><FormGroup>
+							<Label for='cumulative'>{translate('meter.cumulative')}</Label>
+							<Input
+								id='cumulative'
+								name='cumulative'
+								type='select'
+								value={state.cumulative?.toString()}
+								onChange={e => handleBooleanChange(e)}>
+								{Object.keys(TrueFalseType).map(key => {
+									return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>)
+								})}
+							</Input>
+						</FormGroup></Col>
+						{/* cumulativeReset input */}
+						<Col><FormGroup>
+							<Label for='cumulativeReset'>{translate('meter.cumulativeReset')}</Label>
+							<Input
+								id='cumulativeReset'
+								name='cumulativeReset'
+								type='select'
+								value={state.cumulativeReset?.toString()}
+								onChange={e => handleBooleanChange(e)}>
+								{Object.keys(TrueFalseType).map(key => {
+									return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>)
+								})}
+							</Input>
+						</FormGroup></Col>
+					</Row>
+					<Row xs='1' lg='2'>
 						{/* cumulativeResetStart input */}
-						<Col>
-							<FormGroup>
-								<Label for='cumulativeResetStart'>{translate('meter.cumulativeResetStart')}</Label>
-								<Input
-									id='cumulativeResetStart'
-									name='cumulativeResetStart'
-									type='text'
-									autoComplete='off'
-									onChange={e => handleStringChange(e)}
-									value={state.cumulativeResetStart}
-									placeholder='HH:MM:SS' />
-							</FormGroup>
-							{/* cumulativeResetEnd input */}
-							<FormGroup>
-								<Label for='cumulativeResetEnd'>{translate('meter.cumulativeResetEnd')}</Label>
-								<Input
-									id='cumulativeResetEnd'
-									name='cumulativeResetEnd'
-									type='text'
-									autoComplete='off'
-									onChange={e => handleStringChange(e)}
-									value={state?.cumulativeResetEnd}
-									placeholder='HH:MM:SS' />
-							</FormGroup></Col>
+						<Col><FormGroup>
+							<Label for='cumulativeResetStart'>{translate('meter.cumulativeResetStart')}</Label>
+							<Input
+								id='cumulativeResetStart'
+								name='cumulativeResetStart'
+								type='text'
+								autoComplete='off'
+								onChange={e => handleStringChange(e)}
+								value={state.cumulativeResetStart}
+								placeholder='HH:MM:SS' />
+						</FormGroup></Col>
+						{/* cumulativeResetEnd input */}
+						<Col><FormGroup>
+							<Label for='cumulativeResetEnd'>{translate('meter.cumulativeResetEnd')}</Label>
+							<Input
+								id='cumulativeResetEnd'
+								name='cumulativeResetEnd'
+								type='text'
+								autoComplete='off'
+								onChange={e => handleStringChange(e)}
+								value={state?.cumulativeResetEnd}
+								placeholder='HH:MM:SS' />
+						</FormGroup></Col>
 					</Row>
 					<Row xs='1' lg='2'>
 						{/* endOnlyTime input */}
@@ -686,76 +686,76 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 					</Row>
 					<Row xs='1' lg='2'>
 						{/* timeSort input */}
-						<Col>
-							<FormGroup>
-								<Label for='timeSort'>{translate('meter.timeSort')}</Label>
-								<Input
-									id='timeSort'
-									name='timeSort'
-									type='select'
-									value={state?.timeSort}
-									onChange={e => handleStringChange(e)}>
-									{Object.keys(MeterTimeSortType).map(key => {
-										// This is a bit of a hack but it should work fine. The TypeSortTypes and MeterTimeSortType should be in sync.
-										// The translation is on the former so we use that enum name there but loop on the other to get the value desired.
-										return (<option value={key} key={key}>{translate(`TimeSortTypes.${key}`)}</option>)
-									})}
-								</Input>
-							</FormGroup>
-							{/* Timezone input */}
-							<FormGroup>
-								<Label>{translate('meter.time.zone')}</Label>
-								<TimeZoneSelect current={state.timeZone} handleClick={timeZone => handleTimeZoneChange(timeZone)} />
-							</FormGroup>
-							{/* reading input */}
-							<FormGroup>
-								<Label for='reading'>{translate('reading')}</Label>
-								<Input
-									id='reading'
-									name='reading'
-									type='number'
-									onChange={e => handleNumberChange(e)}
-									defaultValue={state?.reading} />
-							</FormGroup>
-						</Col>
+						<Col><FormGroup>
+							<Label for='timeSort'>{translate('meter.timeSort')}</Label>
+							<Input
+								id='timeSort'
+								name='timeSort'
+								type='select'
+								value={state?.timeSort}
+								onChange={e => handleStringChange(e)}>
+								{Object.keys(MeterTimeSortType).map(key => {
+									// This is a bit of a hack but it should work fine. The TypeSortTypes and MeterTimeSortType should be in sync.
+									// The translation is on the former so we use that enum name there but loop on the other to get the value desired.
+									return (<option value={key} key={key}>{translate(`TimeSortTypes.${key}`)}</option>)
+								})}
+							</Input>
+						</FormGroup></Col>
+						{/* Timezone input */}
+						<Col><FormGroup>
+							<Label>{translate('meter.time.zone')}</Label>
+							<TimeZoneSelect current={state.timeZone} handleClick={timeZone => handleTimeZoneChange(timeZone)} />
+						</FormGroup></Col>
+					</Row>
+					<Row xs='1' lg='2'>
+						{/* reading input */}
+						<Col><FormGroup>
+							<Label for='reading'>{translate('reading')}</Label>
+							<Input
+								id='reading'
+								name='reading'
+								type='number'
+								onChange={e => handleNumberChange(e)}
+								defaultValue={state?.reading} />
+						</FormGroup></Col>
 						{/* startTimestamp input */}
-						<Col>
-							<FormGroup>
-								<Label for='startTimestamp'>{translate('meter.startTimeStamp')}</Label>
-								<Input
-									id='startTimestamp'
-									name='startTimestamp'
-									type='text'
-									autoComplete='on'
-									onChange={e => handleStringChange(e)}
-									placeholder='YYYY-MM-DD HH:MM:SS'
-									value={state?.startTimestamp} />
-							</FormGroup>
-							{/* endTimestamp input */}
-							<FormGroup>
-								<Label for='endTimestamp'>{translate('meter.endTimeStamp')}</Label>
-								<Input
-									id='endTimestamp'
-									name='endTimestamp'
-									type='text'
-									autoComplete='on'
-									onChange={e => handleStringChange(e)}
-									placeholder='YYYY-MM-DD HH:MM:SS'
-									value={state?.endTimestamp} />
-							</FormGroup>
-							{/* previousEnd input */}
-							<FormGroup>
-								<Label for='previousEnd'>{translate('meter.previousEnd')}</Label>
-								<Input
-									id='previousEnd'
-									name='previousEnd'
-									type='text'
-									autoComplete='on'
-									onChange={e => handleStringChange(e)}
-									placeholder='YYYY-MM-DD HH:MM:SS'
-									value={state?.previousEnd} />
-							</FormGroup>
-						</Col>
+						<Col><FormGroup>
+							<Label for='startTimestamp'>{translate('meter.startTimeStamp')}</Label>
+							<Input
+								id='startTimestamp'
+								name='startTimestamp'
+								type='text'
+								autoComplete='on'
+								onChange={e => handleStringChange(e)}
+								placeholder='YYYY-MM-DD HH:MM:SS'
+								value={state?.startTimestamp} />
+						</FormGroup></Col>
+					</Row>
+					<Row xs='1' lg='2'>
+						{/* endTimestamp input */}
+						<Col><FormGroup>
+							<Label for='endTimestamp'>{translate('meter.endTimeStamp')}</Label>
+							<Input
+								id='endTimestamp'
+								name='endTimestamp'
+								type='text'
+								autoComplete='on'
+								onChange={e => handleStringChange(e)}
+								placeholder='YYYY-MM-DD HH:MM:SS'
+								value={state?.endTimestamp} />
+						</FormGroup></Col>
+						{/* previousEnd input */}
+						<Col><FormGroup>
+							<Label for='previousEnd'>{translate('meter.previousEnd')}</Label>
+							<Input
+								id='previousEnd'
+								name='previousEnd'
+								type='text'
+								autoComplete='on'
+								onChange={e => handleStringChange(e)}
+								placeholder='YYYY-MM-DD HH:MM:SS'
+								value={state?.previousEnd} />
+						</FormGroup></Col>
 					</Row>
 				</Container></ModalBody>
 				<ModalFooter>

--- a/src/client/app/utils/exportData.ts
+++ b/src/client/app/utils/exportData.ts
@@ -8,14 +8,14 @@ import { ChartTypes, MeterOrGroup } from '../types/redux/graph';
 
 /**
  * Function to converts the meter readings into a CSV formatted string.
- * @param readings The meter readings.
- * @param meter the meter identifier for data being exported
+ * @param readings The readings from the meter/group to export the graphic points.
+ * @param name the meter identifier or group name for data being exported
  * @param unitLabel the full y-axis label on the graphic
  * @param scaling factor to scale readings by, normally the rate factor for line or 1
  * @param meterGroup tells if this is a meter or group export
  * @returns A string containing the CSV formatted meter readings.
  */
-function convertToCSV(readings: LineReading[], meter: string, unitLabel: string, scaling: number, meterGroup: MeterOrGroup) {
+function convertToCSV(readings: LineReading[], name: string, unitLabel: string, scaling: number, meterGroup: MeterOrGroup) {
 	// TODO should be internationalized
 	let meterOrGroupString = '';
 	if (meterGroup === MeterOrGroup.meter) {
@@ -23,7 +23,7 @@ function convertToCSV(readings: LineReading[], meter: string, unitLabel: string,
 	} else {
 		meterOrGroupString = 'Group'
 	}
-	let csvOutput = `Readings, Start Timestamp, End Timestamp, ${meterOrGroupString} name, ${meter}, Unit, ${unitLabel}\n`;
+	let csvOutput = `Readings, Start Timestamp, End Timestamp, ${meterOrGroupString} name, ${name}, Unit, ${unitLabel}\n`;
 	readings.forEach(reading => {
 		const value = reading.reading * scaling;
 		// As usual, maintain UTC.
@@ -57,19 +57,19 @@ function downloadCSV(inputCSV: string, fileName: string) {
 
 /**
  * Function to export readings from the graph currently displaying. May be used for routing if more export options are added
- * @param readings The readings from the meter to export the graphic points.
- * @param meter the meter identifier for data being exported
+ * @param readings The readings from the meter/group to export the graphic points.
+ * @param name the meter identifier or group name for data being exported
  * @param unitLabel the full y-axis label on the graphic
  * @param unitIdentifier the unit identifier for data being exported
  * @param chartName the name of the chart/graphic being exported
  * @param scaling factor to scale readings by, normally the rate factor for line or 1
  * @param meterGroup tells if this is a meter or group export
  */
-export default function graphExport(readings: LineReading[], meter: string, unitLabel: string, unitIdentifier: string,
+export default function graphExport(readings: LineReading[], name: string, unitLabel: string, unitIdentifier: string,
 	chartName: ChartTypes, scaling: number, meterGroup: MeterOrGroup) {
 	// It is possible that some meters have not readings so skip if do. This can happen if resize the range of dates (or no data).
 	if (readings.length !== 0) {
-		const dataToExport = convertToCSV(readings, meter, unitLabel, scaling, meterGroup);
+		const dataToExport = convertToCSV(readings, name, unitLabel, scaling, meterGroup);
 
 		// Determine and format the first time in the dataset which is first one in array since just sorted and the start time.
 		// As usual, maintain UTC.
@@ -82,7 +82,7 @@ export default function graphExport(readings: LineReading[], meter: string, unit
 
 		// This is the file name with all the above info so unique.
 		// Note it only uses the unit identifier not with the rate because that has funny characters.
-		const filename = `oedExport_${chartName}_${startTimeString}_to_${endTimeString}_${meter}_${unitIdentifier}.csv`;
+		const filename = `oedExport_${chartName}_${startTimeString}_to_${endTimeString}_${name}_${unitIdentifier}.csv`;
 		downloadCSV(dataToExport, filename);
 	}
 }


### PR DESCRIPTION
# Description

- The layout of the edit and create meter page was fixed up to mirror development and get the layout to be correct.
- Export functions parameter name changed to reflect that it can be either meter or group.

As the branch name implies, the hope is this is the final changes for v1.0.0. :-)

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

None known
