### PR TITLE
Issue#1449 - Show bounded date range

### DIFF
--- a/src/client/app/components/ChartDataSelectComponent.tsx
+++ b/src/client/app/components/ChartDataSelectComponent.tsx
@@ -6,18 +6,24 @@ import * as React from 'react';
 import { MeterOrGroup } from '../types/redux/graph';
 import MeterAndGroupSelectComponent from './MeterAndGroupSelectComponent';
 import UnitSelectComponent from './UnitSelectComponent';
+import { useAppSelector } from '../redux/reduxHooks';
+import { selectQueryTimeInterval} from '../redux/slices/graphSlice';
+import DateRangeComponent from './DateRangeComponent';
 
 /**
  * A component which allows the user to select which data should be displayed on the chart.
  * @returns Chart data select element
  */
 export default function ChartDataSelectComponent() {
+	const queryTimeInterval = useAppSelector(selectQueryTimeInterval);
+	const isBounded = queryTimeInterval.getIsBounded();
 
 	return (
 		<div>
 			<MeterAndGroupSelectComponent meterOrGroup={MeterOrGroup.groups} />
 			<MeterAndGroupSelectComponent meterOrGroup={MeterOrGroup.meters} />
 			<UnitSelectComponent />
+			{isBounded && <DateRangeComponent />}
 		</div>
 	);
 }

--- a/src/client/app/components/ChartDataSelectComponent.tsx
+++ b/src/client/app/components/ChartDataSelectComponent.tsx
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react';
-import { MeterOrGroup } from '../types/redux/graph';
+import { ChartTypes, MeterOrGroup } from '../types/redux/graph';
 import MeterAndGroupSelectComponent from './MeterAndGroupSelectComponent';
 import UnitSelectComponent from './UnitSelectComponent';
 import { useAppSelector } from '../redux/reduxHooks';
-import { selectQueryTimeInterval} from '../redux/slices/graphSlice';
+import { selectChartToRender, selectQueryTimeInterval} from '../redux/slices/graphSlice';
 import DateRangeComponent from './DateRangeComponent';
 
 /**
@@ -15,6 +15,7 @@ import DateRangeComponent from './DateRangeComponent';
  * @returns Chart data select element
  */
 export default function ChartDataSelectComponent() {
+	const chartToRender = useAppSelector(selectChartToRender);
 	const queryTimeInterval = useAppSelector(selectQueryTimeInterval);
 	const isBounded = queryTimeInterval.getIsBounded();
 
@@ -23,7 +24,7 @@ export default function ChartDataSelectComponent() {
 			<MeterAndGroupSelectComponent meterOrGroup={MeterOrGroup.groups} />
 			<MeterAndGroupSelectComponent meterOrGroup={MeterOrGroup.meters} />
 			<UnitSelectComponent />
-			{isBounded && <DateRangeComponent />}
+			{(isBounded && chartToRender !== ChartTypes.threeD && chartToRender !== ChartTypes.compareLine) && <DateRangeComponent />}
 		</div>
 	);
 }

