### PR TITLE
remove lighting sign for text for en language

### DIFF
--- a/src/client/app/translations/data.ts
+++ b/src/client/app/translations/data.ts
@@ -397,7 +397,7 @@ const LocaleTranslationData = {
 		"page.choice.login": "Page choices & login",
 		"page.choice.logout": "Page choices & logout",
 		"page.restart.button": "Restart OED session",
-		"page.user.refresh.directions": "If clicking the \"Return to Dashboard\" button does not work then please click the button below to restart your OED session\u{26A1}",
+		"page.user.refresh.directions": "If clicking the \"Return to Dashboard\" button does not work then please click the button below to restart your OED session",
 		"password": "Password: ",
 		"password.confirm": "Confirm password: ",
 		"per.day": "Per Day",


### PR DESCRIPTION
# Description

This PR removes the ⚡ icon for texts in "en" language.

Fixes #1415 

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.
