### PR TITLE
Issue #962 - testcase C11 implemented

### DIFF
--- a/src/server/test/web/readingsCompareMeterQuantity.js
+++ b/src/server/test/web/readingsCompareMeterQuantity.js
@@ -159,7 +159,7 @@ mocha.describe('readings API', () => {
 				// Add C10 here
 
 				mocha.it('C11: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as BTU reverse conversion', async () => {
-					const unitData = [
+					const unitData = unitDatakWh.concat([
 						// adding units u1, u2, u3, u16
 						{
 							//u1
@@ -205,9 +205,9 @@ mocha.describe('readings API', () => {
 							preferredDisplay: true, 
 							note: 'OED created standard unit'
 						},
-					];
-					const conversionData = [
-						// adding conversions c1, c2, c3
+					]);
+					const conversionData = conversionDatakWh.concat([
+						// adding conversions c1, c6, c3
 						{
 							// c1
 							sourceName: 'Electric_Utility', 
@@ -218,13 +218,13 @@ mocha.describe('readings API', () => {
 							note: 'Electric_Utility → kWh' 
 						},
 						{
-							// c2
-							sourceName: 'kWh', 
-							destinationName: 'MJ', 
-							bidirectional: true, 
-							slope: 3.6, 
-							intercept: 0, 
-							note: 'kWh → MJ'
+							// c6
+							sourceName: 'MJ',
+							destinationName: 'kWh',
+							bidirectional: true,
+							slope: 1 / 3.6,
+							intercept: 0,
+							note: 'MJ → KWh'
 						},
 						{
 							// c3
@@ -236,7 +236,7 @@ mocha.describe('readings API', () => {
 							note: 'MJ → BTU' 
 						},
 	
-					];
+					]);
 					// redefining the meterData as the unit is different
 					const meterData = [
 						{

--- a/src/server/test/web/readingsCompareMeterQuantity.js
+++ b/src/server/test/web/readingsCompareMeterQuantity.js
@@ -158,8 +158,114 @@ mocha.describe('readings API', () => {
 
 				// Add C10 here
 
-				// Add C11 here
-
+				mocha.it('C11: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as BTU reverse conversion', async () => {
+					const unitData = [
+						// adding units u1, u2, u3, u16
+						{
+							//u1
+							name: 'kWh', 
+							identifier: '', 
+							unitRepresent: Unit.unitRepresentType.QUANTITY, 
+							secInRate: 3600, 
+							typeOfUnit: Unit.unitType.UNIT, 
+							suffix: '', 
+							displayable: Unit.displayableType.ALL, 
+							preferredDisplay: true, 
+							note: 'OED created standard unit'
+						},
+						{
+							//u2
+							name: 'Electric_Utility',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.METER,
+							suffix: '',
+							displayable: Unit.displayableType.NONE,
+							preferredDisplay: false,
+							note: 'special unit'
+						},
+						{
+							// u3
+							name: 'MJ', 
+							identifier: 'megaJoules', 
+							unitRepresent: Unit.unitRepresentType.QUANTITY, 
+							secInRate: 3600, typeOfUnit: Unit.unitType.UNIT, 
+							suffix: '', displayable: Unit.displayableType.ALL, 
+							preferredDisplay: false, 
+							note: 'MJ'
+						},
+						{
+							// u16
+							name: 'BTU', identifier: '', 
+							unitRepresent: Unit.unitRepresentType.QUANTITY, 
+							secInRate: 3600, 
+							typeOfUnit: Unit.unitType.UNIT, 
+							suffix: '', displayable: Unit.displayableType.ALL, 
+							preferredDisplay: true, 
+							note: 'OED created standard unit'
+						},
+					];
+					const conversionData = [
+						// adding conversions c1, c2, c3
+						{
+							// c1
+							sourceName: 'Electric_Utility', 
+							destinationName: 'kWh', 
+							bidirectional: false, 
+							slope: 1, 
+							intercept: 0, 
+							note: 'Electric_Utility → kWh' 
+						},
+						{
+							// c2
+							sourceName: 'kWh', 
+							destinationName: 'MJ', 
+							bidirectional: true, 
+							slope: 3.6, 
+							intercept: 0, 
+							note: 'kWh → MJ'
+						},
+						{
+							// c3
+							sourceName: 'MJ', 
+							destinationName: 'BTU', 
+							bidirectional: true, 
+							slope: 947.8, 
+							intercept: 0, 
+							note: 'MJ → BTU' 
+						},
+	
+					];
+					// redefining the meterData as the unit is different
+					const meterData = [
+						{
+							name: 'Electric Utility BTU',
+							unit: 'Electric_Utility',
+							displayable: true,
+							gps: undefined,
+							note: 'special meter',
+							file: 'test/web/readingsData/readings_ri_15_days_75.csv',
+							deleteFile: false,
+							readingFrequency: '15 minutes',
+							id: METER_ID
+						}
+					];
+					// load data into database
+					await prepareTest(unitData, conversionData, meterData);
+					// Get the unit ID since the DB could use any value
+					const unitId = await getUnitId('BTU');
+					const expected = [10645752.224022, 11490184.2415072];
+					// for compare, need the unitID, currentStart, currentEnd, shift
+					const res = await chai.request(app).get(`/api/compareReadings/meters/${METER_ID}`)
+						.query({
+							curr_start: '2022-10-31 00:00:00',
+							curr_end: '2022-10-31 17:00:00',
+							shift: 'P1D',
+							graphicUnitId: unitId
+						});
+					expectCompareToEqualExpected(res, expected);
+				});
 				// Add C12 here
 
 				// Add C13 here

--- a/src/server/test/web/readingsCompareMeterQuantity.js
+++ b/src/server/test/web/readingsCompareMeterQuantity.js
@@ -160,31 +160,7 @@ mocha.describe('readings API', () => {
 
 				mocha.it('C11: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as BTU reverse conversion', async () => {
 					const unitData = unitDatakWh.concat([
-						// adding units u1, u2, u3, u16
-						{
-							//u1
-							name: 'kWh', 
-							identifier: '', 
-							unitRepresent: Unit.unitRepresentType.QUANTITY, 
-							secInRate: 3600, 
-							typeOfUnit: Unit.unitType.UNIT, 
-							suffix: '', 
-							displayable: Unit.displayableType.ALL, 
-							preferredDisplay: true, 
-							note: 'OED created standard unit'
-						},
-						{
-							//u2
-							name: 'Electric_Utility',
-							identifier: '',
-							unitRepresent: Unit.unitRepresentType.QUANTITY,
-							secInRate: 3600,
-							typeOfUnit: Unit.unitType.METER,
-							suffix: '',
-							displayable: Unit.displayableType.NONE,
-							preferredDisplay: false,
-							note: 'special unit'
-						},
+						// adding units u3, u16
 						{
 							// u3
 							name: 'MJ', 
@@ -207,16 +183,7 @@ mocha.describe('readings API', () => {
 						},
 					]);
 					const conversionData = conversionDatakWh.concat([
-						// adding conversions c1, c6, c3
-						{
-							// c1
-							sourceName: 'Electric_Utility', 
-							destinationName: 'kWh', 
-							bidirectional: false, 
-							slope: 1, 
-							intercept: 0, 
-							note: 'Electric_Utility → kWh' 
-						},
+						// adding conversions c6, c3
 						{
 							// c6
 							sourceName: 'MJ',


### PR DESCRIPTION
This pull request aims to allow testcase C11 to run alongside the other quantity meter tests.
It ensures that the Electric_Utility unit (kWh) is correctly correctly compared when read. The reading requested is in BTU. 
This was accomplished through the specifications outlined in the DesignDocs

Contributors:
Abas Mohamed - @ver1log 
Hyun Oh Kwon - @kwohyuno 
Mon Raphael Fernandez - @vvomby
Ezequiel Reyes - @ezequiel38

Partly Addresses #962 
## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations
No limitation we have been made aware of
