### PR TITLE
remove csv-parse as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
 				"body-parser": "~1.20.2",
 				"bootstrap": "~5.3.3",
 				"csv": "~5.3.2",
-				"csv-parse": "~4.16.3",
 				"csv-stringify": "~5.6.5",
 				"dotenv": "~16.4.5",
 				"escape-html": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
 		"body-parser": "~1.20.2",
 		"bootstrap": "~5.3.3",
 		"csv": "~5.3.2",
-		"csv-parse": "~4.16.3",
 		"csv-stringify": "~5.6.5",
 		"dotenv": "~16.4.5",
 		"escape-html": "~1.0.3",

--- a/src/server/services/obvius/csvDemux.js
+++ b/src/server/services/obvius/csvDemux.js
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const parseCsv = require('csv-parse/lib/sync');
+const util = require('util');
+const csv = require('csv');
+const fs = require('fs').promises;
+
+const parseCsv = util.promisify(csv.parse);
 
 /**
  * Demultiplexes a CSV file with a single column of timestamps and multiple columns
@@ -12,8 +16,8 @@ const parseCsv = require('csv-parse/lib/sync');
  * @param {string} input
  * @param {number} timesColumn
  */
-function demuxCsvWithSingleColumnTimestamps(input, timesColumn = 0) {
-	data = parseCsv(input, {relax_column_count: true});
+async function demuxCsvWithSingleColumnTimestamps(input, timesColumn = 0) {
+	const data = await parseCsv(input, { relax_column_count: true });
 
 	const maxCol = data.reduce((t, c) => {
 		if (c.length > t) {

--- a/src/server/services/obvius/loadLogfileToReadings.js
+++ b/src/server/services/obvius/loadLogfileToReadings.js
@@ -11,7 +11,7 @@ const Preferences = require('../../models/Preferences');
 
 async function loadLogfileToReadings(serialNumber, ipAddress, logfile, conn) {
 	// Get demultiplexed, parsed data from the CSV.
-	const unprocessedData = demuxCsvWithSingleColumnTimestamps(logfile);
+	const unprocessedData = await demuxCsvWithSingleColumnTimestamps(logfile);
 	// Removes the first three values because we expect it to be all zeroes
 	const data = unprocessedData.slice(3);
 	for (let i = 0; i < data.length; i++) {

--- a/src/server/test/db/loadLogfileToReadingsTests.js
+++ b/src/server/test/db/loadLogfileToReadingsTests.js
@@ -32,7 +32,7 @@ const csvDataReal = `'2018-04-26 16:04:59',x,x,x,0,0,0,35304.57,0.42,0.49,0.65,0
 
 mocha.describe('demuxCsvWithSingleColumnTimestamps', async () => {
 	mocha.it('should demultiplex CSVs with index time columns correctly', async () => {
-		const r = demuxCsvWithSingleColumnTimestamps(csvData);
+		const r = await demuxCsvWithSingleColumnTimestamps(csvData);
 		expect(r).to.deep.equal([
 			[
 				['2001-01-01 00:00:00', 0],
@@ -52,7 +52,7 @@ mocha.describe('demuxCsvWithSingleColumnTimestamps', async () => {
 		]);
 	});
 	mocha.it('should demultiplex CSVs with differing time columns correctly', async () => {
-		const r = demuxCsvWithSingleColumnTimestamps(csvData2, timesColumn = 3);
+		const r = await demuxCsvWithSingleColumnTimestamps(csvData2, timesColumn = 3);
 		expect(r).to.deep.equal([
 			[
 				['2001-01-01 00:00:00', 0],
@@ -72,7 +72,7 @@ mocha.describe('demuxCsvWithSingleColumnTimestamps', async () => {
 		]);
 	});
 	mocha.it('should demultiplex CSVs with missing or empty columns', async () => {
-		const r = demuxCsvWithSingleColumnTimestamps(csvDataIncons);
+		const r = await demuxCsvWithSingleColumnTimestamps(csvDataIncons);
 		expect(r).to.deep.equal([
 			[
 				['2001-01-01 00:00:00', null],


### PR DESCRIPTION
# Description

A previous change removed this from another file. This change undoes the other place so csv-parse is not directly needed by OED. This may help with an dependabot upgrade issue and simplify OED's packages.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

Note the package-lock.json file still has the older version of csv-parse than csv package can use. I could not easily fix and hope the next npm install, that will change other things, will fix this or dependabot will do it.
