### PR TITLE
Adding base for the client side Max&Min default values on create unit…

### DIFF
--- a/src/client/app/components/unit/CreateUnitModalComponent.tsx
+++ b/src/client/app/components/unit/CreateUnitModalComponent.tsx
@@ -34,6 +34,8 @@ export default function CreateUnitModalComponent() {
 		secInRate: 3600,
 		suffix: '',
 		note: '',
+		defaultMeterMinimumValue:-999999999999,
+		defaultMeterMaximumValue:999999999999,
 		// These two values are necessary but are not used.
 		// The client code makes the id for the selected unit and default graphic unit be -99
 		// so it can tell it is not yet assigned and do the correct logic for that case.
@@ -266,6 +268,39 @@ export default function CreateUnitModalComponent() {
 								<FormattedMessage id="error.required" />
 							</FormFeedback>
 						</FormGroup></Col>
+
+					</Row>
+					<Row xs='1' lg='2'>
+						{/* default Meter Minimum Value input */}
+						<Col><FormGroup>
+							<Label for='defaultMeterMinimumValue'>{translate('default.meter.minimum.value')}</Label>
+							<Input
+								id='defaultMeterMinimumValue'
+								name='defaultMeterMinimumValue'
+								type='number'
+								onChange={e => handleNumberChange(e)}
+								defaultValue={state.defaultMeterMinimumValue}
+								maxLength={50} />
+							<FormFeedback>
+								<FormattedMessage id="error.required" />
+							</FormFeedback>
+						</FormGroup></Col>
+						{/* default Meter Maximum Value input input */}
+						<Col><FormGroup>
+							<Label for='defaultMeterMaximumValue'>{translate('default.meter.maximum.value')}</Label>
+							<Input
+								id='defaultMeterMaximumValue'
+								name='defaultMeterMaximumValue'
+								type='number'
+								onChange={e => handleNumberChange(e)}
+								defaultValue={state.defaultMeterMaximumValue}
+								maxLength={50} />
+							<FormFeedback>
+								<FormattedMessage id="error.required" />
+							</FormFeedback>
+						</FormGroup></Col>
+
+
 					</Row>
 					{/* Note input */}
 					<FormGroup>

--- a/src/client/app/types/redux/units.ts
+++ b/src/client/app/types/redux/units.ts
@@ -31,6 +31,8 @@ export interface UnitData {
 	displayable: DisplayableType;
 	preferredDisplay: boolean;
 	note: string;
+	defaultMeterMinimumValue:number,
+	defaultMeterMaximumValue:number
 }
 
 export interface UnitEditData {

--- a/src/server/models/Unit.js
+++ b/src/server/models/Unit.js
@@ -18,8 +18,10 @@ class Unit {
 	 * @param {*} displayable Can be none, all, or admin. Restrict the type of user that can see this unit.
 	 * @param {*} preferredDisplay True if this unit is always displayed. If not, the user needs to ask to see (for future enhancement).
 	 * @param {*} note Note about this unit.
+	 * @param {*} defaultMeterMinimumValue The default minimum value for meters.
+	 * @param {*} defaultMeterMaximumValue The default maximum value for meters.
 	 */
-	constructor(id, name, identifier = name, unitRepresent, secInRate = 3600, typeOfUnit, suffix = '', displayable, preferredDisplay, note) {
+	constructor(id, name, identifier = name, unitRepresent, secInRate = 3600, typeOfUnit, suffix = '', displayable, preferredDisplay,defaultMeterMinimumValue, defaultMeterMaximumValue, note) {
 		this.id = id;
 		this.name = name;
 		this.identifier = identifier;
@@ -29,6 +31,8 @@ class Unit {
 		this.suffix = suffix;
 		this.displayable = displayable;
 		this.preferredDisplay = preferredDisplay;
+		this.defaultMeterMinimumValue = defaultMeterMinimumValue;
+		this.defaultMeterMaximumValue = defaultMeterMaximumValue;
 		this.note = note;
 	}
 


### PR DESCRIPTION
… issue

# Description

This pr adds the max min default values to CreateUnitModalComponent.tsx as well as making minor changes units.tx and Unit.js to add the new parameters

Partly Addresses #1307 

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [ ] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [ ] I have removed text in ( ) from the issue request
- [ ] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.github.io/developer/cla.html) and each author is listed in the Description section.

## Limitations

This pr only does the base client side, it still requires the server side connection as well as the prefer display changes to fully address the create unit part of the problem
