### PR TITLE
remove rc-slider types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
 				"@types/lodash": "~4.17.4",
 				"@types/node": "~20.14.10",
 				"@types/plotly.js": "~2.29.2",
-				"@types/rc-slider": "~8.2.3",
 				"@types/react": "~18.3.3",
 				"@types/react-dom": "~18.2.24",
 				"@types/react-plotly.js": "~2.6.0",
@@ -1059,25 +1058,6 @@
 			"version": "15.7.10",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
 			"integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A=="
-		},
-		"node_modules/@types/rc-slider": {
-			"version": "8.2.5",
-			"resolved": "https://registry.npmjs.org/@types/rc-slider/-/rc-slider-8.2.5.tgz",
-			"integrity": "sha512-JamUBE/SUnwX8Zw19dzPnxdScpXJY/l7yK6Gt42aKwdTKXl+gz7JGaxuRU+CVuuD1vn4U7Zwkgo734HP2LN3uQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/rc-tooltip": "*",
-				"@types/react": "*"
-			}
-		},
-		"node_modules/@types/rc-tooltip": {
-			"version": "3.7.10",
-			"resolved": "https://registry.npmjs.org/@types/rc-tooltip/-/rc-tooltip-3.7.10.tgz",
-			"integrity": "sha512-s23GlQbvlu9vDknxyNSTONuZuqiNpWJaccfDDnLojd3lOn1gQRCd8H53zcjOX4HA0qab+lwDI5nnVtekkw9+9w==",
-			"dev": true,
-			"dependencies": {
-				"@types/react": "*"
-			}
 		},
 		"node_modules/@types/react": {
 			"version": "18.3.3",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
 		"@types/lodash": "~4.17.4",
 		"@types/node": "~20.14.10",
 		"@types/plotly.js": "~2.29.2",
-		"@types/rc-slider": "~8.2.3",
 		"@types/react": "~18.3.3",
 		"@types/react-dom": "~18.2.24",
 		"@types/react-plotly.js": "~2.6.0",


### PR DESCRIPTION
# Description

PR #1249 removed rc-slider but the types are still there. This removes them. This should eliminate the need for PR #1297.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

None known
