### PR TITLE
testing readings #962 #C20

### DIFF
--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -366,6 +366,13 @@ mocha.describe('readings API', () => {
 					const unitId = await getUnitId('kW');
 					const expected = [27067.4812056454, 3286.9345597083];    
 
+					const res = await chai.request(app).get(`/api/compareReadings/meters/${METER_ID}`)
+						.query({
+							curr_start: '2022-10-09 00:00:00',
+							curr_end: '2022-10-31 17:12:34',
+							shift: 'P28D',
+							graphicUnitId: unitId
+						});
 			});
 		});
 	});

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -311,7 +311,62 @@ mocha.describe('readings API', () => {
 				// Add C20 here
 				mocha.it('C20: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh', async () => {
 					// Units and Conversions
-					
+					unitData = [ 
+						{
+							//u4
+							name: 'kW',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.FLOW,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: '',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: true,
+							note: 'kilowatts'
+						},
+						{
+							//u5
+							name: 'Electric',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.FLOW,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.METER,
+							suffix: '',
+							displayable: Unit.displayableType.NONE,
+							preferredDisplay: false,
+							note: 'special unit'
+						},
+					];
+					conversionData = [
+						{
+							//c4
+							sourceName: 'Electric',
+							destinationName: 'kW',
+							bidirectional: false,
+							slope: 1,
+							intercept: 0,
+							note: 'Electric → kW'
+						}
+					];
+
+					const meterData = [
+						{
+							name: 'Electric kW',
+							unit: 'Electric',
+							defaultGraphicUnit: 'kW',
+							displayable: true,
+							gps: undefined,
+							note: 'special meter',
+							file: 'test/web/readingsData/readings_ri_15_days_75.csv',
+							deleteFile: false,
+							readingFrequency: '15 minutes',
+							id: METER_ID
+						}
+					];
+					await prepareTest(unitData, conversionData, meterData);
+					const unitId = await getUnitId('kW');
+					const expected = [27067.4812056454, 3286.9345597083];    
+
 			});
 		});
 	});

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -364,7 +364,7 @@ mocha.describe('readings API', () => {
 						}
 					];
 					await prepareTest(unitData, conversionData, meterData);
-					const unitId = await getUnitId('kW');
+					const unitId = await getUnitId('kWh');
 					const expected = [27067.4812056454, 3286.9345597083];    
 
 					const res = await chai.request(app).get(`/api/compareReadings/meters/${METER_ID}`)

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -310,6 +310,7 @@ mocha.describe('readings API', () => {
 
 				// Add C20 here
 				mocha.it('C20: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh', async () =>{
+					// Units and Conversions
 					unitData = [ 
 						{
 							//u4

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -375,6 +375,7 @@ mocha.describe('readings API', () => {
 						});
 					
 					expectCompareToEqualExpected(res, expected, METER_ID);
+				});
 			});
 		});
 	});

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -308,7 +308,6 @@ mocha.describe('readings API', () => {
 	
 				// Add C19 here
 
-				// Add C20 here
 				mocha.it('C20: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh', async () =>{
 					// Units and Conversions
 					unitData = [ 
@@ -365,7 +364,7 @@ mocha.describe('readings API', () => {
 					];
 					await prepareTest(unitData, conversionData, meterData);
 					const unitId = await getUnitId('kW');
-					const expected = [27067.4812056454, 3286.9345597083];    
+					const expected = [27067.4812056454, 27222.4619148768];    
 
 					const res = await chai.request(app).get(`/api/compareReadings/meters/${METER_ID}`)
 						.query({
@@ -377,6 +376,7 @@ mocha.describe('readings API', () => {
 					
 					expectCompareToEqualExpected(res, expected, METER_ID);
 				});
+				
 			});
 		});
 	});

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -373,6 +373,8 @@ mocha.describe('readings API', () => {
 							shift: 'P28D',
 							graphicUnitId: unitId
 						});
+					
+					expectCompareToEqualExpected(res, expected, METER_ID);
 			});
 		});
 	});

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -302,8 +302,8 @@ mocha.describe('readings API', () => {
 							graphicUnitId: unitId
 						});
 					
