### PR TITLE
enhancement to GitHub Action testing for DB #553

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,10 +17,6 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
 
-            # (Optional) if you need psql client on the runner
-            - name: Install PostgreSQL Client
-              run: sudo apt-get update && sudo apt-get install -y postgresql-client
-
             - name: Build & start containers
               run: |
                   docker compose -f docker-compose.ci.yml build

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,10 +37,17 @@ jobs:
             - name: Wait for database to be healthy
               run: docker compose -f docker-compose.ci.yml ps
 
-            - name: Run lint & type checks
+            - name: Install deps & run checks
               run: |
                   docker compose -f docker-compose.ci.yml run --rm web \
-                    sh -c "npm ci && npm run check:header && npm run check:typescript && npm run check:types && npm run check:lint"
+                    sh -c "\
+                      git config --global --add safe.directory /usr/src/app && \
+                      npm ci && \
+                      npm run check:header && \
+                      npm run check:typescript && \
+                      npm run check:types && \
+                      npm run check:lint \
+                    "
 
             - name: Run unit & integration tests
               run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,9 +2,9 @@ name: Build Docker
 
 on:
     pull_request:
-        branches: [development]
+        branches: [ development ]
     push:
-        branches: [development]
+        branches: [ development ]
 
 jobs:
     run-docker-checks-tests:
@@ -34,13 +34,8 @@ jobs:
                   docker compose -f docker-compose.ci.yml build
                   docker compose -f docker-compose.ci.yml up -d
 
-            - name: Wait for DB & Web to be healthy
+            - name: Wait for database to be healthy
               run: docker compose -f docker-compose.ci.yml ps
-
-            - name: Install dependencies inside the web container
-              run: |
-                  docker compose -f docker-compose.ci.yml run --rm web \
-                    sh -c "npm ci"
 
 #            - name: Run lint & type checks
 #              run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -45,7 +45,7 @@ jobs:
             # We need git config --global -add safe.directory /usr/src/app because
             # /usr/src/app is owned by the runner in GitHub Actions virtual machine whereas
             # it is the root to executes git ls-files in checkHeader.sh.
-            # Git denies the execution if the mounted volume (/usr/src/app) is owned by a different user.
+            # Git will deny the execution if the mounted volume (/usr/src/app) is owned by a different user.
             - name: Run checks
               run: |
                   docker compose -f docker-compose.ci.yml run --rm web \

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,12 +22,12 @@ jobs:
 
             - name: Build and start containers
               run: |
-                  sudo docker compose -f docker-compose.ci.yml up
+                  docker compose -f docker-compose.ci.yml up -d
 
             - name: Install dependencies inside the web container
               run: |
-                  sudo docker compose run web sh -c "npm install"
+                  docker compose run web sh -c "npm install"
 
             - name: Run tests inside the web container
               run: |
-                  sudo docker compose exec web sh -c "npm run test"
+                  docker compose exec web sh -c "npm run test"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,6 +32,7 @@ jobs:
                   OED_TOKEN_SECRET=${{ secrets.OED_TOKEN_SECRET }}
                   EOF
 
+
             # Build Docker images and run the containers -> integration smoke test
             - name: Build & start containers
               run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -30,4 +30,8 @@ jobs:
 
             - name: Run tests inside the web container
               run: |
+                  docker compose exec web sh -c "npm run check:header"
+                  docker compose exec web sh -c "npm run check:typescript"
+                  docker compose exec web sh -c "npm run check:types"
+                  docker compose exec web sh -c "npm run check:lint"
                   docker compose exec web sh -c "npm run test"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,33 @@
+name: Docker-build
+
+on:
+    pull_request:
+        branches: [ development ]
+    push:
+        branches: [ development ]
+
+jobs:
+    run-docker-checks-tests:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+
+            - name: Install PostgreSQL Client
+              run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+            - name: Build and start containers
+              run: |
+                  sudo docker compose -f docker-compose.ci.yml up
+
+            - name: Install dependencies inside the web container
+              run: |
+                  sudo docker compose run web sh -c "npm install"
+
+            - name: Run tests inside the web container
+              run: |
+                  sudo docker compose exec web sh -c "npm run test"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -49,6 +49,7 @@ jobs:
                       npm run check:lint \
                     "
 
