### PR TITLE
restructure: Export Redux store from separate file

### DIFF
--- a/src/client/app/components/UnsavedWarningComponent.tsx
+++ b/src/client/app/components/UnsavedWarningComponent.tsx
@@ -8,7 +8,7 @@ import { Prompt, withRouter, RouteComponentProps } from 'react-router-dom';
 import { FlipLogOutStateAction, RemoveUnsavedChangesAction } from '../types/redux/unsavedWarning';
 import { deleteToken } from '../utils/token';
 import { clearCurrentUser } from '../actions/currentUser';
-import store from '../index';
+import { store }  from '../store';
 import { Modal, ModalBody, ModalFooter, Button } from 'reactstrap';
 
 interface UnsavedWarningProps extends RouteComponentProps<any> {

--- a/src/client/app/components/admin/PreferencesComponent.tsx
+++ b/src/client/app/components/admin/PreferencesComponent.tsx
@@ -29,7 +29,7 @@ import { removeUnsavedChanges, updateUnsavedChanges } from '../../actions/unsave
 import { defineMessages, FormattedMessage, injectIntl, WrappedComponentProps } from 'react-intl';
 import { LanguageTypes } from '../../types/redux/i18n';
 import TimeZoneSelect from '../TimeZoneSelect';
-import store from '../../index';
+import { store }  from '../../store';
 import { fetchPreferencesIfNeeded, submitPreferences } from '../../actions/admin';
 import { AreaUnitType } from '../../utils/getAreaUnitConversion';
 import translate from '../../utils/translate';

--- a/src/client/app/components/admin/UsersDetailComponent.tsx
+++ b/src/client/app/components/admin/UsersDetailComponent.tsx
@@ -11,7 +11,7 @@ import TooltipMarkerComponent from '../TooltipMarkerComponent';
 import { FormattedMessage } from 'react-intl';
 import UnsavedWarningContainer from '../../containers/UnsavedWarningContainer';
 import { updateUnsavedChanges, removeUnsavedChanges } from '../../actions/unsavedWarning';
-import store from '../../index'
+import { store }  from '../../store'
 
 interface UserDisplayComponentProps {
 	users: User[];

--- a/src/client/app/components/csv/MetersCSVUploadComponent.tsx
+++ b/src/client/app/components/csv/MetersCSVUploadComponent.tsx
@@ -9,7 +9,7 @@ import FormFileUploaderComponent from '../FormFileUploaderComponent';
 import { FormattedMessage } from 'react-intl';
 import { MODE } from '../../containers/csv/UploadCSVContainer';
 import { fetchMetersDetails } from '../../actions/meters';
-import store from '../../index';
+import { store }  from '../../store';
 
 export default class MetersCSVUploadComponent extends React.Component<MetersCSVUploadProps> {
 	private fileInput: React.RefObject<HTMLInputElement>;

--- a/src/client/app/components/maps/MapViewComponent.tsx
+++ b/src/client/app/components/maps/MapViewComponent.tsx
@@ -5,11 +5,11 @@
 import * as React from 'react';
 import { Button } from 'reactstrap';
 import { Link } from 'react-router-dom';
+import * as moment from 'moment';
 import { hasToken } from '../../utils/token';
 import { FormattedMessage, injectIntl, WrappedComponentProps } from 'react-intl';
 import { CalibrationModeTypes, MapMetadata } from '../../types/redux/map';
-import * as moment from 'moment';
-import store from '../../index';
+import { store } from '../../store';
 import { updateUnsavedChanges } from '../../actions/unsavedWarning';
 import { fetchMapsDetails, submitEditedMaps, confirmEditedMaps } from '../../actions/map';
 

--- a/src/client/app/components/maps/MapsDetailComponent.tsx
+++ b/src/client/app/components/maps/MapsDetailComponent.tsx
@@ -12,7 +12,7 @@ import { Link } from 'react-router-dom';
 import TooltipHelpContainer from '../../containers/TooltipHelpContainer';
 import TooltipMarkerComponent from '../TooltipMarkerComponent';
 import { removeUnsavedChanges } from '../../actions/unsavedWarning';
-import store from '../../index';
+import { store }  from '../../store';
 import UnsavedWarningContainer from '../../containers/UnsavedWarningContainer';
 import HeaderComponent from '../../components/HeaderComponent';
 

--- a/src/client/app/components/unit/EditUnitModalComponent.tsx
+++ b/src/client/app/components/unit/EditUnitModalComponent.tsx
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import * as React from 'react';
-import store from '../../index';
+import { store }  from '../../store';
 //Realize that * is already imported from react
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';

--- a/src/client/app/containers/maps/MapCalibrationChartDisplayContainer.ts
+++ b/src/client/app/containers/maps/MapCalibrationChartDisplayContainer.ts
@@ -8,7 +8,7 @@ import { State } from '../../types/redux/state';
 import * as plotly from 'plotly.js';
 import { CartesianPoint, Dimensions, normalizeImageDimensions } from '../../utils/calibration';
 import { updateCurrentCartesian } from '../../actions/map';
-import store from '../../index';
+import { store }  from '../../store';
 import { CalibrationSettings } from '../../types/redux/map';
 import Locales from '../../types/locales'
 

--- a/src/client/app/index.tsx
+++ b/src/client/app/index.tsx
@@ -3,36 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react';
-import thunkMiddleware from 'redux-thunk';
 import { createRoot } from 'react-dom/client';
-import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import 'bootstrap/dist/css/bootstrap.css';
 import RouteContainer from './containers/RouteContainer';
-import reducers from './reducers';
 import './styles/index.css';
-import { composeWithDevTools } from '@redux-devtools/extension';
-import initScript from './initScript';
+import { store } from './store'
 
-// Creates and applies thunk middleware to the Redux store, which is defined from the Redux reducers.
-// For now we are enabling Redux debug tools on production builds. If had a good way to only do this
-// when not in production mode then maybe we should remove this but it does allow for debugging.
-// Comment this out if enabling traces below.
-const store = createStore(reducers, composeWithDevTools(applyMiddleware(thunkMiddleware)));
-
-// Creates and applies thunk middleware to the Redux store, which is defined from the Redux reducers.
-// It would be nice to enable this automatically if not in production mode. Unfortunately, the client
-// side does not see the docker environment variables so it would require more work to do this. Doing
-// in the initScript with a proper route would likely fix this up.
-// For now,
-// the developer needs to comment out the line above and uncomment the two lines below to get traces.
-// The webpack rebuild should make the change while OED is running.
-// Allow tracing of code.
-// const composeEnhancers = composeWithDevTools({trace: true});
-// const store = createStore(reducers, composeEnhancers(applyMiddleware(thunkMiddleware)));
-
-// Store information that would rarely change throughout using OED into the Redux store when the application first mounts.
-store.dispatch<any>(initScript());
 
 // Renders the entire application, starting with RouteComponent, into the root div
 // Provides the Redux store to all child components

--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -4,9 +4,7 @@
 
 import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware } from 'redux';
-import 'bootstrap/dist/css/bootstrap.css';
 import reducers from './reducers';
-import './styles/index.css';
 import { composeWithDevTools } from '@redux-devtools/extension';
 import initScript from './initScript';
 

--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import thunkMiddleware from 'redux-thunk';
+import { createStore, applyMiddleware } from 'redux';
+import 'bootstrap/dist/css/bootstrap.css';
+import reducers from './reducers';
+import './styles/index.css';
+import { composeWithDevTools } from '@redux-devtools/extension';
+import initScript from './initScript';
+
+// Creates and applies thunk middleware to the Redux store, which is defined from the Redux reducers.
+// For now we are enabling Redux debug tools on production builds. If had a good way to only do this
+// when not in production mode then maybe we should remove this but it does allow for debugging.
+// Comment this out if enabling traces below.
+export const store = createStore(reducers, composeWithDevTools(applyMiddleware(thunkMiddleware)));
+
+// Creates and applies thunk middleware to the Redux store, which is defined from the Redux reducers.
+// It would be nice to enable this automatically if not in production mode. Unfortunately, the client
+// side does not see the docker environment variables so it would require more work to do this. Doing
+// in the initScript with a proper route would likely fix this up.
+// For now,
+// the developer needs to comment out the line above and uncomment the two lines below to get traces.
+// The webpack rebuild should make the change while OED is running.
+// Allow tracing of code.
+// const composeEnhancers = composeWithDevTools({trace: true});
+// const store = createStore(reducers, composeEnhancers(applyMiddleware(thunkMiddleware)));
+
+// Store information that would rarely change throughout using OED into the Redux store when the application first mounts.
+store.dispatch<any>(initScript());

--- a/src/client/app/utils/determineCompatibleUnits.ts
+++ b/src/client/app/utils/determineCompatibleUnits.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import store from '../index';
+import { store }  from '../store';
 import * as _ from 'lodash';
 import { MeterData } from '../types/redux/meters';
 import { ConversionArray } from '../types/conversionArray';

--- a/src/client/app/utils/translate.ts
+++ b/src/client/app/utils/translate.ts
@@ -4,7 +4,7 @@
 
 import { defineMessages, createIntl, createIntlCache } from 'react-intl';
 import localeData from '../translations/data';
-import store from '../index';
+import { store }  from '../store';
 
 // TODO This used to be multiple types of:
 // const enum AsTranslated {}


### PR DESCRIPTION
# Description

Defining the Redux store in the same file as the app will create problems with Vite. There is some issue with circular imports not working properly with HMR (hot module replacement). Upstream tracks this issue at vitejs/vite#3033; a workaround is to define and export the Redux store from a different file. This commit does exactly that to circumvent the circular import issue.

Related to #879

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

N/A