### PR TITLE
DRAFT - Reset database UI testing data repeatability

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,14 +3,49 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { defineConfig } from 'cypress';
+import { exec } from 'child_process';
 
 export default defineConfig({
 	e2e: {
+		baseUrl: 'http://localhost:3000', //ANGEL43V3R DEBUG LINE ADDED
 		setupNodeEvents(on, config) {
 			// implement node event listeners here
+			on('task', {
+				resetDatabase() {
+					return new Promise((resolve, reject) => {
+						let output = '';
+						
+						const child = exec('docker exec oed-web-1 node src/server/util/resetDatabase.js', { env: process.env});
+
+						child.stdout?.on('data', (data) => {
+							output += data;
+						});
+
+						child.stderr?.on('data', (data) => {
+							output += data;
+						});
+
+						child.on('close', (code) => {
+							if (code === 0) {
+								resolve(output);
+							}else {
+								reject(new Error(`Process exited with code ${code}: ${output}`));
+							}
+						});
+
+						child.on('error', (err) => {
+							reject(err);
+						});
+
+					});
+				},
+			});
+
+			//return config to modify it
+			return config;
 		},
 		specPattern: 'src/cypress/e2e/*.cy.ts',
 		supportFile: 'src/cypress/support/e2e.ts',
 		screenshotsFolder: 'src/cypress/screenshots/e2e'
-	}
+	},
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@
 # * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # *
 
-version: "3.8"
 services:
     # Database service. It's PostgreSQL, see the
     # Dockerfile in ./database
@@ -101,6 +100,13 @@ services:
       environment:
         - CYPRESS_BASE_URL=http://web:3000
         - DISPLAY=:99
+        #Pass DB environment variables for resetDatabase.js to access them - ANGEL43V3R
+        - OED_DB_USER=oed
+        - OED_DB_PASSWORD=opened
+        - OED_DB_HOST=database
+        - OED_DB_PORT=5432
+        - OED_DB_TEST_DATABASE=oed_testing
+        #----edit end-----
       working_dir: /usr/src/app
       depends_on:
         web:

--- a/src/cypress/e2e/resetDatabase.cy.ts
+++ b/src/cypress/e2e/resetDatabase.cy.ts
@@ -1,0 +1,12 @@
+//Cypress test for resetDatabase.js - Angel43v3r
+
+describe('Database Reset', () => {
+    it('should reset and repopulate the test database', () => {
+        cy.log('Starting resetDatabase...')
+        cy.task('resetDatabase').then((output: string) => {
+            cy.log(`Database Reset Output: ${output}`);
+            console.log('Full output:', output);
+            expect(output).to.include('Finished generating the test data');
+        });
+    });
+});

--- a/src/server/util/resetDatabase.js
+++ b/src/server/util/resetDatabase.js
@@ -1,0 +1,127 @@
+//Author: ANGEL43V3R - added a script to reset the database and then repopulate it.
+/**
+ * Author: ANGEL43V3R
+ * 
+ * This script resets the test database (oed_testing) by dropping and recreating the test database.
+ * It then uses generateTestingData to populate the table using generateSine function.
+ */
+
+console.log('PGPASSWORD:', typeof process.env.PGPASSWORD, process.env.PGPASSWORD);
+
+
+const { Client } = require('pg');
+const { generateSine } = require('../data/generateTestingData');
+
+//Admin configuration to connect to the Postgres database
+//NOTE: if want to run the test locally change host: 'database' to 'localhost'
+const adminConfig = {
+    user: process.env.OED_DB_USER,
+    host: process.env.OED_DB_HOST,
+    database: 'postgres',
+    password: process.env.OED_DB_PASSWORD,
+    port: process.env.OED_DB_PORT,
+};
+
+//Test configuration to connect to the test database (oed_testing) 
+//NOTE: if want to run the test locally change host: 'database' to 'localhost'
+const testDbConfig = {
+    user: process.env.OED_DB_USER,
+    host: process.env.OED_DB_HOST,
+    database: process.env.OED_DB_TEST_DATABASE,
+    password: process.env.OED_DB_PASSWORD,
+    port:  process.env.OED_DB_PORT,
+};
+
+/**
+ * Drops and recreates the oed_testing database
+ */
+async function resetTestDatabase() {
+    const client = new Client(adminConfig);
+    await client.connect();
+
+    try {
+        console.log('Dropping test database (if exists)...')
+        await client.query('DROP DATABASE IF EXISTS oed_testing;');
+
+        console.log('Recreating the test database...')
+        await client.query('CREATE DATABASE oed_testing WITH OWNER oed;');
+        console.log('Test database reset successfully!');
+    } catch (err) {
+        console.error('Error found during database reset: ', err);
+        throw err;
+    } finally {
+        await client.end();
+    }
+}
+
+/**
+ * Create table and insert generated test data 
+ */
+async function insertTestData() {
+    const client = new Client(testDbConfig);
+    await client.connect();
+
+    try {
+        //Create database tables
+        await client.query(
+            `
+            CREATE TABLE IF NOT EXISTS sine_data (
+            id SERIAL PRIMARY KEY,
+            value DOUBLE PRECISION NOT NULL,
+            start_timestamp TIMESTAMP NOT NULL,
+            end_timestamp TIMESTAMP NOT NULL
+            );
+            `
+        );
+
+        // Generate sine data sample
+        console.log ('Generating the sine test data...')
+        const sineData = generateSine(
+            '2025-01-01 00:00:00', 
+            '2025-01-02 00:00:00', 
+            { 
+                timeStep: {hour: 1 }, 
+                maxAmplitude: 10
+            }
+        );
+
+        //Check if sine data is an array or if array is empty
+        if (!Array.isArray(sineData) || sineData.length === 0) {
+            throw new Error ('Invalid sine data, no sine data generated!')
+        }
+
+
+        //Insert generated data in rows
+        console.log (`Inserting ${sineData.length} rows of test data...`)
+        for (const row of sineData) {
+            await client.query(
+                'INSERT INTO sine_data (value, start_timestamp, end_timestamp) VALUES ($1, $2, $3)',
+                [row.value, row.startTimeStamp, row.endTimeStamp]
+            );
+        }
+
+        //Verifying by running a sample query
+        const res = await client.query('SELECT COUNT(*) FROM sine_data;');
+        console.log('Inserted rows of sine data successfully! Total rows of sine data:', res.rows[0].count);
+    } finally {
+        await client.end();
+    }
+}
+
+/**
+ * Main function - resets and repopulate the database
+ */
+async function main() {
+    try {
+        console.log('Starting database reset...')
+        await resetTestDatabase();
+        console.log('Inserting test data...')
+        await insertTestData();
+        console.log('Finished generating the test data!');
+    } catch (err) {
+        console.error('Error during test setup:', err);
+    }
+    process.exit(0);
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,18 @@
 		"noImplicitAny": true,
 		"strictNullChecks": true,
 		"noUnusedLocals": true,
+		//------------ANGEL43V3R-----------------
+		//Added for TypeScript to include Node.js type definitions to fix child_process error
+		"types": ["node"]
+		//-------------------------------
 	},
 	"include": [
-		"./src/client/app/**/*"
+		"./src/client/app/**/*",
+		//Add Cypress test folder
+		"./cypress.config.ts",
+		"./src/cypress/**/*.ts",
+		//Add server utiltity scripts
+		"./src/server/util/**/*.ts"
 	],
 	"exclude": [
 		"node_modules"


### PR DESCRIPTION
# Description

This pull request adds a 'resetDatabase.js' script that resets and repopulate the test database before running the Cypress UI tests. This also includes a resetDatabase.cy.ts which is a Cypress test file that runs the test using the resetDatabase.js (UITesting.md - Standardized testing data repeatability). 

Contributors: 
@Angel43v3r

Partly Addresses #1419 

## Type of change

- [x] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement] and each author is listed in the Description section.

## Limitations

- The Cypress test resetDatabase.cy.ts currently covers only the database reset functionality, so additional UI tests with more edge cases and error handling may be needed to fully verify this feature. 
- Comments I added in the code during development are not professionally written and may need to be reviewed, updated, or removed for clarity and professionality. The comments contain multiple dashes and my username at times. I marked this pull request as draft because of it.