+
             - name: Run unit & integration tests
               run: |
                   docker compose -f docker-compose.ci.yml run --rm web \

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,4 +1,4 @@
-name: Docker CI
+name: Build Docker
 
 on:
     pull_request:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,10 +34,10 @@ jobs:
                   docker compose -f docker-compose.ci.yml run --rm web \
                     sh -c "npm ci"
 
-            - name: Run lint & type checks
-              run: |
-                  docker compose -f docker-compose.ci.yml run --rm web \
-                    sh -c "npm run check:header && npm run check:typescript && npm run check:types && npm run check:lint"
+#            - name: Run lint & type checks
+#              run: |
+#                  docker compose -f docker-compose.ci.yml run --rm web \
+#                    sh -c "npm run check:header && npm run check:typescript && npm run check:types && npm run check:lint"
 
             - name: Run unit & integration tests
               run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -30,8 +30,4 @@ jobs:
 
             - name: Run tests inside the web container
               run: |
-                  docker compose exec web sh -c "npm run check:header"
-                  docker compose exec web sh -c "npm run check:typescript"
-                  docker compose exec web sh -c "npm run check:types"
-                  docker compose exec web sh -c "npm run check:lint"
                   docker compose exec web sh -c "npm run test"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,12 +20,12 @@ jobs:
             - name: Create .env file for Docker Compose
               run: |
                   cat <<EOF > .env
+                  OED_SERVER_PORT=${{ secrets.OED_SERVER_PORT }}
+                  OED_DB_USER=${{ secrets.OED_DB_USER }}
                   OED_DB_DATABASE=${{ secrets.OED_DB_DATABASE }}
+                  OED_DB_TEST_DATABASE=${{ secrets.OED_DB_TEST_DATABASE }}
                   OED_DB_PASSWORD=${{ secrets.OED_DB_PASSWORD }}
                   OED_DB_PORT=${{ secrets.OED_DB_PORT }}
-                  OED_DB_TEST_DATABASE=${{ secrets.OED_DB_TEST_DATABASE }}
-                  OED_DB_USER=${{ secrets.OED_DB_USER }}
-                  OED_SERVER_PORT=${{ secrets.OED_SERVER_PORT }}
                   OED_TOKEN_SECRET=${{ secrets.OED_TOKEN_SECRET }}
                   EOF
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,10 +37,10 @@ jobs:
             - name: Wait for database to be healthy
               run: docker compose -f docker-compose.ci.yml ps
 
-#            - name: Run lint & type checks
-#              run: |
-#                  docker compose -f docker-compose.ci.yml run --rm web \
-#                    sh -c "npm run check:header && npm run check:typescript && npm run check:types && npm run check:lint"
+            - name: Run lint & type checks
+              run: |
+                  docker compose -f docker-compose.ci.yml run --rm web \
+                    sh -c "npm ci && npm run check:header && npm run check:typescript && npm run check:types && npm run check:lint"
 
             - name: Run unit & integration tests
               run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,10 +1,10 @@
-name: Docker-build
+name: Docker CI
 
 on:
     pull_request:
-        branches: [ development ]
+        branches: [development]
     push:
-        branches: [ development ]
+        branches: [development]
 
 jobs:
     run-docker-checks-tests:
@@ -17,17 +17,33 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
 
+            # (Optional) if you need psql client on the runner
             - name: Install PostgreSQL Client
               run: sudo apt-get update && sudo apt-get install -y postgresql-client
 
-            - name: Build and start containers
+            - name: Build & start containers
               run: |
+                  docker compose -f docker-compose.ci.yml build
                   docker compose -f docker-compose.ci.yml up -d
+
+            - name: Wait for DB & Web to be healthy
+              run: docker compose -f docker-compose.ci.yml ps
 
             - name: Install dependencies inside the web container
               run: |
-                  docker compose run web sh -c "npm install"
+                  docker compose -f docker-compose.ci.yml run --rm web \
+                    sh -c "npm ci"
 
-            - name: Run tests inside the web container
+            - name: Run lint & type checks
               run: |
