### PR TITLE
bump chai to 4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
 				"@typescript-eslint/parser": "~6.11.0",
 				"babel-loader": "~8.2.3",
 				"babel-plugin-formatjs": "~10.3.12",
-				"chai": "~3.5.0",
+				"chai": "~4.4.1",
 				"chai-as-promised": "~7.1.1",
 				"chai-http": "~4.3.0",
 				"css-loader": "~6.8.1",
@@ -2654,15 +2654,6 @@
 				"type-detect": "4.0.8"
 			}
 		},
-		"node_modules/@sinonjs/commons/node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@sinonjs/fake-timers": {
 			"version": "11.2.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
@@ -2690,15 +2681,6 @@
 			"dev": true,
 			"dependencies": {
 				"type-detect": "4.0.8"
-			}
-		},
-		"node_modules/@sinonjs/samsam/node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@sinonjs/text-encoding": {
@@ -4537,17 +4519,21 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-			"integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
 			"dev": true,
 			"dependencies": {
-				"assertion-error": "^1.0.1",
-				"deep-eql": "^0.1.3",
-				"type-detect": "^1.0.0"
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
+				"pathval": "^1.1.1",
+				"type-detect": "^4.0.8"
 			},
 			"engines": {
-				"node": ">= 0.4.0"
+				"node": ">=4"
 			}
 		},
 		"node_modules/chai-as-promised": {
@@ -5405,24 +5391,15 @@
 			}
 		},
 		"node_modules/deep-eql": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-			"integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dev": true,
 			"dependencies": {
-				"type-detect": "0.1.1"
+				"type-detect": "^4.0.0"
 			},
 			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/deep-eql/node_modules/type-detect": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-			"integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
-			"dev": true,
-			"engines": {
-				"node": "*"
+				"node": ">=6"
 			}
 		},
 		"node_modules/deep-is": {
@@ -8350,6 +8327,15 @@
 				"loose-envify": "cli.js"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.1"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8989,15 +8975,6 @@
 				"isarray": "0.0.1"
 			}
 		},
-		"node_modules/nise/node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/node-polyfill-webpack-plugin": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-1.1.4.tgz",
@@ -9423,6 +9400,15 @@
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/pathval": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/pbf": {
@@ -12132,12 +12118,12 @@
 			}
 		},
 		"node_modules/type-detect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-			"integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true,
 			"engines": {
-				"node": "*"
+				"node": ">=4"
 			}
 		},
 		"node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
 		"@typescript-eslint/parser": "~6.11.0",
 		"babel-loader": "~8.2.3",
 		"babel-plugin-formatjs": "~10.3.12",
-		"chai": "~3.5.0",
+		"chai": "~4.4.1",
 		"chai-as-promised": "~7.1.1",
 		"chai-http": "~4.3.0",
 		"css-loader": "~6.8.1",


### PR DESCRIPTION
# Description

dependabot PR #1231 tried to bump to 5.1.1 but OED uses chai-as-promised that cannot go above chai 4. Thus, 4.4.1 is the latest that is compatible. Doing separate PR since easier to do npm for me.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

None known
