### PR TITLE
Fixes Issue #1209 - don't allow cumulative reset without cumulative on meter

### DIFF
--- a/src/client/app/components/meters/CreateMeterModalComponent.tsx
+++ b/src/client/app/components/meters/CreateMeterModalComponent.tsx
@@ -33,7 +33,7 @@ import TooltipMarkerComponent from '../TooltipMarkerComponent';
  * @returns Meter create element
  */
 export default function CreateMeterModalComponent() {
-	// Tracks wheter a unit/ default unit has been selected.
+	// Tracks whether a unit/ default unit has been selected.
 	// RTKQ Mutation to submit add meter
 	const [submitAddMeter] = metersApi.endpoints.addMeter.useMutation();
 	// Memo'd memoized selector
@@ -60,7 +60,6 @@ export default function CreateMeterModalComponent() {
 			setMeterDetails(details => ({ ...details, defaultGraphicUnit: -999 }));
 		}
 	}, [meterDetails.unitId]);
-
 
 	const handleShow = () => setShowModal(true);
 
@@ -412,13 +411,19 @@ export default function CreateMeterModalComponent() {
 						{/* cumulativeReset input */}
 						<Col><FormGroup>
 							<Label for='cumulativeReset'>{translate('meter.cumulativeReset')}</Label>
-							<Input id='cumulativeReset' name='cumulativeReset' type='select'
-								value={meterDetails.cumulativeReset.toString()}
-								onChange={e => handleBooleanChange(e)}>
-								{Object.keys(TrueFalseType).map(key => {
-									return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>);
-								})}
-							</Input>
+							{meterDetails.cumulative === true ? (
+								<Input id='cumulativeReset' name='cumulativeReset' type='select'
+									value={meterDetails.cumulativeReset.toString()}
+									onChange={e => handleBooleanChange(e)}>
+									{Object.keys(TrueFalseType).map(key => {
+										return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>);
+									})}
+								</Input>
+							) : (
+								<Input id='cumulativeReset' name='cumulativeReset' type='select' disabled>
+									<option value='no'>Unavailable</option>
+								</Input>
+							)}
 						</FormGroup></Col>
 					</Row>
 					<Row xs='1' lg='2'>
@@ -428,7 +433,9 @@ export default function CreateMeterModalComponent() {
 							<Input id='cumulativeResetStart' name='cumulativeResetStart' type='text' autoComplete='off'
 								onChange={e => handleStringChange(e)}
 								value={meterDetails.cumulativeResetStart}
-								placeholder='HH:MM:SS' />
+								placeholder='HH:MM:SS'
+								disabled={meterDetails.cumulativeReset === false || meterDetails.cumulative === false ? true : false}
+							/>
 						</FormGroup></Col>
 						{/* cumulativeResetEnd input */}
 						<Col><FormGroup>
@@ -437,7 +444,9 @@ export default function CreateMeterModalComponent() {
 								autoComplete='off'
 								onChange={e => handleStringChange(e)}
 								value={meterDetails.cumulativeResetEnd}
-								placeholder='HH:MM:SS' />
+								placeholder='HH:MM:SS'
+								disabled={meterDetails.cumulativeReset === false || meterDetails.cumulative === false  ? true : false}
+							/>
 						</FormGroup></Col>
 					</Row>
 					<Row xs='1' lg='2'>
@@ -655,6 +664,3 @@ export default function CreateMeterModalComponent() {
 		</>
 	);
 }
-
-
-

--- a/src/client/app/components/meters/CreateMeterModalComponent.tsx
+++ b/src/client/app/components/meters/CreateMeterModalComponent.tsx
@@ -61,6 +61,12 @@ export default function CreateMeterModalComponent() {
 		}
 	}, [meterDetails.unitId]);
 
