### PR TITLE
issue 1158: ability to copy warning and error popup notifications

### DIFF
--- a/src/client/app/utils/notifications.ts
+++ b/src/client/app/utils/notifications.ts
@@ -49,9 +49,10 @@ export function showWarnNotification(message: string, position: ToastPosition = 
 		position: position,
 		autoClose: autoDismiss,
 		hideProgressBar: true,
-		pauseOnHover: false,
-		draggable: true,
-		theme: 'colored'
+		pauseOnHover: true,
+		draggable: false,
+		theme: 'colored',
+		closeOnClick: false
 	});
 }
 
@@ -66,8 +67,9 @@ export function showErrorNotification(message: string, position: ToastPosition =
 		position: position,
 		autoClose: autoDismiss,
 		hideProgressBar: true,
-		pauseOnHover: false,
-		draggable: true,
-		theme: 'colored'
+		pauseOnHover: true,
+		draggable: false,
+		theme: 'colored',
+		closeOnClick: false
 	});
 }

--- a/src/server/services/pipeline-in-progress/processData.js
+++ b/src/server/services/pipeline-in-progress/processData.js
@@ -784,8 +784,8 @@ function appendMsgTotal(msgTotal, newMsg, msgTotalWarning) {
 	if (msgTotal.length < MAX_SIZE) {
 		msgTotal += newMsg;
 	} else if (!msgTotalWarning) {
-		msgTotal = '<h1>WARNING - The total number of messages was stopped due to size.' +
-			' The log file has all the messages.</h1>' + message + '<h1>Message lost starting now.</h1>';
+		msgTotal += '<h1>WARNING - The total number of messages was stopped due to size.' +
+			' The log file has all the messages.</h1>' + newMsg + '<h1>Messages lost starting now.</h1>';
 		// Note that warned so goes from false to true.
 		msgTotalWarning = !msgTotalWarning;
 	}


### PR DESCRIPTION
# Description

This adds a feature that allows the user to copy and paste the toast popup error and warning notifications.

Note you cannot scroll with a long msg but you can quickly click (normally 3 times on machines) to copy the entire msg to view another way. A select all grabs the entire page and not just the msg. This seems fine and needs to be added to documentation.

This also fixes a long-standing bug where long msg were lost and the program crashed.

Fixes #1158

## Type of change

- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [ ] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

Attempted to add a "copy to clipboard" button in the toast notification but could not make it function correctly. I do not think this is necessary but may be beneficial in the future.