-                  docker compose exec web sh -c "npm run test"
+                  docker compose -f docker-compose.ci.yml run --rm web \
+                    sh -c "npm run check:header && npm run check:typescript && npm run check:types && npm run check:lint"
+
+            - name: Run unit & integration tests
+              run: |
+                  docker compose -f docker-compose.ci.yml run --rm web \
+                    sh -c "npm test"
+
+            - name: Tear down
+              if: always()
+              run: docker compose -f docker-compose.ci.yml down -v

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,9 +14,12 @@ jobs:
             - name: Check out repository code
               uses: actions/checkout@v3
 
+            # Install Docker in GitHub Actions virtual machine
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
 
+            # ${{ secrets }} is saved in Repository secrets (Repo -> Settings -> Secrets and variables -> Actions)
+            # This .env file will be used by docker-compose.ci.yml
             - name: Create .env file for Docker Compose
               run: |
                   cat <<EOF > .env
@@ -29,15 +32,21 @@ jobs:
                   OED_TOKEN_SECRET=${{ secrets.OED_TOKEN_SECRET }}
                   EOF
 
+            # Build Docker images and run the containers -> integration smoke test
             - name: Build & start containers
               run: |
                   docker compose -f docker-compose.ci.yml build
                   docker compose -f docker-compose.ci.yml up -d
 
+            # We need the database container for the further tests
             - name: Wait for database to be healthy
               run: docker compose -f docker-compose.ci.yml ps
 
-            - name: Install deps & run checks
+            # We need git config --global -add safe.directory /usr/src/app because
+            # /usr/src/app is owned by the runner in GitHub Actions virtual machine whereas
+            # it is the root to executes git ls-files in checkHeader.sh.
+            # Git will deny the execution if the mounted volume (/usr/src/app) is owned by a different user.
+            - name: Run checks
               run: |
                   docker compose -f docker-compose.ci.yml run --rm web \
                     sh -c "\
@@ -49,8 +58,7 @@ jobs:
                       npm run check:lint \
                     "
 
-
-            - name: Run unit & integration tests
+            - name: Run unit and integration tests
               run: |
                   docker compose -f docker-compose.ci.yml run --rm web \
                     sh -c "npm ci && npm test"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,6 +17,18 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
 
+            - name: Create .env file for Docker Compose
+              run: |
+                  cat <<EOF > .env
+                  OED_DB_DATABASE=${{ secrets.OED_DB_DATABASE }}
+                  OED_DB_PASSWORD=${{ secrets.OED_DB_PASSWORD }}
+                  OED_DB_PORT=${{ secrets.OED_DB_PORT }}
+                  OED_DB_TEST_DATABASE=${{ secrets.OED_DB_TEST_DATABASE }}
+                  OED_DB_USER=${{ secrets.OED_DB_USER }}
+                  OED_SERVER_PORT=${{ secrets.OED_SERVER_PORT }}
+                  OED_TOKEN_SECRET=${{ secrets.OED_TOKEN_SECRET }}
+                  EOF
+
             - name: Build & start containers
               run: |
                   docker compose -f docker-compose.ci.yml build

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Run unit & integration tests
               run: |
                   docker compose -f docker-compose.ci.yml run --rm web \
-                    sh -c "npm test"
+                    sh -c "npm ci && npm test"
 
             - name: Tear down
               if: always()

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -45,7 +45,7 @@ jobs:
             # We need git config --global -add safe.directory /usr/src/app because
             # /usr/src/app is owned by the runner in GitHub Actions virtual machine whereas
             # it is the root to executes git ls-files in checkHeader.sh.
