### PR TITLE
Docker compose down added to startup routine for VSC Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,8 +48,9 @@
 	// "postCreateCommand": "bash /workspace/src/scripts/installOED.sh"
 	// then you see all the output in the terminal that opens up but it shows
 	// "Configuring Dev Container" with a spinning wheel.
-	// When you use the command below then the output goes into nohup.out.
-	"postCreateCommand": "nohup bash -c '/workspace/src/scripts/installOED.sh &'"
+	// When you use the command below then the output goes into nohup.out. The docker compose down is run to prevent vscode from crashing at startup.
+	// The VSCode container cra\ashes if an instance of the container is already running when VSCode starts up, the docker compose down prevents this behaviour.
+	"postCreateCommand": "docker compose down; nohup bash -c '/workspace/src/scripts/installOED.sh &'"
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
 }


### PR DESCRIPTION
# Description

Added a docker compose down command to the VSC Dev Container startup process to prevent VSCode from crashing when an dev container instance is already running.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

None found yet, although this issue could still persist under different circumstances.