### PR TITLE
1187 horizontal shift when error bars

### DIFF
--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -128,9 +128,12 @@ export default function LineChartComponent() {
 			}
 		}
 		// Tries to get the range from the slider range interval, undefined if not bounded
-		const sliderRange: [string, string] | undefined = sliderRangeInterval?.getIsBounded() ? 
-		[sliderRangeInterval.getStartTimestamp()!.utc().toISOString(), 
-		sliderRangeInterval.getEndTimestamp()!.utc().toISOString()] : undefined;
+		const sliderRange: [string, string] | undefined = sliderRangeInterval?.getIsBounded()
+			? [
+				sliderRangeInterval.getStartTimestamp()!.utc().toISOString(),
+				sliderRangeInterval.getEndTimestamp()!.utc().toISOString()
+			]
+			: undefined;
 		// Either sets the xRange to the minDate maxDate or the saved slider range. This keeps the range from resetting when we toggle error bars.
 		const xRange: [string, string] = sliderRange ?? [minDate, maxDate];
 		return (

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -19,7 +19,7 @@ import { selectSelectedLanguage } from '../redux/slices/appStateSlice';
 import Locales from '../types/locales';
 import { useTranslate } from '../redux/componentHooks';
 import SpinnerComponent from './SpinnerComponent';
-import { setInitialXAxisRange, selectSliderRangeInterval } from '../redux/slices/graphSlice';
+import { setInitialXAxisRange } from '../redux/slices/graphSlice';
 import { fullSizeContainer } from '../styles/modalStyle';
 
 /**
@@ -34,7 +34,6 @@ export default function LineChartComponent() {
 	const { meterDeps, groupDeps } = useAppSelector(selectLineChartDeps);
 	const locale = useAppSelector(selectSelectedLanguage);
 	// initial slider range
-	// const sliderRangeInterval = useAppSelector(selectSliderRangeInterval);
 
 	// Fetch data, and derive plotly points
 	const { data: meterPlotlyData, isFetching: meterIsFetching } = readingsApi.useLineQuery(meterArgs,
@@ -147,7 +146,7 @@ export default function LineChartComponent() {
 						showgrid: true,
 						gridcolor: '#ddd'
 					},
-					uirevision: 'static'
+					
 				}}
 				config={{
 					responsive: true,

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -128,9 +128,9 @@ export default function LineChartComponent() {
 			}
 		}
 		// Tries to get the range from the slider range interval, undefined if not bounded
-		const sliderRange = sliderRangeInterval?.getIsBounded() ? [sliderRangeInterval.getStartTimestamp()!.utc().toISOString(), sliderRangeInterval.getEndTimestamp()!.utc().toISOString()]: undefined;
-		// X range is defined as either the slider range interval or the initial min max
-		const xRange = sliderRange ?? [minDate, maxDate];
+		const sliderRange: [string, string] | undefined = sliderRangeInterval?.getIsBounded() ? [sliderRangeInterval.getStartTimestamp()!.utc().toISOString(), sliderRangeInterval.getEndTimestamp()!.utc().toISOString()] : undefined;
+		// Either sets the xRange to the minDate maxDate or the saved slider range. This keeps the range from resetting when we toggle error bars.
+		const xRange: [string, string] = sliderRange ?? [minDate, maxDate];
 		return (
 			<Plot
 				data={data}
@@ -142,7 +142,7 @@ export default function LineChartComponent() {
 					yaxis: { title: unitLabel, gridcolor: '#ddd', fixedrange: true },
 					// 'fixedrange' on the yAxis means that dragging is only allowed on the xAxis which we utilize for selecting dateRanges
 					xaxis: {
-						rangeslider: { visible: true },
+						rangeslider: { visible: true, range: [minDate, maxDate] },
 						range: xRange,
 						showgrid: true,
 						gridcolor: '#ddd'

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -19,7 +19,7 @@ import { selectSelectedLanguage } from '../redux/slices/appStateSlice';
 import Locales from '../types/locales';
 import { useTranslate } from '../redux/componentHooks';
 import SpinnerComponent from './SpinnerComponent';
-import { setInitialXAxisRange } from '../redux/slices/graphSlice';
+import { setInitialXAxisRange, selectSliderRangeInterval } from '../redux/slices/graphSlice';
 import { fullSizeContainer } from '../styles/modalStyle';
 
 /**
@@ -34,6 +34,7 @@ export default function LineChartComponent() {
 	const { meterDeps, groupDeps } = useAppSelector(selectLineChartDeps);
 	const locale = useAppSelector(selectSelectedLanguage);
 	// initial slider range
+	const sliderRangeInterval = useAppSelector(selectSliderRangeInterval);
 
 	// Fetch data, and derive plotly points
 	const { data: meterPlotlyData, isFetching: meterIsFetching } = readingsApi.useLineQuery(meterArgs,
@@ -107,12 +108,9 @@ export default function LineChartComponent() {
 	// See https://community.plotly.com/t/replacing-an-empty-graph-with-a-message/31497 for showing text not plot.
 	if (data.length === 0) {
 		return <h1>{`${translate('select.meter.group')}`}	</h1>;
-	} else if (!enoughData || !data[0].x) {
+	} else if (!enoughData) {
 		return <h1>{`${translate('no.data.in.range')}`}</h1>;
 	} else {
-		// Adjust the min and max values for the x axis
-		// This goes through the list of groups/meters that have data to find the earliest and latest dates.
-		console.log(data);
 		let minDate = '';
 		let maxDate = '';
 		for (const trace of data) {
@@ -120,17 +118,19 @@ export default function LineChartComponent() {
 				const traceMin = trace.x[0] as string;
 				const traceMax = trace.x[trace.x.length - 1] as string;
 				// Update minX if this is the first trace or has an earlier date
-				if (minDate === '' || traceMin < minDate) {
+				if (minDate === '' || utc(traceMin).isBefore(utc(minDate))) {
 					minDate = traceMin;
 				}
 				// Update maxX if this is the first trace or has a later date
-				if (maxDate === '' || traceMax > maxDate) {
+				if (maxDate === '' || utc(traceMax).isAfter(utc(maxDate))) {
 					maxDate = traceMax;
 				}
 			}
-
-
 		}
+		// Tries to get the range from the slider range interval, undefined if not bounded
+		const sliderRange = sliderRangeInterval?.getIsBounded() ? [sliderRangeInterval.getStartTimestamp()!.utc().toISOString(), sliderRangeInterval.getEndTimestamp()!.utc().toISOString()]: undefined;
+		// X range is defined as either the slider range interval or the initial min max
+		const xRange = sliderRange ?? [minDate, maxDate];
 		return (
 			<Plot
 				data={data}
@@ -143,7 +143,7 @@ export default function LineChartComponent() {
 					// 'fixedrange' on the yAxis means that dragging is only allowed on the xAxis which we utilize for selecting dateRanges
 					xaxis: {
 						rangeslider: { visible: true },
-						range: [minDate, maxDate],
+						range: xRange,
 						showgrid: true,
 						gridcolor: '#ddd'
 					}

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -147,7 +147,6 @@ export default function LineChartComponent() {
 						showgrid: true,
 						gridcolor: '#ddd'
 					}
-					
 				}}
 				config={{
 					responsive: true,

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -34,7 +34,7 @@ export default function LineChartComponent() {
 	const { meterDeps, groupDeps } = useAppSelector(selectLineChartDeps);
 	const locale = useAppSelector(selectSelectedLanguage);
 	// initial slider range
-	const sliderRangeInterval = useAppSelector(selectSliderRangeInterval);
+	// const sliderRangeInterval = useAppSelector(selectSliderRangeInterval);
 
 	// Fetch data, and derive plotly points
 	const { data: meterPlotlyData, isFetching: meterIsFetching } = readingsApi.useLineQuery(meterArgs,
@@ -111,6 +111,26 @@ export default function LineChartComponent() {
 	} else if (!enoughData || !data[0].x) {
 		return <h1>{`${translate('no.data.in.range')}`}</h1>;
 	} else {
+		// Adjust the min and max values for the x axis
+		console.log(data);
+		let minX = "";
+		let maxX = "";
+		for (const trace of data) {
+			if (trace.x && trace.x.length > 0) {
+				const traceMin = trace.x[0] as string;  // First element
+				const traceMax = trace.x[trace.x.length - 1] as string;  // Last element
+				// Update minX if this is the first trace or has an earlier date
+				if (minX === "" || traceMin < minX) {
+					minX = traceMin;
+				}
+				// Update maxX if this is the first trace or has a later date
+				if (maxX === "" || traceMax > maxX) {
+					maxX = traceMax;
+				}
+			}
+
+
+		}
 		return (
 			<Plot
 				data={data}
@@ -123,7 +143,7 @@ export default function LineChartComponent() {
 					// 'fixedrange' on the yAxis means that dragging is only allowed on the xAxis which we utilize for selecting dateRanges
 					xaxis: {
 						rangeslider: { visible: true },
-						range: [data[0].x[0], data[0].x[data[0].x.length - 1]],
+						range: [minX, maxX],
 						showgrid: true,
 						gridcolor: '#ddd'
 					},

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -113,18 +113,18 @@ export default function LineChartComponent() {
 		// Adjust the min and max values for the x axis
 		// This goes through the list of groups/meters that have data to find the earliest and latest dates.
 		console.log(data);
-		let minDate = "";
-		let maxDate = "";
+		let minDate = '';
+		let maxDate = '';
 		for (const trace of data) {
 			if (trace.x && trace.x.length > 0) {
-				const traceMin = trace.x[0] as string;  
-				const traceMax = trace.x[trace.x.length - 1] as string;  
+				const traceMin = trace.x[0] as string;
+				const traceMax = trace.x[trace.x.length - 1] as string;
 				// Update minX if this is the first trace or has an earlier date
-				if (minDate === "" || traceMin < minDate) {
+				if (minDate === '' || traceMin < minDate) {
 					minDate = traceMin;
 				}
 				// Update maxX if this is the first trace or has a later date
-				if (maxDate === "" || traceMax > maxDate) {
+				if (maxDate === '' || traceMax > maxDate) {
 					maxDate = traceMax;
 				}
 			}
@@ -146,7 +146,7 @@ export default function LineChartComponent() {
 						range: [minDate, maxDate],
 						showgrid: true,
 						gridcolor: '#ddd'
-					},
+					}
 					
 				}}
 				config={{

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -128,7 +128,9 @@ export default function LineChartComponent() {
 			}
 		}
 		// Tries to get the range from the slider range interval, undefined if not bounded
-		const sliderRange: [string, string] | undefined = sliderRangeInterval?.getIsBounded() ? [sliderRangeInterval.getStartTimestamp()!.utc().toISOString(), sliderRangeInterval.getEndTimestamp()!.utc().toISOString()] : undefined;
+		const sliderRange: [string, string] | undefined = sliderRangeInterval?.getIsBounded() ? 
+		[sliderRangeInterval.getStartTimestamp()!.utc().toISOString(), 
+		sliderRangeInterval.getEndTimestamp()!.utc().toISOString()] : undefined;
 		// Either sets the xRange to the minDate maxDate or the saved slider range. This keeps the range from resetting when we toggle error bars.
 		const xRange: [string, string] = sliderRange ?? [minDate, maxDate];
 		return (

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -108,7 +108,7 @@ export default function LineChartComponent() {
 	// See https://community.plotly.com/t/replacing-an-empty-graph-with-a-message/31497 for showing text not plot.
 	if (data.length === 0) {
 		return <h1>{`${translate('select.meter.group')}`}	</h1>;
-	} else if (!enoughData) {
+	} else if (!enoughData || !data[0].x) {
 		return <h1>{`${translate('no.data.in.range')}`}</h1>;
 	} else {
 		return (
@@ -123,11 +123,11 @@ export default function LineChartComponent() {
 					// 'fixedrange' on the yAxis means that dragging is only allowed on the xAxis which we utilize for selecting dateRanges
 					xaxis: {
 						rangeslider: { visible: true },
-						range: [sliderRangeInterval.getStartTimestamp()?.toISOString(),
-							sliderRangeInterval.getEndTimestamp()?.toISOString()],
+						range: [data[0].x[0], data[0].x[data[0].x.length - 1]],
 						showgrid: true,
 						gridcolor: '#ddd'
-					}
+					},
+					uirevision: 'static'
 				}}
 				config={{
 					responsive: true,

--- a/src/client/app/components/LineChartComponent.tsx
+++ b/src/client/app/components/LineChartComponent.tsx
@@ -111,20 +111,21 @@ export default function LineChartComponent() {
 		return <h1>{`${translate('no.data.in.range')}`}</h1>;
 	} else {
 		// Adjust the min and max values for the x axis
+		// This goes through the list of groups/meters that have data to find the earliest and latest dates.
 		console.log(data);
-		let minX = "";
-		let maxX = "";
+		let minDate = "";
+		let maxDate = "";
 		for (const trace of data) {
 			if (trace.x && trace.x.length > 0) {
-				const traceMin = trace.x[0] as string;  // First element
-				const traceMax = trace.x[trace.x.length - 1] as string;  // Last element
+				const traceMin = trace.x[0] as string;  
+				const traceMax = trace.x[trace.x.length - 1] as string;  
 				// Update minX if this is the first trace or has an earlier date
-				if (minX === "" || traceMin < minX) {
-					minX = traceMin;
+				if (minDate === "" || traceMin < minDate) {
+					minDate = traceMin;
 				}
 				// Update maxX if this is the first trace or has a later date
-				if (maxX === "" || traceMax > maxX) {
-					maxX = traceMax;
+				if (maxDate === "" || traceMax > maxDate) {
+					maxDate = traceMax;
 				}
 			}
 
@@ -142,7 +143,7 @@ export default function LineChartComponent() {
 					// 'fixedrange' on the yAxis means that dragging is only allowed on the xAxis which we utilize for selecting dateRanges
 					xaxis: {
 						rangeslider: { visible: true },
-						range: [minX, maxX],
+						range: [minDate, maxDate],
 						showgrid: true,
 						gridcolor: '#ddd'
 					},


### PR DESCRIPTION
# Description

(Please include a summary of the change and which issue is touched on. Please also include relevant motivation and context.)
Looked into how Plotly works and confirmed that the offset is being caused by the Plotly autorange feature. The change now uses the information in the response data to set the x range. I was able to address the issues that were noted in PR #1409. I changed the logic to check for both enoughData and data[0].x. I added logic to adjust the x-axis min and max values to autofit the line chart. Note that this led to the SliderRangeInterval component being unused in this file

Matthew Tran - @MatthewTran22 

Fixes #1187 

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.
