### PR TITLE
Admin discard button 1326

### DIFF
--- a/src/client/app/components/admin/PreferencesComponent.tsx
+++ b/src/client/app/components/admin/PreferencesComponent.tsx
@@ -321,31 +321,31 @@ export default function PreferencesComponent() {
 				/>
 			</div>
 			<div className='d-flex justify-content-end mt-3'>
-					<Button
-							type='button'
-							onClick={discardChanges}
-							disabled={!hasChanges}
-							style={{ marginRight: '20px' }}
-						>
-							{translate('discard')}
-					</Button>
-					<Button
-						type='submit'
-						onClick={() =>
-							submitPreferences(localAdminPref)
-								.unwrap()
-								.then(() => {
-									showSuccessNotification(translate('updated.preferences'));
-								})
-								.catch(() => {
-									showErrorNotification(translate('failed.to.submit.changes'));
-								})
-						}
-						disabled={!hasChanges}
-					>
-						{translate('submit')}
-					</Button>
-				</div>
+				<Button
+					type='button'
+					onClick={discardChanges}
+					disabled={!hasChanges}
+					style={{ marginRight: '20px' }}
+				>
+					{translate('discard')}
+				</Button>
+				<Button
+					type='submit'
+					onClick={() =>
+						submitPreferences(localAdminPref)
+							.unwrap()
+							.then(() => {
+								showSuccessNotification(translate('updated.preferences'));
+							})
+							.catch(() => {
+								showErrorNotification(translate('failed.to.submit.changes'));
+							})
+					}
+					disabled={!hasChanges}
+				>
+					{translate('submit')}
+				</Button>
+			</div>
 		</div >
 	);
 }

--- a/src/client/app/components/admin/PreferencesComponent.tsx
+++ b/src/client/app/components/admin/PreferencesComponent.tsx
@@ -327,7 +327,7 @@ export default function PreferencesComponent() {
 					disabled={!hasChanges}
 					style={{ marginRight: '20px' }}
 				>
-					{translate('discard')}
+					{translate('discard.changes')}
 				</Button>
 				<Button
 					type='submit'

--- a/src/client/app/components/admin/PreferencesComponent.tsx
+++ b/src/client/app/components/admin/PreferencesComponent.tsx
@@ -320,32 +320,32 @@ export default function PreferencesComponent() {
 					onChange={e => makeLocalChanges('defaultHelpUrl', e.target.value)}
 				/>
 			</div>
-			
-			<Button
-					type='button'
-					onClick={discardChanges}
-					disabled={!hasChanges}
-					className='mr-2'
-				>
-					{translate('discard')}
-				</Button>
-			<Button
-				type='submit'
-				onClick={() =>
-					submitPreferences(localAdminPref)
-						.unwrap()
-						.then(() => {
-							showSuccessNotification(translate('updated.preferences'));
-						})
-						.catch(() => {
-							showErrorNotification(translate('failed.to.submit.changes'));
-						})
-				}
-				disabled={!hasChanges}
-				className='align-self-end mt-3'
-			>
-				{translate('submit')}
-			</Button>
+			<div className='d-flex justify-content-end mt-3'>
+					<Button
+							type='button'
+							onClick={discardChanges}
+							disabled={!hasChanges}
+							style={{ marginRight: '20px' }}
+						>
+							{translate('discard')}
+					</Button>
+					<Button
+						type='submit'
+						onClick={() =>
+							submitPreferences(localAdminPref)
+								.unwrap()
+								.then(() => {
+									showSuccessNotification(translate('updated.preferences'));
+								})
+								.catch(() => {
+									showErrorNotification(translate('failed.to.submit.changes'));
+								})
+						}
+						disabled={!hasChanges}
+					>
+						{translate('submit')}
+					</Button>
+				</div>
 		</div >
 	);
 }

--- a/src/client/app/components/admin/PreferencesComponent.tsx
+++ b/src/client/app/components/admin/PreferencesComponent.tsx
@@ -38,6 +38,10 @@ export default function PreferencesComponent() {
 		setLocalAdminPref({ ...localAdminPref, [key]: value });
 	};
 
+	const discardChanges = () => {
+		setLocalAdminPref(cloneDeep(adminPreferences));
+	};
+
 	return (
 		<div className='d-flex flex-column '>
 			<UnsavedWarningComponent
@@ -316,7 +320,15 @@ export default function PreferencesComponent() {
 					onChange={e => makeLocalChanges('defaultHelpUrl', e.target.value)}
 				/>
 			</div>
-
+			
+			<Button
+					type='button'
+					onClick={discardChanges}
+					disabled={!hasChanges}
+					className='mr-2'
+				>
+					{translate('discard')}
+				</Button>
 			<Button
 				type='submit'
 				onClick={() =>


### PR DESCRIPTION
# Description

There was a desire to add a discard button in admin settings to unwanted changes

Fixes #1326

I added a discard button that reverts the admin preferences to default and I put this button and the submit button into a flex box for organization purposes.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x} I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x} I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

No extra work needs to be done