+	React.useEffect(() => {
+		if (meterDetails.cumulative === false) {
+			setMeterDetails(details => ({ ...details, cumulativeReset: false }));
+		}
+	}, [meterDetails.cumulative]);
+
 	const handleShow = () => setShowModal(true);
 
 	const handleStringChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -434,7 +440,7 @@ export default function CreateMeterModalComponent() {
 								onChange={e => handleStringChange(e)}
 								value={meterDetails.cumulativeResetStart}
 								placeholder='HH:MM:SS'
-								disabled={meterDetails.cumulativeReset === false || meterDetails.cumulative === false ? true : false}
+								disabled={meterDetails.cumulativeReset === false || meterDetails.cumulative === false}
 							/>
 						</FormGroup></Col>
 						{/* cumulativeResetEnd input */}
@@ -445,7 +451,7 @@ export default function CreateMeterModalComponent() {
 								onChange={e => handleStringChange(e)}
 								value={meterDetails.cumulativeResetEnd}
 								placeholder='HH:MM:SS'
-								disabled={meterDetails.cumulativeReset === false || meterDetails.cumulative === false  ? true : false}
+								disabled={meterDetails.cumulativeReset === false || meterDetails.cumulative === false}
 							/>
 						</FormGroup></Col>
 					</Row>

--- a/src/client/app/components/meters/EditMeterModalComponent.tsx
+++ b/src/client/app/components/meters/EditMeterModalComponent.tsx
@@ -431,20 +431,25 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 						{/* cumulativeReset input */}
 						<Col><FormGroup>
 							<Label for='cumulativeReset'>{translate('meter.cumulativeReset')}</Label>
-							<Input
-								id='cumulativeReset'
-								name='cumulativeReset'
-								type='select'
-								value={localMeterEdits.cumulativeReset?.toString()}
-								onChange={e => handleBooleanChange(e)}>
-								{Object.keys(TrueFalseType).map(key => {
-									return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>);
-								})}
-							</Input>
+							{localMeterEdits.cumulative === true ? (
+								<Input
+									id='cumulativeReset'
+									name='cumulativeReset'
+									type='select'
+									value={localMeterEdits.cumulativeReset?.toString()}
+									onChange={e => handleBooleanChange(e)}>
+									{Object.keys(TrueFalseType).map(key => {
+										return (<option value={key} key={key}>{translate(`TrueFalseType.${key}`)}</option>);
+									})}
+								</Input>
+							) : (
+								<Input id='cumulativeReset' name='cumulativeReset' type='select' disabled>
+									<option value='no'>Unavailable</option>
+								</Input>
+							)}
 						</FormGroup></Col>
 					</Row>
 					<Row xs='1' lg='2'>
-
 						{/* cumulativeResetStart input */}
 						<Col><FormGroup>
 							<Label for='cumulativeResetStart'>{translate('meter.cumulativeResetStart')}</Label>
@@ -455,7 +460,9 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 								autoComplete='off'
 								onChange={e => handleStringChange(e)}
 								value={localMeterEdits.cumulativeResetStart}
-								placeholder='HH:MM:SS' />
+								placeholder='HH:MM:SS'
+								disabled={localMeterEdits.cumulativeReset === false || localMeterEdits.cumulative === false ? true : false}
+							/>
 						</FormGroup></Col>
 						{/* cumulativeResetEnd input */}
 						<Col><FormGroup>
@@ -467,7 +474,9 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 								autoComplete='off'
 								onChange={e => handleStringChange(e)}
 								value={localMeterEdits?.cumulativeResetEnd}
-								placeholder='HH:MM:SS' />
+								placeholder='HH:MM:SS'
+								disabled={localMeterEdits.cumulativeReset === false || localMeterEdits.cumulative === false ? true : false}
+							/>
 						</FormGroup></Col>
 					</Row>
 					<Row xs='1' lg='2'>

--- a/src/client/app/components/meters/EditMeterModalComponent.tsx
+++ b/src/client/app/components/meters/EditMeterModalComponent.tsx
@@ -69,6 +69,11 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 	useEffect(() => { setValidMeter(isValidMeter(localMeterEdits)); }, [localMeterEdits]);
 	/* End State */
 
+	React.useEffect(() => {
+		if (localMeterEdits.cumulative === false) {
+			setLocalMeterEdits(details => ({ ...details, cumulativeReset: false }));
+		}
+	}, [localMeterEdits.cumulative]);
 
 	// Save changes
 	// Currently using the old functionality which is to compare inherited prop values to state values
@@ -195,6 +200,7 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 		props.handleClose();
 		resetState();
 	};
+
 	return (
 		<>
 			<Modal isOpen={props.show} toggle={props.handleClose} size='lg'>
@@ -461,7 +467,7 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 								onChange={e => handleStringChange(e)}
 								value={localMeterEdits.cumulativeResetStart}
 								placeholder='HH:MM:SS'
-								disabled={localMeterEdits.cumulativeReset === false || localMeterEdits.cumulative === false ? true : false}
+								disabled={localMeterEdits.cumulativeReset === false || localMeterEdits.cumulative === false}
 							/>
 						</FormGroup></Col>
 						{/* cumulativeResetEnd input */}
@@ -475,7 +481,7 @@ export default function EditMeterModalComponent(props: EditMeterModalComponentPr
 								onChange={e => handleStringChange(e)}
 								value={localMeterEdits?.cumulativeResetEnd}
 								placeholder='HH:MM:SS'
-								disabled={localMeterEdits.cumulativeReset === false || localMeterEdits.cumulative === false ? true : false}
+								disabled={localMeterEdits.cumulativeReset === false || localMeterEdits.cumulative === false}
 							/>
 						</FormGroup></Col>
 					</Row>


### PR DESCRIPTION
# Description

This disables the Cumulative Reset option and the Cumulative Reset Start and Stop times if Cumulative is selected as 'no'.
The Cumulative Reset Start and Stop times are also disabled if Cumulative Reset is marked as 'no'.

Fixes #1209

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

Needs Reviewing