### PR TITLE
Revised margins for graphics components

### DIFF
--- a/src/client/app/components/BarChartComponent.tsx
+++ b/src/client/app/components/BarChartComponent.tsx
@@ -81,7 +81,7 @@ export default function BarChartComponent() {
 				data={datasets}
 				style={{ width: '100%', height: '100%', minHeight: '700px' }}
 				layout={{
-					margin: { t: 0, b: 0, r: 0 }, // Eliminate top, bottom, and right margins
+					margin: { t: 0, b: 0, r: 3 }, // Eliminate top, bottom, and right margins
 					barmode: (barStacking ? 'stack' : 'group'),
 					bargap: 0.2, // Gap between different times of readings
 					bargroupgap: 0.1, // Gap between different meter's readings under the same timestamp

--- a/src/client/app/components/BarChartComponent.tsx
+++ b/src/client/app/components/BarChartComponent.tsx
@@ -81,6 +81,7 @@ export default function BarChartComponent() {
 				data={datasets}
 				style={{ width: '100%', height: '100%', minHeight: '700px' }}
 				layout={{
+					margin: { t: 0, b: 0, r: 0 }, // Eliminate top, bottom, and right margins
 					barmode: (barStacking ? 'stack' : 'group'),
 					bargap: 0.2, // Gap between different times of readings
 					bargroupgap: 0.1, // Gap between different meter's readings under the same timestamp

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -78,6 +78,7 @@ export default function LineChartComponent() {
 				data={data}
 				style={{ width: '100%', height: '100%', minHeight: '700px' }}
 				layout={{
+					margin: { t: 0, b: 0, r: 0 }, // Eliminate top, bottom, and right margins
 					autosize: true, showlegend: true,
 					legend: { x: 0, y: 1.1, orientation: 'h' },
 					// 'fixedrange' on the yAxis means that dragging is only allowed on the xAxis which we utilize for selecting dateRanges

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -78,7 +78,7 @@ export default function LineChartComponent() {
 				data={data}
 				style={{ width: '100%', height: '100%', minHeight: '700px' }}
 				layout={{
-					margin: { t: 0, b: 0, r: 0 }, // Eliminate top, bottom, and right margins
+					margin: { t: 0, b: 0, r: 3 }, // Eliminate top, bottom, and right margins
 					autosize: true, showlegend: true,
 					legend: { x: 0, y: 1.1, orientation: 'h' },
 					// 'fixedrange' on the yAxis means that dragging is only allowed on the xAxis which we utilize for selecting dateRanges

--- a/src/client/app/components/MapChartComponent.tsx
+++ b/src/client/app/components/MapChartComponent.tsx
@@ -419,6 +419,7 @@ export default function MapChartComponent() {
 
 	// set map background image
 	const layout: any = {
+		margin: { b: 0, l: 0, r: 0 }, // Eliminate bottom, left, and right margins
 		// Either the actual map name or text to say it is not available.
 		title: {
 			text: (map) ? map.name : translate('map.unavailable')

--- a/src/client/app/containers/MapChartContainer.ts
+++ b/src/client/app/containers/MapChartContainer.ts
@@ -308,6 +308,7 @@ function mapStateToProps(state: State) {
 
 	// set map background image
 	const layout: any = {
+		margin: { b: 0, l: 0, r: 0 }, // Eliminate bottom, left, and right margins
 		// Either the actual map name or text to say it is not available.
 		title: {
 			text: (map) ? map.name : translate('map.unavailable')


### PR DESCRIPTION
# Description

Modified margins in the layout objects of the specified components in src/client/app/components. This was done with the intent of making the graphs bigger by eliminating unnecessary space.

Implemented changes in Bar and Line: set top, bottom, and right margins to 0. Left margin was not removed because the y axis label would overlap with the units.
Implemented changes in Map: set bottom, left, and right margins to 0. Top margin was not removed because it would hide the name of the map. **Also made the same change to app/containers/MapChartContainer.ts to be consistent, which changed the size of the circles representing groups/meters over the buildings.

3D is unmodified because it was previously addressed. MultiCompare and Radar are unmodified because they have special, preset margin settings.

Fixes #1172

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

No remaining issues, unless it's decided that some margins should be further modified for whatever reason.
