### PR TITLE
Do not import unused and duplicate variable name

### DIFF
--- a/src/client/app/translations/data.js
+++ b/src/client/app/translations/data.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { localeData } from 'moment';
-
 /* eslint-disable */
 
 // This file used to be a json file, but had issues with importing, so we declared the json variable in a js file instead.


### PR DESCRIPTION
# Description

As a part of the #879 work to move to Vite, this fixes an issue with imports that caused Vite to fail:

```console
$ npm run vite:build

> open-energy-dashboard@1.0.0 vite:build
> vite --config ./src/vite.config.mjs build

vite v5.0.4 building for production...
✓ 82 modules transformed.
Identifier "localeData" has already been declared
file: /storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/src/client/app/translations/data.js:10:6
 8: 
 9: // This file used to be a json file, but had issues with importing, so we declared the json variable in a js file ins...
10: const localeData = {
          ^
11:   "en": {
12:     "3D": "3D",
error during build:
RollupError: Identifier "localeData" has already been declared
    at error (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/parseAst.js:337:30)
    at Module.error (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:12738:16)
    at ModuleScope.addDeclaration (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:11569:21)
    at Identifier.declare (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:7203:39)
    at VariableDeclarator.declareDeclarator (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:10179:17)
    at VariableDeclaration.initialise (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:11844:24)
    at new NodeBase (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:4607:14)
    at new VariableDeclaration (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:11816:1)
    at Program.parseNode (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:4718:27)
    at new NodeBase (file:///storage/ur/storage_home/Docs/Programming/Repositories/fox-forks/OED/node_modules/rollup/dist/es/shared/node-entry.js:4606:14)
```

Related to #879

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

N/A