### PR TITLE
fix middleware to allow test login

### DIFF
--- a/src/server/routes/authenticator.js
+++ b/src/server/routes/authenticator.js
@@ -55,7 +55,7 @@ function credentialsRequestValidationMiddleware(req, res, next) {
 		properties: {
 			username: {
 				type: 'string',
-				minLength: 5,
+				minLength: 3,
 				maxLength: 254
 			},
 			password: {


### PR DESCRIPTION
# Description

PR #1489 changed the middle ware for login. This had a new limit of at least 5 characters for a username. This did not match the login.js limit of 3. This resulted in developers not being able to login with the test user. This makes the middle ware consistent so its min in 3.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

None known
