### PR TITLE
fix: Use static plotly.js imports to make Vite happy

### DIFF
--- a/src/client/app/types/locales.ts
+++ b/src/client/app/types/locales.ts
@@ -1,8 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @ts-expect-error Suppress TypeScript declaration file not found error
+import esLocale from 'plotly.js/lib/locales/es'
+// @ts-expect-error Suppress TypeScript declaration file not found error
+import frLocale from 'plotly.js/lib/locales/fr'
 
-export default class Locales{
-	static es = require('plotly.js/lib/locales/es');
-	static fr = require('plotly.js/lib/locales/fr');
+export default class Locales {
+	static es = esLocale;
+	static fr = frLocale;
 }


### PR DESCRIPTION
# Description

Vite will not play nice with these dynamic requires for some reason. To make Vite happy, convert the imports to static imports. Also change them to ESM-imports for consistency.

Related to #879

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

N/A