### PR TITLE
Test B9 Implementation

### DIFF
--- a/src/server/test/web/readingsBarMeterQuantity.js
+++ b/src/server/test/web/readingsBarMeterQuantity.js
@@ -190,7 +190,62 @@ mocha.describe('readings API', () => {
                     expectReadingToEqualExpected(res, expected);
                 });
 
-                // Add B9 here
+                mocha.it('B9: 1 day bars for 15 minute reading intervals and quantity units with +-inf start/end time & kWh as MJ reverse conversion', async () => {
+                    // Load the data into the database
+                    const unitData = unitDatakWh.concat([
+                        {
+                            // u3
+                            name: 'MJ',
+                            identifier: 'megaJoules',
+                            unitRepresent: Unit.unitRepresentType.QUANTITY,
+                            secInRate: 3600,
+                            typeOfUnit: Unit.unitType.UNIT,
+                            suffix: '',
+                            displayable: Unit.displayableType.ALL,
+                            preferredDisplay: false,
+                            note: 'MJ'
+                        }
+                    ]);
+                    const conversionData = conversionDatakWh.concat([
+                        {
+                            // c6
+                            sourceName: 'MJ',
+                            destinationName: 'kWh',
+                            bidirectional: true,
+                            slope: 1 / 3.6,
+                            intercept: 0,
+                            note: 'MJ → kWh reverse conversion'
+                        }
+                    ]);
+                    const meterData = [
+                        {
+                            name: 'Electric_Utility MJ Reverse',
+                            unit: 'Electric_Utility',
+                            displayable: true,
+                            gps: undefined,
+                            defaultGraphicUnit: 'MJ',
+                            note: 'special meter',
+                            file: 'test/web/readingsData/readings_ri_15_days_75.csv',
+                            deleteFile: false,
+                            readingFrequency: '15 minutes',
+                            id: METER_ID
+                        }
+                    ];
+                    await prepareTest(unitData, conversionData, meterData);
+                    // Get the unit ID since the DB could use any value.
+                    const unitId = await getUnitId('MJ');
+                    // Load the expected response data from the corresponding csv file
+                    const expected = await parseExpectedCsv('src/server/test/web/readingsData/expected_bar_ri_15_mu_kWh_gu_MJ_st_-inf_et_inf_bd_1.csv');
+                    // Create a request to the API for unbounded reading times and save the response
+                    const res = await chai.request(app).get(`/api/unitReadings/bar/meters/${METER_ID}`)
+                        .query({
+                            timeInterval: ETERNITY.toString(),
+                            barWidthDays: 1,
+                            graphicUnitId: unitId
+                        });
+                    // Check that the API reading is equal to what it is expected to equal
+                    expectReadingToEqualExpected(res, expected);
+                });
 
                 // Add B10 here
                 mocha.it('B10: 1 day bars for 15 minute reading intervals and quantity units with +-inf start/end time & kWh as BTU', async () => {


### PR DESCRIPTION
# Description

Implemented test case B9 with description: "1 day bars for 15-minute intervals, quantity units with +-inf start/end time, and kWh as MJ reverse conversion," ensuring API response alignment with expected readings.

Co-authored by: @abccodes, and @ryanvflannery

Addresses an issue at [#962](https://github.com/OpenEnergyDashboard/OED/issues/962)

## Type of change


- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist


- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

None