### PR TITLE
Worked on Issue 1307

### DIFF
--- a/src/server/sql/preferences/create_preferences_table.sql
+++ b/src/server/sql/preferences/create_preferences_table.sql
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+CREATE TYPE disable_checks_enum AS ENUM (
+	'no_reject_bad',
+	'no_reject_all',
+	'yes_no_checks'
+);
 -- create preferences table
 CREATE TABLE IF NOT EXISTS preferences (
 	id SERIAL PRIMARY KEY,
@@ -21,6 +26,6 @@ CREATE TABLE IF NOT EXISTS preferences (
     default_meter_maximum_date TIMESTAMP NOT NULL,
 	default_meter_reading_gap REAL NOT NULL,
     default_meter_maximum_errors INTEGER NOT NULL,
-	default_meter_disable_checks BOOLEAN NOT NULL,
+	default_meter_disable_checks disable_checks_enum NOT NULL,
 	default_help_url TEXT DEFAULT NULL
 );

--- a/src/server/sql/preferences/insert_default_row.sql
+++ b/src/server/sql/preferences/insert_default_row.sql
@@ -21,7 +21,7 @@ IF NOT EXISTS(SELECT *
 	default_meter_disable_checks, default_help_url) 
 	VALUES ('', 'line', FALSE, 'en', NULL, 5, 25, FALSE, 'meters', '00:15:00', 
 	-9007199254740991, 9007199254740991, '1970-01-01 00:00:00+00:00', '6970-01-01 00:00:00+00:00',
-	0, 75, FALSE, 'https://openenergydashboard.github.io/');
+	0, 75, 'no_reject_all', 'https://openenergydashboard.github.io/');
 END IF ;
 
 END;


### PR DESCRIPTION
# Description

I worked on issue 1307 and modified how the system handles range checks for meter readings in OED. Before, if a reading was outside the set range, all the readings in the batch were rejected but now the selective rejection is allowed. Database schema was updated as well as test cases. 

Fixes #1307 

## Type of change

- [X] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [X] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [X] I have removed text in ( ) from the issue request
- [X] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations
