### PR TITLE
Switch from docker-compose to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
               # database:
               # We need the database and it has to be ready for work (see healthcheck above).
               # condition: service_healthy
-        # Lets docker-compose up work right
+        # Lets docker compose up work right
         # If environment variable install_args is not set then it becomes blank without warning user.
         command:
             [

--- a/src/scripts/installOED.sh
+++ b/src/scripts/installOED.sh
@@ -39,7 +39,7 @@ while test $# -gt 0; do
 			skip_db_initialize=yes
 			;;
 		"")
-			# Empty string so just ignore. Esp. happens if no install_args on docker-compose up.
+			# Empty string so just ignore. Esp. happens if no install_args on docker compose up.
 			shift
 			;;
 		*)

--- a/src/scripts/oed.service
+++ b/src/scripts/oed.service
@@ -11,8 +11,9 @@ Requires=docker.service
 After=docker.service
 
 [Service]
-ExecStart=/usr/bin/docker-compose up
-ExecStop=/usr/bin/docker-compose down
+# Modify only if your docker is located somewhere else or you have an old system with only docker-compose.
+ExecStart=/usr/bin/docker compose up
+ExecStop=/usr/bin/docker compose down
 WorkingDirectory=/example/path/to/project/OED
 Restart=always
 RestartSec=10

--- a/src/scripts/refreshHourlyReadingViewsCron.bash
+++ b/src/scripts/refreshHourlyReadingViewsCron.bash
@@ -4,5 +4,5 @@
 # The absolute path the project root directory (OED)
 cd '/example/path/to/project/OED'
 
-# The following line should NOT need to be edited except by devs.
-docker-compose run --rm web npm run --silent refreshHourlyReadingViews &>> /dev/null &
+# The following line should NOT need to be edited except by devs or if you have an old system with only docker-compose.
+docker compose run --rm web npm run --silent refreshHourlyReadingViews &>> /dev/null &

--- a/src/scripts/refreshReadingViewsCron.bash
+++ b/src/scripts/refreshReadingViewsCron.bash
@@ -5,5 +5,5 @@
 # The absolute path the project root directory (OED)
 cd '/example/path/to/project/OED'
 
-# The following line should NOT need to be edited except by devs.
-docker-compose run --rm web npm run --silent refreshReadingViews &>> /dev/null &
+# The following line should NOT need to be edited except by devs or if you have an old system with only docker-compose.
+docker compose run --rm web npm run --silent refreshReadingViews &>> /dev/null &

--- a/src/scripts/sendLogEmailCron.bash
+++ b/src/scripts/sendLogEmailCron.bash
@@ -2,5 +2,5 @@
 # The absolute path the project root directory (OED)
 cd '/example/path/to/project/OED'
 
-# The following line should NOT need to be edited except by devs.
-docker-compose run --rm web npm run --silent sendLogEmail &>> /dev/null &
+# The following line should NOT need to be edited except by devs or if you have an old system with only docker-compose.
+docker compose run --rm web npm run --silent sendLogEmail &>> /dev/null &

--- a/src/scripts/updateEgaugeMetersOEDCron.bash
+++ b/src/scripts/updateEgaugeMetersOEDCron.bash
@@ -2,5 +2,5 @@
 # The absolute path the project root directory (OED)
 cd '/example/path/to/project/OED'
 
-# The following line should NOT need to be edited except by devs.
-docker-compose run --rm web npm run --silent updateEgaugeMeters &>> /dev/null &
+# The following line should NOT need to be edited except by devs or if you have an old system with only docker-compose.
+docker compose run --rm web npm run --silent updateEgaugeMeters &>> /dev/null &

--- a/src/scripts/updateMamacMetersOEDCron.bash
+++ b/src/scripts/updateMamacMetersOEDCron.bash
@@ -2,5 +2,5 @@
 # The absolute path the project root directory (OED)
 cd '/example/path/to/project/OED'
 
-# The following line should NOT need to be edited except by devs.
-docker-compose run --rm web npm run --silent updateMamacMeters &>> /dev/null &
+# The following line should NOT need to be edited except by devs or if you have an old system with only docker-compose.
+docker compose run --rm web npm run --silent updateMamacMeters &>> /dev/null &


### PR DESCRIPTION
# Description

Docker formally made this switch a while ago. Some systems no longer have docker-compose so this formally makes that change for OED. Comments are left in case someone is running an older system.

## Type of change

- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

None known
