### PR TITLE
fix help links

### DIFF
--- a/src/client/app/components/HeaderButtonsComponent.tsx
+++ b/src/client/app/components/HeaderButtonsComponent.tsx
@@ -36,7 +36,7 @@ export default function HeaderButtonsComponent() {
 	const version = useAppSelector(selectOEDVersion);
 	const helpUrl = useAppSelector(selectHelpUrl);
 	// options help
-	const optionsHelp = helpUrl + '/optionsMenu.html';
+	const optionsHelp = helpUrl + '/optionsMenu/';
 
 	const loggedInAsAdmin = useAppSelector(selectIsAdmin);
 	const loggedIn = useAppSelector(selectIsLoggedIn);
@@ -127,7 +127,7 @@ export default function HeaderButtonsComponent() {
 			display: pathname === '/' ? 'block' : 'none'
 		};
 		// Admin help or regular user page
-		const neededPage = loggedInAsAdmin ? '/adminPageChoices.html' : '/pageChoices.html';
+		const neededPage = loggedInAsAdmin ? '/adminPageChoices/' : '/pageChoices/';
 		const currentPageChoicesHelp = helpUrl + neededPage;
 
 		setState(prevState => ({

--- a/src/client/app/components/LanguageSelectorComponent.tsx
+++ b/src/client/app/components/LanguageSelectorComponent.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { DropdownItem, DropdownMenu, DropdownToggle, UncontrolledDropdown } from 'reactstrap';
 import { selectSelectedLanguage, updateSelectedLanguage } from '../redux/slices/appStateSlice';
-import { selectOEDVersion } from '../redux/api/versionApi';
 import { useAppDispatch, useAppSelector } from '../redux/reduxHooks';
 import { LanguageTypes } from '../types/redux/i18n';
 import { selectBaseHelpUrl } from '../redux/slices/adminSlice';
@@ -19,10 +18,9 @@ export default function LanguageSelectorComponent() {
 	const dispatch = useAppDispatch();
 
 	const selectedLanguage = useAppSelector(selectSelectedLanguage);
-	const version = useAppSelector(selectOEDVersion);
 	const baseHelpUrl = useAppSelector(selectBaseHelpUrl);
 
-	const helpUrl = baseHelpUrl + version;
+	const helpUrl = baseHelpUrl;
 
 	return (
 		<>
@@ -48,7 +46,7 @@ export default function LanguageSelectorComponent() {
 					</DropdownItem>
 					<DropdownItem divider />
 					<DropdownItem
-						href={helpUrl + '/language.html'}>
+						href={helpUrl + '/language/'}>
 						<FormattedMessage id="help" />
 					</DropdownItem>
 				</DropdownMenu>

--- a/src/client/app/components/LanguageSelectorComponent.tsx
+++ b/src/client/app/components/LanguageSelectorComponent.tsx
@@ -8,7 +8,7 @@ import { DropdownItem, DropdownMenu, DropdownToggle, UncontrolledDropdown } from
 import { selectSelectedLanguage, updateSelectedLanguage } from '../redux/slices/appStateSlice';
 import { useAppDispatch, useAppSelector } from '../redux/reduxHooks';
 import { LanguageTypes } from '../types/redux/i18n';
-import { selectBaseHelpUrl } from '../redux/slices/adminSlice';
+import { selectHelpUrl } from '../redux/slices/adminSlice';
 
 /**
  * A component that allows users to select which language the page should be displayed in.
@@ -18,9 +18,7 @@ export default function LanguageSelectorComponent() {
 	const dispatch = useAppDispatch();
 
 	const selectedLanguage = useAppSelector(selectSelectedLanguage);
-	const baseHelpUrl = useAppSelector(selectBaseHelpUrl);
-
-	const helpUrl = baseHelpUrl;
+	const helpUrl = useAppSelector(selectHelpUrl);
 
 	return (
 		<>


### PR DESCRIPTION
# Description

Several help links were still pointing to the old web address. I tried to search for them all so hopefully all fixed now.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

None known
