### PR TITLE
updated ThreeD, Radar, Map area calculation method

### DIFF
--- a/src/client/app/components/MapChartComponent.tsx
+++ b/src/client/app/components/MapChartComponent.tsx
@@ -145,22 +145,20 @@ export default function MapChartComponent() {
 
 			for (const meterID of selectedMeters) {
 				// Get meter id number.
-				// Get meter GPS value.
-				const gps = meterDataById[meterID].gps;
+				const entity = meterDataById[meterID];
 				// filter meters with actual gps coordinates.
-				if (gps !== undefined && gps !== null && meterReadings !== undefined) {
-					let meterArea = meterDataById[meterID].area;
+				if (entity.gps !== undefined && entity.gps !== null && meterReadings !== undefined) {
 					// we either don't care about area, or we do in which case there needs to be a nonzero area
-					if (!areaNormalization || (meterArea > 0 && meterDataById[meterID].areaUnit != AreaUnitType.none)) {
-						meterArea = selectAreaScalingFromEntity(meterDataById[meterID], selectedAreaUnit, areaNormalization);
+					if (!areaNormalization || (entity.area > 0 && entity.areaUnit != AreaUnitType.none)) {
+						const meterArea = selectAreaScalingFromEntity(entity, selectedAreaUnit, areaNormalization);
 						// Convert the gps value to the equivalent Plotly grid coordinates on user map.
 						// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
 						// It must be on true north map since only there are the GPS axis parallel to the map axis.
 						// To start, calculate the user grid coordinates (Plotly) from the GPS value. This involves calculating
 						// it coordinates on the true north map and then rotating/shifting to the user map.
-						const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap, map.northAngle);
+						const meterGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, entity.gps, origin, scaleOfMap, map.northAngle);
 						// Only display items within valid info and within map.
-						if (itemMapInfoOk(meterID, DataType.Meter, map, gps) && itemDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
+						if (itemMapInfoOk(meterID, DataType.Meter, map, entity.gps) && itemDisplayableOnMap(imageDimensionNormalized, meterGPSInUserGrid)) {
 							// The x, y value for Plotly to use that are on the user map.
 							x.push(meterGPSInUserGrid.x);
 							y.push(meterGPSInUserGrid.y);
@@ -172,7 +170,7 @@ export default function MapChartComponent() {
 							// This protects against there being no readings or that the data is being updated.
 							if (readingsData !== undefined && !meterIsFetching) {
 								// Meter name to include in hover on graph.
-								const label = meterDataById[meterID].identifier;
+								const label = entity.identifier;
 								// The usual color for this meter.
 								colors.push(getGraphColor(meterID, DataType.Meter));
 								if (!readingsData) {
@@ -218,21 +216,20 @@ export default function MapChartComponent() {
 
 			for (const groupID of selectedGroups) {
 				// Get group id number.
-				// Get group GPS value.
-				const gps = groupDataById[groupID].gps;
+				const entity = groupDataById[groupID];
 				// Filter groups with actual gps coordinates.
-				if (gps !== undefined && gps !== null && groupData !== undefined) {
-					let groupArea = groupDataById[groupID].area;
-					if (!areaNormalization || (groupArea > 0 && groupDataById[groupID].areaUnit != AreaUnitType.none)) {
-						groupArea = selectAreaScalingFromEntity(groupDataById[groupID], selectedAreaUnit, areaNormalization);
+				if (entity.gps !== undefined && entity.gps !== null && groupData !== undefined) {
+					// we either don't care about area, or we do in which case there needs to be a nonzero area
+					if (!areaNormalization || (entity.area > 0 && entity.areaUnit != AreaUnitType.none)) {
+						const groupArea = selectAreaScalingFromEntity(entity, selectedAreaUnit, areaNormalization);
 						// Convert the gps value to the equivalent Plotly grid coordinates on user map.
 						// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
 						// It must be on true north map since only there are the GPS axis parallel to the map axis.
 						// To start, calculate the user grid coordinates (Plotly) from the GPS value. This involves calculating
 						// it coordinates on the true north map and then rotating/shifting to the user map.
-						const groupGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, gps, origin, scaleOfMap, map.northAngle);
+						const groupGPSInUserGrid: CartesianPoint = gpsToUserGrid(imageDimensionNormalized, entity.gps, origin, scaleOfMap, map.northAngle);
 						// Only display items within valid info and within map.
-						if (itemMapInfoOk(groupID, DataType.Group, map, gps) && itemDisplayableOnMap(imageDimensionNormalized, groupGPSInUserGrid)) {
+						if (itemMapInfoOk(groupID, DataType.Group, map, entity.gps) && itemDisplayableOnMap(imageDimensionNormalized, groupGPSInUserGrid)) {
 							// The x, y value for Plotly to use that are on the user map.
 							x.push(groupGPSInUserGrid.x);
 							y.push(groupGPSInUserGrid.y);
@@ -243,7 +240,7 @@ export default function MapChartComponent() {
 							// This protects against there being no readings or that the data is being updated.
 							if (readingsData && !groupIsFetching) {
 								// Group name to include in hover on graph.
-								const label = groupDataById[groupID].name;
+								const label = entity.name;
 								// The usual color for this group.
 								colors.push(getGraphColor(groupID, DataType.Group));
 								if (!readingsData) {

--- a/src/client/app/components/MapChartComponent.tsx
+++ b/src/client/app/components/MapChartComponent.tsx
@@ -18,6 +18,7 @@ import { readingsApi } from '../redux/api/readingsApi';
 import { selectUnitDataById } from '../redux/api/unitsApi';
 import { useAppSelector } from '../redux/reduxHooks';
 import { selectMapChartQueryArgs } from '../redux/selectors/chartQuerySelectors';
+import { selectAreaScalingFromEntity } from '../redux/selectors/entitySelectors';
 import { DataType } from '../types/Datasources';
 import { State } from '../types/redux/state';
 import { UnitRepresentType } from '../types/redux/units';
@@ -30,7 +31,7 @@ import {
 	itemMapInfoOk,
 	normalizeImageDimensions
 } from '../utils/calibration';
-import { AreaUnitType, getAreaUnitConversion } from '../utils/getAreaUnitConversion';
+import { AreaUnitType } from '../utils/getAreaUnitConversion';
 import getGraphColor from '../utils/getGraphColor';
 import { useTranslate } from '../redux/componentHooks';
 import SpinnerComponent from './SpinnerComponent';
@@ -151,10 +152,7 @@ export default function MapChartComponent() {
 					let meterArea = meterDataById[meterID].area;
 					// we either don't care about area, or we do in which case there needs to be a nonzero area
 					if (!areaNormalization || (meterArea > 0 && meterDataById[meterID].areaUnit != AreaUnitType.none)) {
-						if (areaNormalization) {
-							// convert the meter area into the proper unit, if needed
-							meterArea *= getAreaUnitConversion(meterDataById[meterID].areaUnit, selectedAreaUnit);
-						}
+						meterArea = selectAreaScalingFromEntity(meterDataById[meterID], selectedAreaUnit, areaNormalization);
 						// Convert the gps value to the equivalent Plotly grid coordinates on user map.
 						// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
 						// It must be on true north map since only there are the GPS axis parallel to the map axis.
@@ -226,10 +224,7 @@ export default function MapChartComponent() {
 				if (gps !== undefined && gps !== null && groupData !== undefined) {
 					let groupArea = groupDataById[groupID].area;
 					if (!areaNormalization || (groupArea > 0 && groupDataById[groupID].areaUnit != AreaUnitType.none)) {
-						if (areaNormalization) {
-							// convert the meter area into the proper unit, if needed
-							groupArea *= getAreaUnitConversion(groupDataById[groupID].areaUnit, selectedAreaUnit);
-						}
+						groupArea = selectAreaScalingFromEntity(groupDataById[groupID], selectedAreaUnit, areaNormalization);
 						// Convert the gps value to the equivalent Plotly grid coordinates on user map.
 						// First, convert from GPS to grid units. Since we are doing a GPS calculation, this happens on the true north map.
 						// It must be on true north map since only there are the GPS axis parallel to the map axis.

--- a/src/client/app/components/RadarChartComponent.tsx
+++ b/src/client/app/components/RadarChartComponent.tsx
@@ -13,13 +13,14 @@ import { readingsApi } from '../redux/api/readingsApi';
 import { selectUnitDataById } from '../redux/api/unitsApi';
 import { useAppSelector } from '../redux/reduxHooks';
 import { selectRadarChartQueryArgs } from '../redux/selectors/chartQuerySelectors';
+import { selectScalingFromEntity } from '../redux/selectors/entitySelectors';
 import {
 	selectAreaUnit, selectGraphAreaNormalization, selectLineGraphRate,
 	selectSelectedGroups, selectSelectedMeters, selectSelectedUnit
 } from '../redux/slices/graphSlice';
 import { DataType } from '../types/Datasources';
 import Locales from '../types/locales';
-import { AreaUnitType, getAreaUnitConversion } from '../utils/getAreaUnitConversion';
+import { AreaUnitType } from '../utils/getAreaUnitConversion';
 import getGraphColor from '../utils/getGraphColor';
 import { lineUnitLabel } from '../utils/graphics';
 import { useTranslate } from '../redux/componentHooks';
@@ -71,17 +72,13 @@ export default function RadarChartComponent() {
 	// Add all valid data from existing meters to the radar plot
 	for (const meterID of selectedMeters) {
 		if (meterReadings) {
-			const meterArea = meterDataById[meterID].area;
+			const entity = meterDataById[meterID];
 			// We either don't care about area, or we do in which case there needs to be a nonzero area.
-			if (!areaNormalization || (meterArea > 0 && meterDataById[meterID].areaUnit != AreaUnitType.none)) {
-				// Convert the meter area into the proper unit if normalizing by area or use 1 if not so won't change reading values.
-				const areaScaling = areaNormalization ?
-					meterArea * getAreaUnitConversion(meterDataById[meterID].areaUnit, selectedAreaUnit) : 1;
-				// Divide areaScaling into the rate so have complete scaling factor for readings.
-				const scaling = rateScaling / areaScaling;
+			if (!areaNormalization || (entity.area > 0 && entity.areaUnit != AreaUnitType.none)) {
+				const scaling = selectScalingFromEntity(entity, selectedAreaUnit, areaNormalization, rateScaling);
 				const readingsData = meterReadings[meterID];
 				if (readingsData) {
-					const label = meterDataById[meterID].identifier;
+					const label = entity.identifier;
 					const colorID = meterID;
 					// TODO If we are sure the data is always defined then remove this commented out code.
 					// Be consistent for all graphing and groups below.
@@ -132,17 +129,13 @@ export default function RadarChartComponent() {
 	for (const groupID of selectedGroups) {
 		// const byGroupID = state.readings.line.byGroupID[groupID];
 		if (groupData) {
-			const groupArea = groupDataById[groupID].area;
+			const entity = groupDataById[groupID];
 			// We either don't care about area, or we do in which case there needs to be a nonzero area.
-			if (!areaNormalization || (groupArea > 0 && groupDataById[groupID].areaUnit != AreaUnitType.none)) {
-				// Convert the group area into the proper unit if normalizing by area or use 1 if not so won't change reading values.
-				const areaScaling = areaNormalization ?
-					groupArea * getAreaUnitConversion(groupDataById[groupID].areaUnit, selectedAreaUnit) : 1;
-				// Divide areaScaling into the rate so have complete scaling factor for readings.
-				const scaling = rateScaling / areaScaling;
+			if (!areaNormalization || (entity.area > 0 && entity.areaUnit != AreaUnitType.none)) {
+				const scaling = selectScalingFromEntity(entity, selectedAreaUnit, areaNormalization, rateScaling);
 				const readingsData = groupData[groupID];
 				if (readingsData) {
-					const label = groupDataById[groupID].name;
+					const label = entity.name;
 					const colorID = groupID;
 					// if (readingsData.readings === undefined) {
 					// 	throw new Error('Unacceptable condition: readingsData.readings is undefined.');

--- a/src/client/app/components/ThreeDComponent.tsx
+++ b/src/client/app/components/ThreeDComponent.tsx
@@ -11,6 +11,7 @@ import { selectUnitDataById } from '../redux/api/unitsApi';
 import { useAppSelector } from '../redux/reduxHooks';
 import { selectThreeDQueryArgs } from '../redux/selectors/chartQuerySelectors';
 import { selectThreeDComponentInfo } from '../redux/selectors/threeDSelectors';
+import { selectScalingFromEntity } from '../redux/selectors/entitySelectors';
 import { selectGraphState } from '../redux/slices/graphSlice';
 import { ThreeDReading } from '../types/readings';
 import { GraphState, MeterOrGroup } from '../types/redux/graph';
@@ -18,7 +19,7 @@ import { GroupDataByID } from '../types/redux/groups';
 import { MeterDataByID } from '../types/redux/meters';
 import { UnitDataById } from '../types/redux/units';
 import { isValidThreeDInterval, roundTimeIntervalForFetch } from '../utils/dateRangeCompatibility';
-import { AreaUnitType, getAreaUnitConversion } from '../utils/getAreaUnitConversion';
+import { AreaUnitType } from '../utils/getAreaUnitConversion';
 import { lineUnitLabel } from '../utils/graphics';
 // Both translates are used since some are in the function component where the React Hook is okay
 // and some are in other functions where the older method is needed.
@@ -138,23 +139,13 @@ function formatThreeDData(
 			// The rate will be 1 if it is per hour (since state readings are per hour) or no rate scaling so no change.
 			const rateScaling = needsRateScaling ? currentSelectedRate.rate : 1;
 
-			const meterArea = meterOrGroup === MeterOrGroup.meters ?
-				meterDataById[selectedMeterOrGroupID].area
+			const entity = meterOrGroup === MeterOrGroup.meters ?
+				meterDataById[selectedMeterOrGroupID]
 				:
-				groupDataById[selectedMeterOrGroupID].area;
+				groupDataById[selectedMeterOrGroupID];
+			const scaling = selectScalingFromEntity(entity, graphState.selectedAreaUnit, graphState.areaNormalization, rateScaling);
 
-			const areaUnit = meterOrGroup === MeterOrGroup.meters ?
-				meterDataById[selectedMeterOrGroupID].areaUnit
-				:
-				groupDataById[selectedMeterOrGroupID].areaUnit;
-
-			// We either don't care about area, or we do in which case there needs to be a nonzero area.
-			if (!graphState.areaNormalization || (meterArea > 0 && areaUnit != AreaUnitType.none)) {
-				// Convert the meter area into the proper unit if normalizing by area or use 1 if not so won't change reading values.
-				const areaScaling = graphState.areaNormalization ?
-					meterArea * getAreaUnitConversion(areaUnit, graphState.selectedAreaUnit) : 1;
-				// Divide areaScaling into the rate so have complete scaling factor for readings.
-				const scaling = rateScaling / areaScaling;
+			if (!graphState.areaNormalization || (entity.area > 0 && entity.areaUnit != AreaUnitType.none)) {
 				zDataToRender = data.zData.map(day => day.map(reading => reading === null ? null : reading * scaling));
 			}
 		}


### PR DESCRIPTION
# Description
Updated the method of area calculation / normalization in ThreeD, Radar, and Map components. They used to calculate area individually, but now call functions from src/client/app/redux/selectors/entitySelectors.ts to do so. This is now consistent across all components. Line and Bar are unchanged because they already follow this method. MultiCompare doesn't need to.

Fixes #1200

## Type of change
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist
- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations
none
