### PR TITLE
1510 configured cy.log to output to terminal when running in headless mode

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,8 +7,7 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
 	e2e: {
 		setupNodeEvents(on, config) {
-
-			// This directs the output of cy.log() to the terminal for debug purposes
+			// implement node event listeners here
 			on("task", {
 				log(args) {
 					console.log(...args);

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
 	e2e: {
 		setupNodeEvents(on, config) {
 			// implement node event listeners here
+			on("task", {
+				log(args) {
+					console.log(...args);
+					return null
+				}
+			})
 		},
 		specPattern: 'src/cypress/e2e/*.cy.ts',
 		supportFile: 'src/cypress/support/e2e.ts',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,13 +7,14 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
 	e2e: {
 		setupNodeEvents(on, config) {
-			// implement node event listeners here
+
+			// This directs the output of cy.log() to the terminal for debug purposes
 			on("task", {
 				log(args) {
 					console.log(...args);
-					return null
+					return null;
 				}
-			})
+			});
 		},
 		specPattern: 'src/cypress/e2e/*.cy.ts',
 		supportFile: 'src/cypress/support/e2e.ts',

--- a/src/cypress/e2e/general_ui.cy.ts
+++ b/src/cypress/e2e/general_ui.cy.ts
@@ -11,6 +11,32 @@ describe('UI Functionality Tests for Open Energy Dashboard', () => {
 		cy.visit('/');
 	});
 
+	const viewports = [
+		{ name: 'desktop', width: 1280, height: 800 },
+		{ name: 'mobile',  width: 375,  height: 667 }
+	];
+
+	viewports.forEach(({ name, width, height }) => {
+		context(`@${name} viewport`, () => {
+			before(() => {
+				cy.viewport(width, height);
+			});
+
+			it(`should click all visible buttons on ${name}`, () => {
+				cy.get('button:visible').then(($buttons) => {
+					const count = $buttons.length;
+					cy.log(`Found ${count} visible buttons on ${name}`)
+				});
+				cy.get('button:visible').each(($btn) => {
+					cy.wrap($btn)
+						.scrollIntoView()
+						.click();
+				});
+
+			});
+		});
+	});
+
 	// it('Tests all buttons functionality', () => {
 	// 	// Ensure buttons are visible and clickable
 	// 	cy.get('button').should('have.length.greaterThan', 0); // Ensure buttons exist

--- a/src/cypress/support/commands.ts
+++ b/src/cypress/support/commands.ts
@@ -31,18 +31,18 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 Cypress.Commands.overwrite("log", function(log, ...args) {
-  const indent = "\t"; // You can adjust the number of tabs or spaces here
-  const formattedArgs = args.map((arg) =>
-        typeof arg === "string" ? indent + arg : indent + JSON.stringify(arg)
-  );
-  if (Cypress.browser.isHeadless) {
-    return cy.task("log", formattedArgs, { log: false }).then(() => {
-      return log(...args);
-    });
-  } else {
-    console.log(...formattedArgs);
-    return log(...args);
-  }
+	const indent = "\t"; // You can adjust the number of tabs or spaces here
+	const formattedArgs = args.map((arg) =>
+				typeof arg === "string" ? indent + arg : indent + JSON.stringify(arg)
+	);
+	if (Cypress.browser.isHeadless) {
+		return cy.task("log", formattedArgs, { log: false }).then(() => {
+			return log(...args);
+		});
+	} else {
+		console.log(...formattedArgs);
+		return log(...args);
+	}
 });
 
 //

--- a/src/cypress/support/commands.ts
+++ b/src/cypress/support/commands.ts
@@ -30,6 +30,21 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+Cypress.Commands.overwrite("log", function(log, ...args) {
+  const indent = "\t"; // You can adjust the number of tabs or spaces here
+  const formattedArgs = args.map((arg) =>
+        typeof arg === "string" ? indent + arg : indent + JSON.stringify(arg)
+  );
+  if (Cypress.browser.isHeadless) {
+    return cy.task("log", formattedArgs, { log: false }).then(() => {
+      return log(...args);
+    });
+  } else {
+    console.log(...formattedArgs);
+    return log(...args);
+  }
+});
+
 //
 // declare global {
 //   namespace Cypress {


### PR DESCRIPTION
# Description

I added terminal output to Cypress tests, to make it easier to determine why tests are failing when they do.

Fixes #1510 

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

I just added output to the terminal, no permanent logging system.
