### PR TITLE
Remove transitive use of `core-js@2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"csv-parse": "~4.16.3",
 				"csv-stringify": "~5.6.5",
 				"dotenv": "~16.0.3",
+				"escape-html": "~1.0.3",
 				"express": "~4.17.3",
 				"express-rate-limit": "~5.5.1",
 				"history": "~4.7.2",
@@ -2784,8 +2785,7 @@
 		"node_modules/@types/lodash": {
 			"version": "4.14.201",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
-			"integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==",
-			"dev": true
+			"integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ=="
 		},
 		"node_modules/@types/lodash.memoize": {
 			"version": "4.1.7",
@@ -6748,20 +6748,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-		},
-		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"csv-parse": "~4.16.3",
 		"csv-stringify": "~5.6.5",
 		"dotenv": "~16.0.3",
+		"escape-html": "~1.0.3",
 		"express": "~4.17.3",
 		"express-rate-limit": "~5.5.1",
 		"history": "~4.7.2",

--- a/src/server/routes/authenticator.js
+++ b/src/server/routes/authenticator.js
@@ -10,7 +10,7 @@ const { log } = require('../log');
 const validate = require('jsonschema').validate;
 const { isTokenAuthorized, isUserAuthorized } = require('../util/userRoles');
 const { getConnection } = require('../db');
-const escapeHtml = require('core-js/fn/string/escape-html');
+const escapeHtml = require('escape-html');
 
 /**
  * Middleware function to force a route to require authentication

--- a/src/server/routes/obvius.js
+++ b/src/server/routes/obvius.js
@@ -27,7 +27,7 @@ const middleware = require('../middleware');
 const obvius = require('../util').obvius;
 const { obviusEmailAndPasswordAuthMiddleware } = require('./authenticator');
 const { getConnection } = require('../db');
-const escapeHtml = require('core-js/fn/string/escape-html');
+const escapeHtml = require('escape-html');
 
 const upload = multer({ storage: multer.memoryStorage() });
 const router = express.Router();

--- a/src/server/services/csvPipeline/failure.js
+++ b/src/server/services/csvPipeline/failure.js
@@ -4,7 +4,7 @@
 
 const express = require('express') /* needed to resolve types in JSDoc comments */
 const { CSVPipelineError } = require('./CustomErrors');
-const escapeHtml = require('core-js/fn/string/escape-html');
+const escapeHtml = require('escape-html');
 const { log } = require('../../log');
 
 /**


### PR DESCRIPTION
# Description

When using Babel, `core-js` is a common dependency used for automatically polyfillying modern ECMAScript features. In general, it is used client-side and not server-side. So, remove its use on the server and instead use the `escapeHtml` pollyfill.

Related to #871

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

N/A