-					expectCompareToEqualExpected(res, expected, METER_ID);
-
+						expectCompareToEqualExpected(res, expected, METER_ID);
+					});
 				});
 	
 				// Add C19 here

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -304,11 +304,10 @@ mocha.describe('readings API', () => {
 					
 						expectCompareToEqualExpected(res, expected, METER_ID);
 					});
-				});
+				
 	
 				// Add C19 here
 
-				// Add C20 here
 				mocha.it('C20: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh', async () =>{
 					// Units and Conversions
 					unitData = [ 
@@ -364,7 +363,7 @@ mocha.describe('readings API', () => {
 						}
 					];
 					await prepareTest(unitData, conversionData, meterData);
-					const unitId = await getUnitId('kWh');
+					const unitId = await getUnitId('kW');
 					const expected = [27067.4812056454, 3286.9345597083];    
 
 					const res = await chai.request(app).get(`/api/compareReadings/meters/${METER_ID}`)

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -308,7 +308,7 @@ mocha.describe('readings API', () => {
 	
 				// Add C19 here
 
-				mocha.it('C20: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh', async () =>{
+				mocha.it('C20: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kW as kW', async () =>{
 					// Units and Conversions
 					unitData = [ 
 						{

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -364,7 +364,7 @@ mocha.describe('readings API', () => {
 					];
 					await prepareTest(unitData, conversionData, meterData);
 					const unitId = await getUnitId('kW');
-					const expected = [27067.4812056454, 3286.9345597083];    
+					const expected = [27067.4812056454,  27222.4619148768];    
 
 					const res = await chai.request(app).get(`/api/compareReadings/meters/${METER_ID}`)
 						.query({

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -309,6 +309,66 @@ mocha.describe('readings API', () => {
 				// Add C19 here
 
 				// Add C20 here
+				mocha.it('C20: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh', async () =>{
+					unitData = [ 
+						{
+							//u4
+							name: 'kW',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.FLOW,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: '',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: true,
+							note: 'kilowatts'
+						},
+						{
+							//u5
+							name: 'Electric',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.FLOW,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.METER,
+							suffix: '',
+							displayable: Unit.displayableType.NONE,
+							preferredDisplay: false,
+							note: 'special unit'
+						},
+					];
+					conversionData = [
+						{
+							//c4
+							sourceName: 'Electric',
+							destinationName: 'kW',
+							bidirectional: false,
+							slope: 1,
+							intercept: 0,
+							note: 'Electric → kW'
+						}
+					];
+
+					const meterData = [
+						{
+							name: 'Electric kW',
+							unit: 'Electric',
+							defaultGraphicUnit: 'kW',
+							displayable: true,
+							gps: undefined,
+							note: 'special meter',
+							file: 'test/web/readingsData/readings_ri_15_days_75.csv',
+							deleteFile: false,
+							readingFrequency: '15 minutes',
+							id: METER_ID
+						}
+					];
+
+
+					expectCompareToEqualExpected(res, expected, METER_ID);
+
+				});
+
+
 			});
 		});
 	});

--- a/src/server/test/web/readingsCompareMeterFlow.js
+++ b/src/server/test/web/readingsCompareMeterFlow.js
@@ -309,6 +309,9 @@ mocha.describe('readings API', () => {
 				// Add C19 here
 
 				// Add C20 here
+				mocha.it('C20: 28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh', async () => {
+					// Units and Conversions
+					
 			});
 		});
 	});


### PR DESCRIPTION
# Description

Added C20 test case: "28 day shift end 2022-10-31 17:12:34 (partial hour) for 15 minute reading intervals and quantity units & kWh as kWh". 
Contributer: @selenasat @KySuongLam

Partially Addresses testing readings #962 

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist
- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations
