### PR TITLE
Test  B9 Implementation

### DIFF
--- a/src/server/test/web/readingsBarMeterQuantity.js
+++ b/src/server/test/web/readingsBarMeterQuantity.js
@@ -230,13 +230,13 @@ mocha.describe('readings API', () => {
                             id: METER_ID
                         }
                     ];
-                    // Load the data into the database
+                    // Load the data into the database 
                     await prepareTest(unitData, conversionData, meterData);
                     // Get the unit ID since the DB could use any value.
                     const unitId = await getUnitId('MJ');
-                    // Load the expected response data from the corresponding csv file
+                    // Load the expected response data from the corresponding csv file 
                     const expected = await parseExpectedCsv('src/server/test/web/readingsData/expected_bar_ri_15_mu_kWh_gu_MJ_st_-inf_et_inf_bd_1.csv');
-                    // Create a request to the API for unbounded reading times and save the response
+                    // Create a request to the API for unbounded reading times and save the response 
                     const res = await chai.request(app).get(`/api/unitReadings/bar/meters/${METER_ID}`)
                         .query({
                             timeInterval: ETERNITY.toString(),

--- a/src/server/test/web/readingsBarMeterQuantity.js
+++ b/src/server/test/web/readingsBarMeterQuantity.js
@@ -189,12 +189,12 @@ mocha.describe('readings API', () => {
                     // Check that the API reading is equal to what it is expected to equal
                     expectReadingToEqualExpected(res, expected);
                 });
-
-                mocha.it('B9: 1 day bars for 15 minute reading intervals and quantity units with +-inf start/end time & kWh as MJ reverse conversion', async () => {
+                mocha.it('B9:1 day bars for 15 minute reading intervals and quantity units with +-inf start/end time & kWh as MJ reverse conversion', async () => {
                     // Load the data into the database
+
                     const unitData = unitDatakWh.concat([
                         {
-                            // u3
+                            //u3
                             name: 'MJ',
                             identifier: 'megaJoules',
                             unitRepresent: Unit.unitRepresentType.QUANTITY,
@@ -208,22 +208,22 @@ mocha.describe('readings API', () => {
                     ]);
                     const conversionData = conversionDatakWh.concat([
                         {
-                            // c6
+                            //c6
                             sourceName: 'MJ',
                             destinationName: 'kWh',
                             bidirectional: true,
                             slope: 1 / 3.6,
                             intercept: 0,
-                            note: 'MJ → kWh reverse conversion'
+                            note: 'MJ → KWh'
                         }
                     ]);
                     const meterData = [
                         {
-                            name: 'Electric_Utility MJ Reverse',
+                            name: 'Electric Utility MJ',
                             unit: 'Electric_Utility',
+                            defaultGraphicUnit: 'MJ',
                             displayable: true,
                             gps: undefined,
-                            defaultGraphicUnit: 'MJ',
                             note: 'special meter',
                             file: 'test/web/readingsData/readings_ri_15_days_75.csv',
                             deleteFile: false,
@@ -231,6 +231,7 @@ mocha.describe('readings API', () => {
                             id: METER_ID
                         }
                     ];
+                    // Load the data into the database
                     await prepareTest(unitData, conversionData, meterData);
                     // Get the unit ID since the DB could use any value.
                     const unitId = await getUnitId('MJ');

--- a/src/server/test/web/readingsBarMeterQuantity.js
+++ b/src/server/test/web/readingsBarMeterQuantity.js
@@ -191,10 +191,9 @@ mocha.describe('readings API', () => {
                 });
                 mocha.it('B9:1 day bars for 15 minute reading intervals and quantity units with +-inf start/end time & kWh as MJ reverse conversion', async () => {
                     // Load the data into the database
-
                     const unitData = unitDatakWh.concat([
                         {
-                            //u3
+                            // u3
                             name: 'MJ',
                             identifier: 'megaJoules',
                             unitRepresent: Unit.unitRepresentType.QUANTITY,


### PR DESCRIPTION
# Description

Implemented test B9 with description: "1 day bars for 15 minute reading intervals and quantity units with +-inf start/end time & kWh as MJ reverse conversion"

Co-authors: @gyordong , @kn15235

Partly Addresses #962 


## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [ x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [ x] I have removed text in ( ) from the issue request
- [ x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.


