### PR TITLE
Issue 1187 - Horizontal shift when show error bars

### DIFF
--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -73,14 +73,13 @@ export default function LineChartComponent() {
 		return <SpinnerComponent loading height={50} width={50} />;
 	}
 
-
-	// Check if there is at least one valid graph
-	const enoughData = data.find(data => data.x!.length > 1);
 	// Customize the layout of the plot
 	// See https://community.plotly.com/t/replacing-an-empty-graph-with-a-message/31497 for showing text not plot.
 	if (data.length === 0) {
 		return <h1>{`${translate('select.meter.group')}`}	</h1>;
-	} else if (!enoughData) {
+	}
+	// Checks if there is enough data for at least one valid graph
+	else if (!data[0].x) {
 		return <h1>{`${translate('no.data.in.range')}`}</h1>;
 	} else {
 		return (
@@ -93,7 +92,8 @@ export default function LineChartComponent() {
 					legend: { x: 0, y: 1.1, orientation: 'h' },
 					// 'fixedrange' on the yAxis means that dragging is only allowed on the xAxis which we utilize for selecting dateRanges
 					yaxis: { title: unitLabel, gridcolor: '#ddd', fixedrange: true },
-					xaxis: { rangeslider: { visible: true }, showgrid: true, gridcolor: '#ddd' }
+					//Range must be between these values to allow error bars to show properly
+					xaxis: { rangeslider: { visible: true }, showgrid: true, gridcolor: '#ddd', range: [data[0].x[0], data[0].x[data[0].x.length - 1]]}
 				}}
 				config={{
 					responsive: true,


### PR DESCRIPTION
# Description

When creating a line bar graph and "Show error bars" is checked, the graph horizontally shrinks. 
This request changes a check to allow the use of the x-axis values. Which can be used in a range modifier that affects the size of the x-axis. This range modifier allows error bars to not adjust the size of the graph.

Mason Sain - @sainmas
Pedro Valdovinos Reyes - @PValdovinos

Fixes #[1187](https://github.com/OpenEnergyDashboard/OED/issues/1187)

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

One potential issue that remains is the fact that the rangeslider still shows grey area on the right and left.