### PR TITLE
Update readingsCompareMeterQuantity.js

### DIFF
--- a/src/scripts/backupScript.sh
+++ b/src/scripts/backupScript.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+# Input the pathname for the desired backup directory
+# ie PATH="/home/<your_username>/path_to/database_dumps/dump.sql"
+# This path MUST exist
+
+# This could probably be programmatically populated. Currently needs to be set manually
+db_dump_path="/home/<your_username>/database_dumps" #INPUT REQUIRED
+
+# Generate a timestamp to append to the dump file. This line has errors at the moment.
+date=`date +%Y-%m-%d_%H_%M_%S`
+
+# Set the final path for the backup file
+final_path="${db_dump_path}/dump_${date}.sql"
+
+# Perform the backup using pg_dump
+docker compose exec database pg_dump -U oed > "$final_path"

--- a/src/scripts/backupScript.sh
+++ b/src/scripts/backupScript.sh
@@ -3,6 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # The OED Docker database container must be running for this script to work
 
 # Input the pathname for the desired backup directory
@@ -27,3 +28,5 @@ final_path="${db_dump_path}/dump_${date}.sql"
 
 # Perform the backup using pg_dump
 docker compose exec database pg_dump -U oed > "$final_path"
+
+echo "OED database backup placed in ${final_path}"

--- a/src/scripts/backupScript.sh
+++ b/src/scripts/backupScript.sh
@@ -3,16 +3,23 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
+# The OED Docker database container must be running for this script to work
 
 # Input the pathname for the desired backup directory
-# ie PATH="/home/<your_username>/path_to/database_dumps/dump.sql"
-# This path MUST exist
+# ie PATH="/home/<your_username>/path_to/database_dumps/"
+# This path MUST exist, otherwise, this script will attempt to create the directory, or fail.
 
 # This could probably be programmatically populated. Currently needs to be set manually
-db_dump_path="/home/<your_username>/database_dumps" #INPUT REQUIRED
+db_dump_path="/home/<username>/database_dumps" #INPUT REQUIRED
 
-# Generate a timestamp to append to the dump file. This line has errors at the moment.
+# Checks to see if the directory is exists
+# If not, it will display a message, and attempt to create the backup directory
+if [ ! -d "$db_dump_path" ]; then
+    echo "Backup directory does not exist. Creating it now..."
+    mkdir -p "$db_dump_path" || { echo "Failed to create directory. Exiting."; exit 1; }
+fi
+
+# Generate a timestamp to append to the dump file.
 date=`date +%Y-%m-%d_%H_%M_%S`
 
 # Set the final path for the backup file

--- a/src/server/test/web/readingsCompareMeterQuantity.js
+++ b/src/server/test/web/readingsCompareMeterQuantity.js
@@ -85,16 +85,16 @@ mocha.describe('readings API', () => {
 					expectCompareToEqualExpected(res, expected);
 				});
 
-				mocha.it('C6: 28 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as kWh', async () => {
+				mocha.it('C6: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh', async () => {
 					await prepareTest(unitDatakWh, conversionDatakWh, meterDatakWh);
 					const unitId = await getUnitId('kWh');
 					const expected = [108269.924822581, 108889.847659507];
-					const res = await chai.request(app).get('/api/compareReadings/meters/${METER_ID}')
+					const res = await chai.request(app).get(`/api/compareReadings/meters/${METER_ID}`)
 						.query({
 							curr_start: '2022-10-09 00:00:00',
-							curr_end: '2022-10-31 17:00:00',
+							curr_end: '2022-10-31 17:12:34', 
 							shift: 'P28D',
-							graphicUnitID:unitId
+							graphicUnitId: unitId
 						});
 					expectCompareToEqualExpected(res, expected);
 				});

--- a/src/server/test/web/readingsCompareMeterQuantity.js
+++ b/src/server/test/web/readingsCompareMeterQuantity.js
@@ -85,7 +85,19 @@ mocha.describe('readings API', () => {
 					expectCompareToEqualExpected(res, expected);
 				});
 
-				// Add C6 here
+				mocha.it('C6: 28 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as kWh', async () => {
+					await prepareTest(unitDatakWh, conversionDatakWh, meterDatakWh);
+					const unitId = await getUnitId('kWh');
+					const expected = [108269.924822581, 108889.847659507];
+					const res = await chai.request(app).get('/api/compareReadings/meters/${METER_ID}')
+						.query({
+							curr_start: '2022-10-09 00:00:00',
+							curr_end: '2022-10-31 17:00:00',
+							shift: 'P28D',
+							graphicUnitID:unitId
+						});
+					expectCompareToEqualExpected(res, expected);
+				});
 
 				mocha.it('C8: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as MJ', async () => {
 					// Use predefined unit and conversion data


### PR DESCRIPTION
# Description
Authors: Alec Gonzales(alecdog04), Mia Escobar(miaescobar1), AungKhant Min (Aung-Khant-Min1211)

Wrote test case C6, verifying the compare readings API for an electric meter. The shift period is 28 days, ensuring the API can handle long-period shifts. This test also validates timestamp alignment for 15-minute reading intervals and proper unit conversion from Electric_Utility to kWh. This test case was completed as part of the CTI open source internship cohert.

Partly Addresses #issue #962, Test Case C6

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.