### PR TITLE
Update VSCode launch config to support debugging client and server code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,14 +15,34 @@
 			"name": "Launch Chrome against localhost",
 			"url": "http://localhost:3000",
 			"webRoot": "${workspaceFolder}"
+		},
+		{
+			"type": "firefox",
+			"request": "launch",
+			"name": "Launch Firefox against localhost",
+			"url": "http://localhost:3000",
+			"webRoot": "${workspaceFolder}",
+			"pathMappings": [
+				{
+					"url": "webpack://open-energy-dashboard/src",
+					"path": "${workspaceFolder}/src"
+				}
+			]
 		}
 	],
 	"compounds": [
 		{
-			"name": "Debug Server and Client",
+			"name": "Debug Server and Client (Chrome)",
 			"configurations": [
 				"Attach to Node in Docker",
 				"Launch Chrome against localhost"
+			]
+		},
+		{
+			"name": "Debug Server and Client (Firefox)",
+			"configurations": [
+				"Attach to Node in Docker",
+				"Launch Firefox against localhost"
 			]
 		}
 	]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,11 +6,24 @@
 			"type": "node",
 			"request": "attach",
 			"port": 9229,
-			"address": "localhost",
-			"localRoot": "${workspaceFolder}",
 			"remoteRoot": "/usr/src/app",
-			"protocol": "inspector",
-			"restart": true
+			"sourceMaps": true
+		},
+		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Launch Chrome against localhost",
+			"url": "http://localhost:3000",
+			"webRoot": "${workspaceFolder}"
+		}
+	],
+	"compounds": [
+		{
+			"name": "Debug Server and Client",
+			"configurations": [
+				"Attach to Node in Docker",
+				"Launch Chrome against localhost"
+			]
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"repository": "https://github.com/OpenEnergyDashboard/OED",
 	"scripts": {
 		"start": "node ./src/bin/www",
-		"start:dev": "nodemon --legacy-watch --inspect=0.0.0.0 ./src/bin/www",
+		"start:dev": "nodemon --legacy-watch --inspect=0.0.0.0:9229 ./src/bin/www",
 		"checkWebsiteStatus": "node src/server/services/checkWebsiteStatus.js",
 		"webpack:dev": "webpack watch --color --progress --mode development",
 		"webpack:build": "webpack build --node-env production",


### PR DESCRIPTION
# Description

This allows developers to use VSCode's debugger when working on OED.

With the app running in dev mode, you can execute the `Attach to Node in Docker` config to attach the debugger to the server-side Node.js code. Executing the `Launch Chrome against localhost` config will open a browser with a debugger attached to the client-side code.

Also included in a compound config `Debug Server and Client` that will launch both the server and client debuggers.

Fixes #1501

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

For debugging client-side code, I have only included a config to launch Chrome. Configurations could be added for other browsers.

Other tasks could be created to further streamline development. For example, `docker compose up` could be configured as a pre-launch task to enable starting the app and debugger with a single button press.