--- a/src/client/app/components/MoreOptionsComponent.tsx
+++ b/src/client/app/components/MoreOptionsComponent.tsx
@@ -26,7 +26,6 @@ export default function MoreOptionsComponent() {
 	const chartToRender = useAppSelector(selectChartToRender);
 	const queryTimeInterval = useAppSelector(selectQueryTimeInterval);
 	const isBounded = queryTimeInterval.getIsBounded();
-	console.log(isBounded);
 	const [showModal, setShowModal] = useState(false);
 	const handleShow = () => setShowModal(true);
 	const handleClose = () => {

--- a/src/client/app/components/MoreOptionsComponent.tsx
+++ b/src/client/app/components/MoreOptionsComponent.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 import { useAppSelector } from '../redux/reduxHooks';
-import { selectChartToRender } from '../redux/slices/graphSlice';
+import { selectChartToRender, selectQueryTimeInterval } from '../redux/slices/graphSlice';
 import { ChartTypes } from '../types/redux/graph';
 import '../styles/modal.css';
 import AreaUnitSelectComponent from './AreaUnitSelectComponent';
@@ -24,6 +24,9 @@ import { useTranslate } from '../redux/componentHooks';
 export default function MoreOptionsComponent() {
 	const translate = useTranslate();
 	const chartToRender = useAppSelector(selectChartToRender);
+	const queryTimeInterval = useAppSelector(selectQueryTimeInterval);
+	const isBounded = queryTimeInterval.getIsBounded();
+	console.log(isBounded);
 	const [showModal, setShowModal] = useState(false);
 	const handleShow = () => setShowModal(true);
 	const handleClose = () => {
@@ -44,14 +47,14 @@ export default function MoreOptionsComponent() {
 						<ModalBody>
 							{/* More UI options for line graphic */}
 							{chartToRender == ChartTypes.line && <GraphicRateMenuComponent />}
-							{chartToRender == ChartTypes.line && <DateRangeComponent />}
+							{chartToRender == ChartTypes.line && !isBounded && <DateRangeComponent />}
 							{chartToRender == ChartTypes.line && <AreaUnitSelectComponent />}
 							{chartToRender == ChartTypes.line && <ErrorBarComponent />}
 							{chartToRender == ChartTypes.line && <ExportComponent />}
 							{chartToRender == ChartTypes.line && <ChartLinkComponent />}
 
 							{/* More UI options for bar graphic */}
-							{chartToRender == ChartTypes.bar && <DateRangeComponent />}
+							{chartToRender == ChartTypes.bar && !isBounded && <DateRangeComponent />}
 							{chartToRender == ChartTypes.bar && <AreaUnitSelectComponent />}
 							{chartToRender == ChartTypes.bar && <ExportComponent />}
 							{chartToRender == ChartTypes.bar && <ChartLinkComponent />}
@@ -61,7 +64,7 @@ export default function MoreOptionsComponent() {
 							{chartToRender == ChartTypes.compare && <ChartLinkComponent />}
 
 							{/* More UI options for map graphic */}
-							{chartToRender == ChartTypes.map && <DateRangeComponent />}
+							{chartToRender == ChartTypes.map && !isBounded && <DateRangeComponent />}
 							{chartToRender == ChartTypes.map && <AreaUnitSelectComponent />}
 							{chartToRender == ChartTypes.map && <ChartLinkComponent />}
 
@@ -72,7 +75,7 @@ export default function MoreOptionsComponent() {
 
 							{/* More UI options for radar graphic */}
 							{chartToRender == ChartTypes.radar && <GraphicRateMenuComponent />}
-							{chartToRender == ChartTypes.radar && <DateRangeComponent />}
+							{chartToRender == ChartTypes.radar && !isBounded && <DateRangeComponent />}
 							{chartToRender == ChartTypes.radar && <AreaUnitSelectComponent />}
 							{chartToRender == ChartTypes.radar && <ChartLinkComponent />}
 

--- a/src/client/app/styles/DateRangeCustom.css
+++ b/src/client/app/styles/DateRangeCustom.css
@@ -10,6 +10,7 @@
 
 .react-daterange-picker__inputGroup {
 	min-width: auto;
+	font-size: 13px;
 }
 
 .react-daterange-picker {

--- a/src/client/app/styles/DateRangeCustom.css
+++ b/src/client/app/styles/DateRangeCustom.css
@@ -10,7 +10,6 @@
 
 .react-daterange-picker__inputGroup {
 	min-width: auto;
-	font-size: 13px;
 }
 
 .react-daterange-picker {


### PR DESCRIPTION
# Description

The feature update improves the visibility of the Date Range selection without physically moving the component. When a specific date range is selected (bounded), the Date Range component is displayed in the ChartDataSelectComponent on the main graphic page while being hidden in the MoreOptionsComponent's modal. Conversely, when dates are unbounded, the component is hidden in the ChartDataSelectComponent and shown in the MoreOptionsComponent's modal. This approach enhances user awareness of active date filters and provides easier access for modifications when needed.

Fixes #1449 

Co-Author:
@MatthewTran22 

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

Test cases were not implemented for Issue#1449 due to being only frontend change
