### PR TITLE
Final test C10

### DIFF
--- a/src/server/test/web/readingsCompareMeterQuantity.js
+++ b/src/server/test/web/readingsCompareMeterQuantity.js
@@ -159,30 +159,9 @@ mocha.describe('readings API', () => {
 				mocha.it('C10: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as BTU', async () => {
 					// Use predefined unit and conversion data
 					const unitData = unitDatakWh.concat([
-						//adding u1, u2, u3, u16
-						{ 	//u1
-							name: 'kWh',
-							identifier: '',
-							unitRepresent: Unit.unitRepresentType.QUANTITY,
-							secInRate: 3600,
-							typeOfUnit: Unit.unitType.UNIT,
-							suffix: '',
-							displayable: Unit.displayableType.ALL,
-							preferredDisplay: false,
-							note: 'OED created standard unit'
-						},							
-						{	//u2
-							name: 'Electric_Utility',
-							identifier: '',
-							unitRepresent: Unit.unitRepresentType.QUANTITY,
-							secInRate: 3600,
-							typeOfUnit: Unit.unitType.METER,
-							suffix: '',
-							displayable: Unit.displayableType.NONE,
-							preferredDisplay: false,
-							note: 'special unit'
-						},
-						{	//u3
+						//adding u3, u16
+						{	
+							// u3
 							name: 'MJ',
 							identifier: 'megaJoules',
 							unitRepresent: Unit.unitRepresentType.QUANTITY,
@@ -193,7 +172,8 @@ mocha.describe('readings API', () => {
 							preferredDisplay: false,
 							note: 'MJ'
 						},
-						{ 	// u16
+						{ 	
+							// u16
 							name: 'BTU',
 							identifier: '',
 							unitRepresent: Unit.unitRepresentType.QUANTITY,
@@ -206,16 +186,9 @@ mocha.describe('readings API', () => {
 						}
 					]);
 					const conversionData = conversionDatakWh.concat([
-						// adding c1, c2, c3
-						{	// c1
-							sourceName: 'Electric_Utility',
-							destinationName: 'kWh',
-							bidirectional: false,
-							slope: 1,
-							intercept: 0,
-							note: 'Electric_Utility → kWh'
-						},
-						{	// c2
+						// adding c2, c3
+						{	
+							// c2
 							sourceName: 'kWh',
 							destinationName: 'MJ',
 							bidirectional: true,
@@ -223,7 +196,8 @@ mocha.describe('readings API', () => {
 							intercept: 0,
 							note: 'MJ → BTU'
 						},
-						{	//c3
+						{	
+							// c3
 							sourceName: 'MJ',
 							destinationName: 'BTU',
 							bidirectional: true,

--- a/src/server/test/web/readingsCompareMeterQuantity.js
+++ b/src/server/test/web/readingsCompareMeterQuantity.js
@@ -156,7 +156,99 @@ mocha.describe('readings API', () => {
 
 				// Add C9 here
 
-				// Add C10 here
+				mocha.it('C10: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as BTU', async () => {
+					// Use predefined unit and conversion data
+					const unitData = unitDatakWh.concat([
+						//adding u1, u2, u3, u16
+						{ 	//u1
+							name: 'kWh',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: '',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: false,
+							note: 'OED created standard unit'
+						},							
+						{	//u2
+							name: 'Electric_Utility',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.METER,
+							suffix: '',
+							displayable: Unit.displayableType.NONE,
+							preferredDisplay: false,
+							note: 'special unit'
+						},
+						{	//u3
+							name: 'MJ',
+							identifier: 'megaJoules',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: '',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: false,
+							note: 'MJ'
+						},
+						{ 	// u16
+							name: 'BTU',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: '',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: true,
+							note: 'OED created standard unit'
+						}
+					]);
+					const conversionData = conversionDatakWh.concat([
+						// adding c1, c2, c3
+						{	// c1
+							sourceName: 'Electric_Utility',
+							destinationName: 'kWh',
+							bidirectional: false,
+							slope: 1,
+							intercept: 0,
+							note: 'Electric_Utility → kWh'
+						},
+						{	// c2
+							sourceName: 'kWh',
+							destinationName: 'MJ',
+							bidirectional: true,
+							slope: 3.6,
+							intercept: 0,
+							note: 'MJ → BTU'
+						},
+						{	//c3
+							sourceName: 'MJ',
+							destinationName: 'BTU',
+							bidirectional: true,
+							slope: 947.8,
+							intercept: 0,
+							note: 'MJ → BTU'
+						}
+					]);
+					
+					// load data into database
+					await prepareTest(unitData, conversionData, meterDatakWh);
+
+					// Get the unit ID since the DB could use any value
+					const unitId = await getUnitId('BTU');
+					const expected = [10645752.224022, 11490184.2415072];
+					// for compare, need the unitID, currentStart, currentEnd, shift
+					const res = await chai.request(app).get(`/api/compareReadings/meters/${METER_ID}`)
+						.query({
+							curr_start: '2022-10-31 00:00:00',
+							curr_end: '2022-10-31 17:00:00',
+							shift: 'P1D',
+							graphicUnitId: unitId
+							});
+						expectCompareToEqualExpected(res, expected);
+					});
 
 				// Add C11 here
 


### PR DESCRIPTION
Co-authored by: Caden Carpenter <cadencarpenter63@gmail.com>  @CadenC63
Co-authored by: Anthony Theng <theng.anthonyy@gmail.com> @anthonytheng

# Description

This pull request aims to allow testcase C10 to run alongside the other quantity meter tests.
It ensures that the Electric_Utility unit (BTU) is correctly correctly compared when read. The reading requested is in BTU.
This was accomplished through the specifications outlined in the DesignDocs

Partly addresses #962

(In general, OED likes to have at least one issue associated with each pull request. Replace [issue] with the OED GitHub issue number. In the preview you will see an issue description if you hover over that number. You can create one yourself before doing this pull request. This is where details are normally given on what is being addressed. Note you should not use the word "Fixes" if it does not completely address the issue since the issue would automatically be closed on merging the pull request. In that case use "Partly Addresses #[issue].)

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

No limitations we were made aware of.