-            # Git will deny the execution if the mounted volume (/usr/src/app) is owned by a different user.
+            # Git denies the execution if the mounted volume (/usr/src/app) is owned by a different user.
             - name: Run checks
               run: |
                   docker compose -f docker-compose.ci.yml run --rm web \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_PASSWORD: ${{ secrets.OED_DB_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.OED_DB_TEST_DATABASE }}
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       OED_TOKEN_SECRET: ${{ secrets.OED_TOKEN_SECRET }}
       OED_SERVER_PORT: ${{ secrets.OED_SERVER_PORT }}
       OED_TEST_SITE_READING_RATE: ${{ secrets.OED_TEST_SITE_READING_RATE }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      POSTGRES_PASSWORD: ${{ secrets.OED_DB_PASSWORD }}
 
     runs-on: ubuntu-latest
     # Make sure the node version here matches containers/web/Dockerfile for the standard OED build.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   run-checks-tests:
     env:
+      # ${{ secrets }} is saved in Repository secrets (Repo -> Settings -> Secrets and variables -> Actions)
       OED_DB_USER: ${{ secrets.OED_DB_USER }}
       OED_DB_PASSWORD: ${{ secrets.OED_DB_PASSWORD }}
       OED_DB_DATABASE: ${{ secrets.OED_DB_DATABASE }}
@@ -28,6 +29,7 @@ jobs:
       postgres:
         image: postgres
         env:
+          # ${{ secrets }} is saved in Repository secrets (Repo -> Settings -> Secrets and variables -> Actions)
           POSTGRES_PASSWORD: ${{ secrets.OED_DB_PASSWORD }}
           POSTGRES_DB: ${{ secrets.OED_DB_TEST_DATABASE }}
         options: >-
@@ -72,6 +74,7 @@ jobs:
       - name: Connect to PostgreSQL
         run: node client.js
         env:
+          # ${{ secrets }} is saved in Repository secrets (Repo -> Settings -> Secrets and variables -> Actions)
           POSTGRES_HOST: ${{ secrets.OED_DB_HOST }}
           POSTGRES_PORT: ${{ secrets.OED_DB_PORT }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,16 @@ on:
 jobs:
   run-checks-tests:
     env:
-      OED_DB_USER: test
-      OED_DB_PASSWORD: travisTest
-      OED_DB_DATABASE: travis_ci_dummy
-      OED_DB_TEST_DATABASE: travis_ci_test
-      OED_DB_HOST: postgres
-      OED_DB_PORT: 5432
-      OED_TOKEN_SECRET: travis
-      OED_SERVER_PORT: 3000
-      OED_TEST_SITE_READING_RATE: 00:15:00
-      POSTGRES_PASSWORD: travisTest
+      OED_DB_USER: ${{ secrets.OED_DB_USER }}
+      OED_DB_PASSWORD: ${{ secrets.OED_DB_PASSWORD }}
+      OED_DB_DATABASE: ${{ secrets.OED_DB_DATABASE }}
+      OED_DB_TEST_DATABASE: ${{ secrets.OED_DB_TEST_DATABASE }}
+      OED_DB_HOST: ${{ secrets.OED_DB_HOST }}
+      OED_DB_PORT: ${{ secrets.OED_DB_PORT }}
+      OED_TOKEN_SECRET: ${{ secrets.OED_TOKEN_SECRET }}
+      OED_SERVER_PORT: ${{ secrets.OED_SERVER_PORT }}
+      OED_TEST_SITE_READING_RATE: ${{ secrets.OED_TEST_SITE_READING_RATE }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
 
     runs-on: ubuntu-latest
     # Make sure the node version here matches containers/web/Dockerfile for the standard OED build.
@@ -28,8 +28,8 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: travisTest
-          POSTGRES_DB: travis_ci_test
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -72,8 +72,8 @@ jobs:
       - name: Connect to PostgreSQL
         run: node client.js
         env:
-          POSTGRES_HOST: postgres
-          POSTGRES_PORT: 5432
+          POSTGRES_HOST: ${{ secrets.OED_DB_HOST }}
+          POSTGRES_PORT: ${{ secrets.OED_DB_PORT }}
 
       - name: node tests
         run: |

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,113 @@
+# *
+# * This Source Code Form is subject to the terms of the Mozilla Public
+# * License, v. 2.0. If a copy of the MPL was not distributed with this
+# * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# *
+
+version: "3.8"
+services:
+    # Database service. It's PostgreSQL, see the
+    # Dockerfile in ./database
+    database:
+        build: ./containers/database/
+        environment:
+            # Custom PGDATA per recommendations from official Docker page
+            - PGDATA=/var/lib/postgresql/data/pgdata
+            - POSTGRES_PASSWORD=opened # default postgres password that should be changed for security.
+        volumes:
+            - ./postgres-data:/var/lib/postgresql/data/pgdata
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            interval: 10s
+            timeout: 10s
+            retries: 3
+        # ports:
+        #    - "5432:5432"
+        # Uncomment the above lines to enable access to the PostgreSQL server
+        # from the host machine.
+
+    web:
+        # Configuration variables for the app.
+        environment:
+            - OED_PRODUCTION=yes
+            - OED_SERVER_PORT=3000
+            - OED_DB_USER=oed
+            - OED_DB_DATABASE=oed
+            - OED_DB_TEST_DATABASE=oed_testing
+            - OED_DB_PASSWORD=opened
+            - OED_DB_HOST=database # Docker will set this hostname
+            - OED_DB_PORT=5432
+            - OED_TOKEN_SECRET=?
+            - OED_LOG_FILE=log.txt
+            - OED_MAIL_METHOD=none # Method of sending mail. Supports "secure-smtp", "none". Case insensitive.
+            - OED_MAIL_SMTP=smtp.example.com # Edit this
+            - OED_MAIL_SMTP_PORT=465 # Edit this
+            - OED_MAIL_IDENT=someone@example.com # The user email that is used for sending emails (SMTP)
+            - OED_MAIL_CREDENTIAL=credential # Set the email password for sending email here
+            - OED_MAIL_FROM=mydomain@example.com # The email address that the email will come from
+            - OED_MAIL_TO=someone@example.com # Set the destination address here for where to send emails
+            - OED_MAIL_ORG=My Organization Name # Org name for mail that is included in the subject
+            # Changing this value does not impact what OED displays.
+            # What it will change is the date/time stamp on logs, notes and change dates that place the current date/time.
+            # It can also impact the interpretation of readings sent to OED such as Unix timestamps.
+            - TZ=Etc/UTC # Set the timezone of the Docker container where OED runs the web services.
+            # If in a subdirectory, set it here
+            # - OED_SUBDIR=/subdir/
+            # Set the correct build environment.
+        build:
+            context: ./
+            dockerfile: ./containers/web/Dockerfile
+        # Link to the database so the app can persist data
+        links:
+            - database
+        # Load the source code into the container.
+        # Using a volume allows autorebuild to work.
+        volumes:
+            - ./:/usr/src/app
+        # Map the default port.
+        ports:
+            - "3000:3000" # Should be commented out if you uncomment 80:3000 below.
+            - "9229:9229" # Debug port, should be commented out for production
+            # For production you might want something like:
+            # - "80:3000"
+            # and comment out the debug port and 3000:3000 line above
+            # Don't bring this up without the DB
+        depends_on:
+            # - database
+            database:
+                # We need the database and it has to be ready for work (see healthcheck above).
+                condition: service_healthy
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:3000"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+        # Lets docker compose up work right
+        # If environment variable install_args is not set then it becomes blank without warning user.
+        command:
+          [
+              "bash",
+              "./src/scripts/installOED.sh",
+              "--nostart"
+          ]
+        # Use this if you are using a docker-compose that is earlier than version 2 and comment out the one above.
+        # command: ["bash", "./src/scripts/installOED.sh"]
+
+    # Cypress testing service
+    cypress:
+        image: cypress/included
+        profiles:
+            - ui-testing
+        environment:
+            - CYPRESS_BASE_URL=http://web:3000
+            - DISPLAY=:99
+        working_dir: /usr/src/app
+        depends_on:
+            web:
+                condition: service_healthy
+        volumes:
+            - ./:/usr/src/app
+        entrypoint: >
+            /bin/sh -c "
+            rm -f /tmp/.X99-lock &&
+            Xvfb :99 -screen 0 1024x768x16"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,7 +13,7 @@ services:
         environment:
             # Custom PGDATA per recommendations from official Docker page
             PGDATA: /var/lib/postgresql/data/pgdata
-            POSTGRES_PASSWORD: pleaseChange
+            POSTGRES_PASSWORD: ${OED_DB_PASSWORD}
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -12,8 +12,8 @@ services:
         build: ./containers/database/
         environment:
             # Custom PGDATA per recommendations from official Docker page
-            - PGDATA=/var/lib/postgresql/data/pgdata
-            - POSTGRES_PASSWORD=opened # default postgres password that should be changed for security.
+            PGDATA: /var/lib/postgresql/data/pgdata
+            POSTGRES_PASSWORD: ${OED_DB_PASSWORD} # default postgres password that should be changed for security.
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:
@@ -29,28 +29,28 @@ services:
     web:
         # Configuration variables for the app.
         environment:
-            - OED_PRODUCTION=yes
-            - OED_SERVER_PORT=3000
-            - OED_DB_USER=oed
-            - OED_DB_DATABASE=oed
-            - OED_DB_TEST_DATABASE=oed_testing
-            - OED_DB_PASSWORD=opened
-            - OED_DB_HOST=database # Docker will set this hostname
-            - OED_DB_PORT=5432
-            - OED_TOKEN_SECRET=?
-            - OED_LOG_FILE=log.txt
-            - OED_MAIL_METHOD=none # Method of sending mail. Supports "secure-smtp", "none". Case insensitive.
-            - OED_MAIL_SMTP=smtp.example.com # Edit this
-            - OED_MAIL_SMTP_PORT=465 # Edit this
-            - OED_MAIL_IDENT=someone@example.com # The user email that is used for sending emails (SMTP)
-            - OED_MAIL_CREDENTIAL=credential # Set the email password for sending email here
-            - OED_MAIL_FROM=mydomain@example.com # The email address that the email will come from
-            - OED_MAIL_TO=someone@example.com # Set the destination address here for where to send emails
-            - OED_MAIL_ORG=My Organization Name # Org name for mail that is included in the subject
+            OED_PRODUCTION: "yes"
+            OED_SERVER_PORT: ${OED_SERVER_PORT}
+            OED_DB_USER: ${OED_DB_USER}
+            OED_DB_DATABASE: ${OED_DB_DATABASE}
+            OED_DB_TEST_DATABASE: ${OED_DB_TEST_DATABASE}
+            OED_DB_PASSWORD: ${OED_DB_PASSWORD}
+            OED_DB_HOST: database # Docker will set this hostname
+            OED_DB_PORT: ${OED_DB_PORT}
+            OED_TOKEN_SECRET: ${OED_TOKEN_SECRET}
+            OED_LOG_FILE: log.txt
+            OED_MAIL_METHOD: none # Method of sending mail. Supports "secure-smtp", "none". Case insensitive.
+            OED_MAIL_SMTP: smtp.example.com # Edit this
+            OED_MAIL_SMTP_PORT: 465 # Edit this
+            OED_MAIL_IDENT: someone@example.com # The user email that is used for sending emails (SMTP)
+            OED_MAIL_CREDENTIAL: credential # Set the email password for sending email here
+            OED_MAIL_FROM: mydomain@example.com # The email address that the email will come from
+            OED_MAIL_TO: someone@example.com # Set the destination address here for where to send emails
+            OED_MAIL_ORG: My Organization Name # Org name for mail that is included in the subject
             # Changing this value does not impact what OED displays.
             # What it will change is the date/time stamp on logs, notes and change dates that place the current date/time.
             # It can also impact the interpretation of readings sent to OED such as Unix timestamps.
-            - TZ=Etc/UTC # Set the timezone of the Docker container where OED runs the web services.
+            TZ: Etc/UTC # Set the timezone of the Docker container where OED runs the web services.
             # If in a subdirectory, set it here
             # - OED_SUBDIR=/subdir/
             # Set the correct build environment.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,7 +13,7 @@ services:
         environment:
             # Custom PGDATA per recommendations from official Docker page
             PGDATA: /var/lib/postgresql/data/pgdata
-            POSTGRES_PASSWORD: ${OED_DB_PASSWORD}
+            POSTGRES_PASSWORD: pleaseChange
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,7 +13,7 @@ services:
         environment:
             # Custom PGDATA per recommendations from official Docker page
             PGDATA: /var/lib/postgresql/data/pgdata
-            POSTGRES_USER: ${OED_DB_USER}
+            POSTGRES_PASSWORD: ${OED_DB_PASSWORD}
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,7 +13,10 @@ services:
         environment:
             # Custom PGDATA per recommendations from official Docker page
             PGDATA: /var/lib/postgresql/data/pgdata
-            POSTGRES_PASSWORD: ${OED_DB_PASSWORD} # default postgres password that should be changed for security.
+            POSTGRES_USER: ${OED_DB_USER}
+            POSTGRES_PASSWORD: ${OED_DB_PASSWORD}
+            # Create the “test” database that your tests actually target
+            POSTGRES_DB: ${OED_DB_TEST_DATABASE}
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -29,7 +29,7 @@ services:
     web:
         # Configuration variables for the app.
         environment:
-            OED_PRODUCTION: "no"
+            OED_PRODUCTION: "yes"
             OED_SERVER_PORT: ${OED_SERVER_PORT}
             OED_DB_USER: ${OED_DB_USER}
             OED_DB_DATABASE: ${OED_DB_DATABASE}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,9 +14,6 @@ services:
             # Custom PGDATA per recommendations from official Docker page
             PGDATA: /var/lib/postgresql/data/pgdata
             POSTGRES_USER: ${OED_DB_USER}
-            POSTGRES_PASSWORD: ${OED_DB_PASSWORD}
-            # Create the “test” database that your tests actually target
-            POSTGRES_DB: ${OED_DB_TEST_DATABASE}
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:
@@ -32,7 +29,7 @@ services:
     web:
         # Configuration variables for the app.
         environment:
-            OED_PRODUCTION: "yes"
+            OED_PRODUCTION: "no"
             OED_SERVER_PORT: ${OED_SERVER_PORT}
             OED_DB_USER: ${OED_DB_USER}
             OED_DB_DATABASE: ${OED_DB_DATABASE}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -29,7 +29,7 @@ services:
     web:
         # Configuration variables for the app.
         environment:
-            OED_PRODUCTION: "yes"
+            OED_PRODUCTION: "no"
             OED_SERVER_PORT: ${OED_SERVER_PORT}
             OED_DB_USER: ${OED_DB_USER}
             OED_DB_DATABASE: ${OED_DB_DATABASE}


### PR DESCRIPTION
# Description

(1) .github/workflows/build.yml: Replaced the hardcoded credentials with GitHub secrets environment variables.
(2) .github/workflows/build-docker.yml: This is a newly added workflow; it builds Docker images and run the container in the GitHub Actions virtual machine; conducts check and test.
(3) docker-compose.ci.yml: This is a new docker-compose file for docker composing up in the GitHub Actions virtual machine. It is the same as the original docker-compose.yml except the credentials.

Fixes #553

(1) The new build.yml file is basically the same as before except the credentials. Please add the following environment variables to GitHub secrets.

OED_DB_DATABASE			= oed
OED_DB_HOST				= postgres
OED_DB_PASSWORD			= opened
OED_DB_PORT				= 5432
OED_DB_TEST_DATABASE		= oed_testing
OED_DB_USER				= oed
OED_SERVER_PORT			= 3000
OED_TEST_SITE_READING_RATE = 00:15:00
OED_TOKEN_SECRET			= travis

Repo -> Settings -> Secrets and variables -> Actions
<img width="782" alt="image" src="https://github.com/user-attachments/assets/11d48478-b1b0-4c50-9b4c-3fce281b1d5e" />

(2) The new build-docker.yml workflow was added so we can check and test the OED in the same environment as the developers do. This workflow builds Docker images, runs the containers, checks header, typescript, types and lint, and npm test.

(3) The newly added docker-compose.ci.yml is for docker composing up in GitHub Actions virtual machine. This is basically the same as the original docker-compose.yml except the credentials.

## Type of change

- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

(1) I think OED_DB_HOST doesn't need to be injected as an environment variable. OED_DB_HOST can be hardcoded as before. It should be identical with the name of the database. In build.yml, it is "postgres" and in build-docker.yml, it is "database," which are already defined in the respective yml file.
(2) Other environment variables in docker-compose.ci.yml should be also stored in GitHub secrets?
![image](https://github.com/user-attachments/assets/3531bb1a-0977-4dc8-a828-ae275def20cf)
