### PR TITLE
tempreature meter added

### DIFF
--- a/src/client/app/components/TemperatureGraphComponent.tsx
+++ b/src/client/app/components/TemperatureGraphComponent.tsx
@@ -1,0 +1,154 @@
+import * as moment from "moment";
+import * as React from "react";
+import Plot from "react-plotly.js";
+import { readingsApi, stableEmptyLineReadings } from "../redux/api/readingsApi";
+import { useAppSelector } from "../redux/reduxHooks";
+import { selectCompareLineQueryArgs } from "../redux/selectors/chartQuerySelectors";
+import { selectLineUnitLabel } from "../redux/selectors/plotlyDataSelectors";
+import { selectSelectedLanguage } from "../redux/slices/appStateSlice";
+import { selectGraphState, selectShiftAmount } from "../redux/slices/graphSlice";
+import { selectThreeDComponentInfo } from "../redux/selectors/threeDSelectors";
+import { selectPlotlyMeterData } from "../redux/selectors/lineChartSelectors";
+import { MeterOrGroup, ShiftAmount } from "../types/redux/graph";
+import { useGetTemperatureDataQuery } from "../redux/api/temperatureApi";
+import { selectTemperatureUnit } from "../redux/slices/temperatureSlice";
+import translate from "../utils/translate";
+import SpinnerComponent from "./SpinnerComponent";
+import ThreeDPillComponent from "./ThreeDPillComponent";
+import { setHelpLayout } from "./ThreeDComponent";
+
+const TemperatureGraphComponent: React.FC = () => {
+  const graphState = useAppSelector(selectGraphState);
+  const meterOrGroupID = useAppSelector(selectThreeDComponentInfo).meterOrGroupID;
+  const unitLabel = useAppSelector(selectLineUnitLabel);
+  const locale = useAppSelector(selectSelectedLanguage);
+  const shiftAmount = useAppSelector(selectShiftAmount);
+  const { args, shouldSkipQuery, argsDeps } = useAppSelector(selectCompareLineQueryArgs);
+  const selectedUnit = useAppSelector(selectTemperatureUnit);
+
+  // Fetch temperature data every hour for the current year (each month)
+  const { data: temperatureData, isFetching: isFetchingTemperature } = useGetTemperatureDataQuery();
+
+  // Process temperature data to calculate monthly averages and ensure values are in the correct unit
+  const processedTemperatureData = temperatureData?.map((d) => ({
+    timestamp: new Date(d.timestamp).toISOString(),
+    value: selectedUnit === "Fahrenheit" ? (d.value * 9) / 5 + 32 : d.value,
+  })) ?? [];
+
+  // Fetch meter data using `readingsApi.useLineQuery()`
+  const { data: meterGraphData, isFetching: isFetchingMeterData } = readingsApi.useLineQuery(args, {
+    skip: shouldSkipQuery,
+    selectFromResult: ({ data, ...rest }) => ({
+      ...rest,
+      data: selectPlotlyMeterData(data ?? stableEmptyLineReadings, {
+        ...argsDeps,
+        compatibleEntities: [meterOrGroupID!],
+      }),
+    }),
+  });
+
+  // Helper function to clean and flatten data
+  const cleanArray = (arr: any): number[] => {
+    if (arr instanceof Float32Array || arr instanceof Int8Array) {
+      return Array.from(arr);
+    }
+    if (Array.isArray(arr)) {
+      return arr.flat().filter((v) => typeof v === "number");
+    }
+    return [];
+  };
+
+  // Ensure meter data x-values are properly formatted
+  const meterX: (string | number | Date)[] =
+    meterGraphData
+      ?.flatMap((d) => {
+        if (Array.isArray(d.x)) return d.x.flat().map(String);
+        if (d.x instanceof Float32Array || d.x instanceof Int8Array) return Array.from(d.x).map(String);
+        return d.x ? [String(d.x)] : [];
+      }) ?? [];
+
+  const meterY: number[] = meterGraphData?.flatMap((d) => cleanArray(d.y)) ?? [];
+
+  // Ensure temperature data x and y values are properly formatted
+  const tempX: (string | number | Date)[] = processedTemperatureData.map((d) => d.timestamp);
+  const tempY: number[] = processedTemperatureData.map((d) => d.value);
+
+  const enoughData = meterX.length > 1 && tempX.length > 1;
+
+  let layout = {};
+
+  if (!meterOrGroupID) {
+    layout = setHelpLayout(translate("select.meter.group"));
+  } else if (!graphState.queryTimeInterval.getIsBounded()) {
+    layout = setHelpLayout(translate("please.set.the.date.range"));
+  } else if (!enoughData) {
+    layout = setHelpLayout(translate("no.data.in.range"));
+  } else {
+    layout = {
+      autosize: true,
+      showlegend: true,
+      legend: { x: 0, y: 1.1, orientation: "h" },
+      yaxis: {
+        title: "Meter Readings",
+        gridcolor: "#ddd",
+        fixedrange: true,
+      },
+      yaxis2: {
+        title: `Temperature (${selectedUnit})`, // Dynamically display temperature units (°C or °F)
+        overlaying: "y",
+        side: "right",
+        showgrid: false,
+      },
+      xaxis: {
+        title: "Time",
+        type: "category", // Treat X-axis as categorical for months
+        tickmode: "array",
+        tickvals: tempX, // Use the generated month timestamps
+        ticktext: tempX.map((date) => moment(date).format("MMM YYYY")), // Format months as "Jan 2025", "Feb 2025"
+      },
+    };
+  }
+
+  return (
+    <div>
+      <ThreeDPillComponent />
+      {isFetchingMeterData || isFetchingTemperature ? (
+        <SpinnerComponent loading height={50} width={50} />
+      ) : (
+        <Plot
+          key={JSON.stringify(args)} // Force re-render if args change
+          data={[
+            // Meter Data Line (Left Y-Axis)
+            {
+              x: meterX, // Correct Type: (string | number | Date)[]
+              y: meterY, // Correct Type: number[]
+              type: "scatter",
+              mode: "lines",
+              marker: { color: "red" },
+              name: "Meter Data",
+              yaxis: "y1",
+            },
+            // Temperature Data Line (Right Y-Axis)
+            {
+              x: tempX, // Correct Type: (string | number | Date)[]
+              y: tempY, // Correct Type: number[]
+              type: "scatter",
+              mode: "lines",
+              marker: { color: "#0bb8ff" },
+              name: "Temperature",
+              yaxis: "y2",
+            },
+          ]}
+          layout={layout}
+          config={{
+            responsive: true,
+            displayModeBar: false,
+            locale,
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TemperatureGraphComponent;

--- a/src/client/app/components/TemperatureUnitDropdown.tsx
+++ b/src/client/app/components/TemperatureUnitDropdown.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useAppSelector, useAppDispatch } from "../redux/reduxHooks";
+import { selectTemperatureUnit, updateTemperatureUnit, } from "../redux/slices/temperatureSlice";
+import translate from "../utils/translate";
+import { TemperatureUnit } from "redux/temperature";
+
+const TemperatureUnitDropdown: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const selectedUnit = useAppSelector(selectTemperatureUnit);
+
+  const handleUnitChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    dispatch(updateTemperatureUnit(event.target.value as TemperatureUnit)); // Type assertion to fix error
+  };
+
+  return (
+    <div>
+      <label htmlFor="temp-unit-select">{translate("temperature.unit")}:</label>
+      <select id="temp-unit-select" value={selectedUnit} onChange={handleUnitChange}>
+        <option value="Celsius">{translate("temperature.celsius")}</option>
+        <option value="Fahrenheit">{translate("temperature.fahrenheit")}</option>
+      </select>
+    </div>
+  );
+};
+
+export default TemperatureUnitDropdown;

--- a/src/client/app/redux/api/temperatureApi.ts
+++ b/src/client/app/redux/api/temperatureApi.ts
@@ -1,0 +1,63 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { TemperatureData } from "redux/temperature";
+import moment from "moment";
+
+const fetchTemperatureData = async (): Promise<{ data: TemperatureData[] }> => {
+  try {
+    const currentYear = new Date().getFullYear();
+    const startDate = `${currentYear}-01-01T00:00:00Z`; // Start date: January 1st of the current year
+    const endDate = moment().toISOString(); // End date: Today's date and time
+
+    // Use Open-Meteo's API to get hourly temperature data for today
+    const response = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=52.52&longitude=13.41&hourly=temperature_2m`
+    );
+    const result = await response.json();
+
+    if (!result.hourly || !result.hourly.time || !result.hourly.temperature_2m) {
+      return { data: [] }; // Return empty data if API response is invalid
+    }
+
+    // Process the data: Calculate average temperature per month for the current year
+    const temperatureData: TemperatureData[] = [];
+    const months = Array(12).fill(0); // To accumulate temperatures for each month
+    const monthsCount = Array(12).fill(0); // To count how many data points for each month
+
+    // Process hourly data and accumulate values for each month
+    result.hourly.time.forEach((timestamp: string, index: number) => {
+      const month = new Date(timestamp).getMonth(); // Extract the month (0-based index)
+      months[month] += result.hourly.temperature_2m[index]; // Add the temperature to the corresponding month
+      monthsCount[month] += 1; // Increment the count of temperature data points for the month
+    });
+
+    // Calculate the average temperature for each month
+    for (let i = 0; i < 12; i++) {
+      if (monthsCount[i] > 0) {
+        temperatureData.push({
+          timestamp: `${currentYear}-${String(i + 1).padStart(2, '0')}-01T00:00:00Z`, // Set the first day of the month
+          value: months[i] / monthsCount[i], // Average temperature for the month
+        });
+      }
+    }
+
+    return { data: temperatureData };
+  } catch (error) {
+    console.error("Failed to fetch temperature data:", error);
+    return { data: [] };
+  }
+};
+
+export const temperatureApi = createApi({
+  reducerPath: "temperatureApi",
+  baseQuery: fetchBaseQuery(),
+  endpoints: (builder) => ({
+    getTemperatureData: builder.query<TemperatureData[], void>({
+      queryFn: async () => {
+        const { data } = await fetchTemperatureData();
+        return { data };
+      },
+    }),
+  }),
+});
+
+export const { useGetTemperatureDataQuery } = temperatureApi;

--- a/src/client/app/redux/selectors/temperatureSelectors.ts
+++ b/src/client/app/redux/selectors/temperatureSelectors.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ import { createSelector } from '@reduxjs/toolkit';
+ import { RootState } from 'store';
+ 
+ /**
+  * Selector to get the temperature data from the Redux store.
+  * @param state - The Redux state.
+  * @returns The temperature data.
+  */
+ export const selectTemperatureData = (state: RootState) => state.temperature.temperatureData;
+ 
+ /**
+  * Selector to get the loading state for temperature data.
+  * @param state - The Redux state.
+  * @returns Whether the temperature data is being loaded.
+  */
+ export const selectTemperatureLoading = (state: RootState) => state.temperature.isFetching;
+ 
+ /**
+  * Selector to get the error state for temperature data.
+  * @param state - The Redux state.
+  * @returns The error message, if any.
+  */
+ export const selectTemperatureError = (state: RootState) => state.temperature.error;
+ 
+ /**
+  * Selector to get the selected temperature unit (Celsius or Fahrenheit).
+  * @param state - The Redux state.
+  * @returns The selected temperature unit.
+  */
+ export const selectTemperatureUnit = (state: RootState) => state.temperature.unit;
+ 
+ /**
+  * Selector to get the formatted temperature data for plotting.
+  * This selector processes the raw temperature data into a format suitable for Plotly.
+  * @param state - The Redux state.
+  * @returns The formatted temperature data.
+  */
+ export const selectFormattedTemperatureData = createSelector(
+   [selectTemperatureData],
+   (temperatureData) => {
+     if (!temperatureData || !temperatureData.hourly) {
+       return null;
+     }
+ 
+     // Using optional chaining and nullish coalescing to handle undefined properties
+     return {
+       time: temperatureData.hourly.time ?? [], // Default to empty array if undefined
+       temperature: temperatureData.hourly.temperature ?? [], // Default to empty array if undefined
+     };
+   }
+ );
+ 
+ /**
+  * Selector to check if there is enough temperature data to display.
+  * @param state - The Redux state.
+  * @returns Whether there is enough temperature data.
+  */
+ export const selectHasEnoughTemperatureData = createSelector(
+   [selectTemperatureData],
+   (temperatureData) => {
+     return (
+       (temperatureData?.hourly?.time?.length ?? 0) > 1 &&
+       (temperatureData?.hourly?.temperature?.length ?? 0) > 1
+     );
+   }
+ );
+ 
+ /**
+  * Selector to get the temperature unit options (Celsius and Fahrenheit).
+  * @param state - The Redux state.
+  * @returns The temperature unit options.
+  */
+ export const selectTemperatureUnitOptions = createSelector(
+   [selectTemperatureUnit],
+   (unit) => {
+     return [
+       { value: 'Celsius', label: 'Celsius' },
+       { value: 'Fahrenheit', label: 'Fahrenheit' },
+     ];
+   }
+ );
+ 

--- a/src/client/app/redux/slices/temperatureSlice.ts
+++ b/src/client/app/redux/slices/temperatureSlice.ts
@@ -1,0 +1,116 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { TemperatureUnit } from "redux/temperature";
+import { createSelector } from "@reduxjs/toolkit";
+import { RootState } from "store";
+
+// Define the structure of our Redux state for temperature
+interface TemperatureState {
+  unit: TemperatureUnit;
+  temperatureData: {
+    hourly: {
+      time: string[]; // Array of timestamps
+      temperature: number[]; // Array of temperature values
+    };
+  } | null; // Set as null initially if no data is present
+  isFetching: boolean;
+  error: string | null;
+}
+
+// Example mock data for temperature
+const mockTemperatureData = {
+  hourly: {
+    time: [
+      "2025-01-01T00:00:00Z",
+      "2025-01-01T01:00:00Z",
+      "2025-01-01T02:00:00Z",
+      "2025-01-01T03:00:00Z",
+      "2025-01-01T04:00:00Z",
+      "2025-01-01T05:00:00Z",
+      "2025-01-01T06:00:00Z",
+      "2025-01-01T07:00:00Z",
+      "2025-01-01T08:00:00Z",
+      "2025-01-01T09:00:00Z",
+      "2025-01-01T10:00:00Z",
+      "2025-01-01T11:00:00Z",
+    ],
+    temperature: [5.0, 6.2, 7.0, 6.5, 5.8, 4.5, 3.2, 2.1, 2.5, 3.1, 4.0, 5.1], // Example Celsius temperature values
+  },
+};
+
+// Initial state with hourly structure and mock data
+const initialState: TemperatureState = {
+  unit: "Celsius", // Default temperature unit
+  temperatureData: mockTemperatureData, // Set mock data as the initial state
+  isFetching: false,
+  error: null,
+};
+
+// Create the Redux slice
+export const temperatureSlice = createSlice({
+  name: "temperature",
+  initialState,
+  reducers: {
+    updateTemperatureUnit: (state, action: PayloadAction<TemperatureUnit>) => {
+      state.unit = action.payload;
+    },
+    setTemperatureData: (
+      state,
+      action: PayloadAction<{ time: string[]; temperature: number[] }>
+    ) => {
+      state.temperatureData = { hourly: action.payload };
+      state.isFetching = false;
+      state.error = null; // Clear error when data is successfully set
+    },
+    setFetchingTemperature: (state, action: PayloadAction<boolean>) => {
+      state.isFetching = action.payload;
+    },
+    setTemperatureError: (state, action: PayloadAction<string | null>) => {
+      state.error = action.payload;
+      state.isFetching = false; // Stop fetching when there's an error
+    },
+  },
+});
+
+// Export actions for use in components
+export const {
+  updateTemperatureUnit,
+  setTemperatureData,
+  setFetchingTemperature,
+  setTemperatureError,
+} = temperatureSlice.actions;
+
+// Selectors
+export const selectTemperatureUnit = (state: RootState) => state.temperature.unit;
+export const selectTemperatureData = (state: RootState) => state.temperature.temperatureData;
+export const selectIsFetchingTemperature = (state: RootState) => state.temperature.isFetching;
+export const selectTemperatureError = (state: RootState) => state.temperature.error;
+
+// New selector to handle formatted temperature data for plotting
+export const selectFormattedTemperatureData = createSelector(
+  [selectTemperatureData],
+  (temperatureData) => {
+    if (!temperatureData || !temperatureData.hourly) {
+      return null;
+    }
+
+    return {
+      time: temperatureData.hourly.time,
+      temperature: temperatureData.hourly.temperature,
+    };
+  }
+);
+
+// Selector to check if there is enough temperature data to display
+export const selectHasEnoughTemperatureData = createSelector(
+  [selectTemperatureData],
+  (temperatureData) => {
+    // Ensure temperatureData is not null and that hourly exists
+    return (
+      (temperatureData?.hourly?.time?.length ?? 0) > 1 &&
+      (temperatureData?.hourly?.temperature?.length ?? 0) > 1
+    );
+  }
+);
+
+// Export reducer to add to store
+export default temperatureSlice.reducer;

--- a/src/client/app/redux/temperature.ts
+++ b/src/client/app/redux/temperature.ts
@@ -1,0 +1,5 @@
+export type TemperatureUnit = "Celsius" | "Fahrenheit";
+export interface TemperatureData {
+    timestamp: string;
+    value: number;
+  }

--- a/src/client/app/services/weatherApi.js
+++ b/src/client/app/services/weatherApi.js
@@ -1,0 +1,44 @@
+// src/services/weatherApi.js
+import { fetchWeatherApi } from 'openmeteo';
+
+export const fetchWeatherData = async (latitude, longitude) => {
+  const params = {
+    latitude,
+    longitude,
+    hourly: 'temperature_2m',
+  };
+  const url = 'https://api.open-meteo.com/v1/forecast';
+  const responses = await fetchWeatherApi(url, params);
+
+  // Helper function to form time ranges
+  const range = (start, stop, step) =>
+    Array.from({ length: (stop - start) / step }, (_, i) => start + i * step);
+
+  // Process first location
+  const response = responses[0];
+
+  // Attributes for timezone and location
+  const utcOffsetSeconds = response.utcOffsetSeconds();
+  const timezone = response.timezone();
+  const timezoneAbbreviation = response.timezoneAbbreviation();
+  const latitudeResponse = response.latitude();
+  const longitudeResponse = response.longitude();
+
+  const hourly = response.hourly();
+
+  // Weather data structure
+  const weatherData = {
+    latitude: latitudeResponse,
+    longitude: longitudeResponse,
+    timezone,
+    timezoneAbbreviation,
+    hourly: {
+      time: range(Number(hourly.time()), Number(hourly.timeEnd()), hourly.interval()).map(
+        (t) => new Date((t + utcOffsetSeconds) * 1000)
+      ),
+      temperature2m: hourly.variables(0).valuesArray(),
+    },
+  };
+
+  return weatherData;
+};


### PR DESCRIPTION
# Description

This pull request adds support for displaying temperature data in the graph component of the Open Energy Dashboard. It introduces a new line plot for temperature (styled in blue), plotted against the right Y-axis. The component supports unit selection between Celsius and Fahrenheit via a dropdown menu, which is internationalized and follows the existing graph selection conventions.

Fixes #3

This work addresses the temperature data integration as part of improving environmental context in energy usage graphs. Temperature data is currently mocked and uses Redux Toolkit for state management. The styling and structure are aligned with existing meter graph components, and missing data is linearly interpolated for consistent hourly display.

## Type of change

This change does not modify the database configuration.  
This change does not require a documentation update.

## Checklist

I have followed the OED pull request ideas.  
I have removed instructional text from the issue request.  
I acknowledge that every person contributing to this work has signed the OED Contributing License Agreement and each author is listed in the Description section.

## Limitations

This implementation uses mock temperature data; real backend integration is pending.  
The unit toggle currently resets on refresh; Redux persistence or URL state syncing may be considered in the future.  
Additional styling or accessibility adjustments may be needed based on user feedback.
