### PR TITLE
Script to check website status and send email to users if website is down

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"bcryptjs": "~2.4.3",
 				"body-parser": "~1.20.2",
 				"bootstrap": "~5.3.3",
+				"colors": "~1.4.0",
 				"csv": "~5.3.2",
 				"csv-stringify": "~5.6.5",
 				"d3": "~7.8.5",
@@ -34,6 +35,7 @@
 				"multer": "~1.4.5-lts.1",
 				"ngraph.graph": "~20.0.0",
 				"ngraph.path": "~1.5.0",
+				"node-cron": "~3.0.3",
 				"nodemailer": "~6.9.13",
 				"pg": "~8.12.0",
 				"pg-promise": "~11.8.0",
@@ -2885,6 +2887,15 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
+		},
+		"node_modules/colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.1.90"
+			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -7251,6 +7262,27 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
 			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
 			"dev": true
+		},
+		"node_modules/node-cron": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+			"integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+			"license": "ISC",
+			"dependencies": {
+				"uuid": "8.3.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/node-cron/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
 		"node_modules/node-polyfill-webpack-plugin": {
 			"version": "1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
 				"bcryptjs": "~2.4.3",
 				"body-parser": "~1.20.2",
 				"bootstrap": "~5.3.3",
-				"colors": "~1.4.0",
 				"csv": "~5.3.2",
 				"csv-stringify": "~5.6.5",
 				"d3": "~7.8.5",
@@ -35,7 +34,6 @@
 				"multer": "~1.4.5-lts.1",
 				"ngraph.graph": "~20.0.0",
 				"ngraph.path": "~1.5.0",
-				"node-cron": "~3.0.3",
 				"nodemailer": "~6.9.13",
 				"pg": "~8.12.0",
 				"pg-promise": "~11.8.0",
@@ -2887,15 +2885,6 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
-		},
-		"node_modules/colors": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.1.90"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -7262,27 +7251,6 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
 			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
 			"dev": true
-		},
-		"node_modules/node-cron": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
-			"integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
-			"license": "ISC",
-			"dependencies": {
-				"uuid": "8.3.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/node-cron/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
 		},
 		"node_modules/node-polyfill-webpack-plugin": {
 			"version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"start": "node ./src/bin/www",
 		"start:dev": "nodemon --legacy-watch --inspect=0.0.0.0 ./src/bin/www",
+		"status": "node src/server/services/checkWebsiteStatus.js",
 		"webpack:dev": "webpack watch --color --progress --mode development",
 		"webpack:build": "webpack build --node-env production",
 		"webpack": "webpack build --color --progress --mode development",
@@ -62,6 +63,7 @@
 		"bcryptjs": "~2.4.3",
 		"body-parser": "~1.20.2",
 		"bootstrap": "~5.3.3",
+		"colors": "~1.4.0",
 		"csv": "~5.3.2",
 		"csv-stringify": "~5.6.5",
 		"d3": "~7.8.5",
@@ -81,6 +83,7 @@
 		"multer": "~1.4.5-lts.1",
 		"ngraph.graph": "~20.0.0",
 		"ngraph.path": "~1.5.0",
+		"node-cron": "~3.0.3",
 		"nodemailer": "~6.9.13",
 		"pg": "~8.12.0",
 		"pg-promise": "~11.8.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"start": "node ./src/bin/www",
 		"start:dev": "nodemon --legacy-watch --inspect=0.0.0.0 ./src/bin/www",
-		"status": "node src/server/services/checkWebsiteStatus.js",
+		"checkWebsiteStatus": "node src/server/services/checkWebsiteStatus.js",
 		"webpack:dev": "webpack watch --color --progress --mode development",
 		"webpack:build": "webpack build --node-env production",
 		"webpack": "webpack build --color --progress --mode development",
@@ -63,7 +63,6 @@
 		"bcryptjs": "~2.4.3",
 		"body-parser": "~1.20.2",
 		"bootstrap": "~5.3.3",
-		"colors": "~1.4.0",
 		"csv": "~5.3.2",
 		"csv-stringify": "~5.6.5",
 		"d3": "~7.8.5",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
 		"multer": "~1.4.5-lts.1",
 		"ngraph.graph": "~20.0.0",
 		"ngraph.path": "~1.5.0",
-		"node-cron": "~3.0.3",
 		"nodemailer": "~6.9.13",
 		"pg": "~8.12.0",
 		"pg-promise": "~11.8.0",

--- a/src/scripts/checkWebsiteStatusCron.bash
+++ b/src/scripts/checkWebsiteStatusCron.bash
@@ -1,9 +1,16 @@
-# This aggregates the readings data at hour level.
+#!/bin/bash
+# *
+# * This Source Code Form is subject to the terms of the Mozilla Public
+# * License, v. 2.0. If a copy of the MPL was not distributed with this
+# * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# *
+
+# This check the website status at hour level.
 # This should be copied to /etc/ or /etc/cron.hourly/ or /etc/cron.daily and the copy renamed so that its function will be clear to admins.
 
 # Check if a URL is provided as an argument
 if [ -z "$1" ]; then
-    echo "Error: No URL provided. Usage: $0"
+    echo "Error: No URL provided. Usage: $0 URL-to-check"
     exit 1
 fi
 

--- a/src/scripts/checkWebsiteStatusCron.bash
+++ b/src/scripts/checkWebsiteStatusCron.bash
@@ -1,0 +1,16 @@
+# This aggregates the readings data at hour level.
+# This should be copied to /etc/ or /etc/cron.hourly/ or /etc/cron.daily and the copy renamed so that its function will be clear to admins.
+
+# Check if a URL is provided as an argument
+if [ -z "$1" ]; then
+    echo "Error: No URL provided. Usage: $0"
+    exit 1
+fi
+
+URL=$1
+
+# The absolute path the project root directory (OED)
+cd '/example/path/to/project/OED'
+
+# The following line should NOT need to be edited except by devs or if you have an old system with only docker-compose.
+docker compose run --rm web npm run --silent checkWebsiteStatus -- $URL &>> /dev/null &

--- a/src/server/services/checkWebsiteStatus.js
+++ b/src/server/services/checkWebsiteStatus.js
@@ -2,11 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-	const cron = require('node-cron');
-	const { getConnection } = require('../db');
 	const { log } = require('../log');
-	const { logMailer } = require('../logMailer');
-	const LogEmail = require('../models/LogEmail');
 	const WEBSITE_URL = process.argv[2];
 	
 	async function checkWebsite() {

--- a/src/server/services/checkWebsiteStatus.js
+++ b/src/server/services/checkWebsiteStatus.js
@@ -2,23 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-	const { log } = require('../log');
-	const WEBSITE_URL = process.argv[2];
-	
-	async function checkWebsite() {
-		try {
-			const response = await fetch(WEBSITE_URL, { method: 'HEAD' });
-	
-			if (!response.ok) {
-				const errorMessage = `The server at ${WEBSITE_URL} is down.`;
-				// Log the error using Logger class
-				log.error(errorMessage);	
-			}
-		} catch (error) {
-			const errorMessage = `Failed to reach ${WEBSITE_URL}. Error: ${error.message}`;
-	  log.error(errorMessage, error);
+const { log } = require('../log');
+const WEBSITE_URL = process.argv[2];
+
+async function checkWebsite() {
+	try {
+		const response = await fetch(WEBSITE_URL, { method: 'HEAD' });
+
+		if (!response.ok) {
+			const errorMessage = `The server at ${WEBSITE_URL} is down.`;
+			// Log the error using Logger class
+			log.error(errorMessage);
 		}
+	} catch (error) {
+		const errorMessage = `Failed to reach ${WEBSITE_URL}. Error: ${error.message}`;
+		log.error(errorMessage, error);
 	}
-	
-	checkWebsite();
-	
+}
+
+checkWebsite();

--- a/src/server/services/checkWebsiteStatus.js
+++ b/src/server/services/checkWebsiteStatus.js
@@ -1,0 +1,52 @@
+const cron = require('node-cron');
+const { getConnection } = require('../db');
+const { logMailer } = require('../logMailer');
+const LogEmail = require('../models/LogEmail');
+const colors = require('colors');
+  
+async function checkWebsite() {
+  const conn = getConnection();
+
+  try {
+    const response = await fetch('https://httpstat.us/500/', { method: 'HEAD' });
+
+    if (response.ok) {
+      console.log('The server is up'.green.inverse);
+    } else {
+      console.error('The server is down'.red.inverse);
+
+      const errorMessage = 'The server at https://httpstat.us/500/ is down.';
+
+      // Log the error in the database
+      const log = new LogEmail(undefined, errorMessage);
+      await log.insert(conn);
+
+      // Send a logging email
+      await logMailer(conn);
+    }
+  } 
+  catch (error) {
+    console.error('Error:', error);
+
+    const errorMessage = `Failed to reach https://httpstat.us/500/. Error: ${error.message}`;
+
+    // Log the error in the database
+    const log = new LogEmail(undefined, errorMessage);
+    await log.insert(conn);
+
+    // Send a logging email
+    await logMailer(conn);
+  } finally {
+    if (conn.close) {
+      await conn.close();
+    }
+  }
+}
+
+// Schedule the task to run every hour
+// cron.schedule('0 * * * *', () => {
+//   console.log('Running website status check...');
+//   checkWebsite();
+// });
+
+checkWebsite();


### PR DESCRIPTION
# Description

Created a file named 'checkWebsiteStatus.js' that contains the script to check website status and sends email to users when the website is down. 

Partly Addresses #557 

## Type of change
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

Currently, I am unable to see if the email-sending part works. I verified that it prints 'The server is down' in the console when the website is down.  I replaced some variables in docker-compose.yml with my emails and credentials, restarted the server and ran the script with command 'npm run status' but no email was received. 

Could you run the script to see if it works on your end since your email is already in the database? Feel free give any feedback if you notice anything wrong. 

The cron schedule is currently excluded for ease of testing.