### PR TITLE
Default meter select

### DIFF
--- a/src/client/app/components/ThreeDPillComponent.tsx
+++ b/src/client/app/components/ThreeDPillComponent.tsx
@@ -52,7 +52,7 @@ export default function ThreeDPillComponent() {
 				meterOrGroup: singlePill.meterOrGroup
 			}));
 		}
-	}, [meterPillData, groupPillData, dispatch]);
+	}, [meterPillData, groupPillData]);
 
 	// When a Pill Badge is clicked update threeD state to indicate new meter or group to render.
 	const handlePillClick = (pillData: MeterOrGroupPill) => dispatch(
@@ -61,7 +61,6 @@ export default function ThreeDPillComponent() {
 			meterOrGroup: pillData.meterOrGroup
 		})
 	);
-
 
 	// Method Generates Reactstrap Pill Badges for selected meters or groups
 	const populatePills = (meterOrGroupPillData: MeterOrGroupPill[]) => {

--- a/src/client/app/components/ThreeDPillComponent.tsx
+++ b/src/client/app/components/ThreeDPillComponent.tsx
@@ -41,16 +41,18 @@ export default function ThreeDPillComponent() {
 		return { meterOrGroupID: groupID, isDisabled: isDisabled, meterOrGroup: MeterOrGroup.groups } as MeterOrGroupPill;
 	});
 
-	// when there is only one meter, it must be selected as a default (there is no other option)
+	// when there is only one choice, it must be selected as a default (there is no other option)
 	useEffect(() => {
-		if (meterPillData.length === 1) {
-			const singleMeter = meterPillData[0];
+		const combinedPillData = [...meterPillData, ...groupPillData];
+
+		if (combinedPillData.length === 1) {
+			const singlePill = combinedPillData[0];
 			dispatch(updateThreeDMeterOrGroupInfo({
-				meterOrGroupID: singleMeter.meterOrGroupID,
-				meterOrGroup: singleMeter.meterOrGroup
+				meterOrGroupID: singlePill.meterOrGroupID,
+				meterOrGroup: singlePill.meterOrGroup
 			}));
 		}
-	}, [meterPillData, dispatch]);
+	}, [meterPillData, groupPillData, dispatch]);
 
 	// When a Pill Badge is clicked update threeD state to indicate new meter or group to render.
 	const handlePillClick = (pillData: MeterOrGroupPill) => dispatch(

--- a/src/client/app/components/ThreeDPillComponent.tsx
+++ b/src/client/app/components/ThreeDPillComponent.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react';
+import { useEffect } from 'react';
 import { Badge } from 'reactstrap';
 import { selectGraphState, selectThreeDState, updateThreeDMeterOrGroupInfo } from '../redux/slices/graphSlice';
 import { selectGroupDataById } from '../redux/api/groupsApi';
@@ -40,6 +41,17 @@ export default function ThreeDPillComponent() {
 		return { meterOrGroupID: groupID, isDisabled: isDisabled, meterOrGroup: MeterOrGroup.groups } as MeterOrGroupPill;
 	});
 
+	// when there is only one meter, it must be selected as a default (there is no other option)
+	useEffect(() => {
+		if (meterPillData.length === 1) {
+			const singleMeter = meterPillData[0];
+			dispatch(updateThreeDMeterOrGroupInfo({
+				meterOrGroupID: singleMeter.meterOrGroupID,
+				meterOrGroup: singleMeter.meterOrGroup
+			}));
+		}
+	}, [meterPillData, dispatch]);
+
 	// When a Pill Badge is clicked update threeD state to indicate new meter or group to render.
 	const handlePillClick = (pillData: MeterOrGroupPill) => dispatch(
 		updateThreeDMeterOrGroupInfo({
@@ -47,6 +59,7 @@ export default function ThreeDPillComponent() {
 			meterOrGroup: pillData.meterOrGroup
 		})
 	);
+
 
 	// Method Generates Reactstrap Pill Badges for selected meters or groups
 	const populatePills = (meterOrGroupPillData: MeterOrGroupPill[]) => {


### PR DESCRIPTION
# Description

Fixes #1186 

Utilized React's useEffect hook to manage which option is selected when there is only one option (the only available choice, by default). 

## Type of change

- [ x] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [ x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [ x] I have removed text in ( ) from the issue request
- [ x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

None, at first the code was too specific and only applied to one of the data categories but after reanalysis it was rewritten to work in a more general sense.
