### PR TITLE
Disable "Save" button on invalid conversion creation forms

### DIFF
--- a/src/client/app/components/conversion/CreateConversionModalComponent.tsx
+++ b/src/client/app/components/conversion/CreateConversionModalComponent.tsx
@@ -233,7 +233,7 @@ export default function CreateConversionModalComponent() {
 						<FormattedMessage id="discard.changes" />
 					</Button>
 					{/* On click calls the function handleSaveChanges in this component */}
-					<Button color='primary' onClick={handleSubmit} >
+					<Button color='primary' onClick={handleSubmit} disabled={!validConversion} >
 						<FormattedMessage id="save.all" />
 					</Button>
 				</ModalFooter>


### PR DESCRIPTION
# Description

This PR enhances the conversion creation capabilities of OED by disabling the "Save" button when the form is not yet valid. This prevents the form from attempting to save incomplete or incorrect conversions and improves overall consistency of the user interface.

Fixes #1456

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

N/A
