### PR TITLE
Disable meter unit #1521

### DIFF
--- a/src/client/app/components/unit/EditUnitModalComponent.tsx
+++ b/src/client/app/components/unit/EditUnitModalComponent.tsx
@@ -447,7 +447,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 									>
 										{Object.keys(UnitType).map(key => {
 											const isMeter = key === UnitType.meter;
-											const disableMeter = isMeter && inConversions()
+											const disableMeter = isMeter && inConversions();
 											return (
 												<option
 													value={key}

--- a/src/client/app/components/unit/EditUnitModalComponent.tsx
+++ b/src/client/app/components/unit/EditUnitModalComponent.tsx
@@ -410,7 +410,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 										name='identifier'
 										type='text'
 										autoComplete='on'
-										onChange={e => {handleStringChange(e);}}
+										onChange={e => { handleStringChange(e); }}
 										value={state.identifier} />
 								</FormGroup>
 							</Col>
@@ -423,7 +423,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 										name='name'
 										type='text'
 										autoComplete='on'
-										onChange={e => {handleStringChange(e);}}
+										onChange={e => { handleStringChange(e); }}
 										value={state.name}
 										invalid={state.name === ''} />
 									<FormFeedback>
@@ -441,16 +441,18 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 										id='typeOfUnit'
 										name='typeOfUnit'
 										type='select'
-										onChange={e => {handleStringChange(e);}}
+										onChange={e => { handleStringChange(e); }}
 										value={state.typeOfUnit}
 										invalid={state.typeOfUnit !== UnitType.suffix && state.suffix !== ''}
 									>
 										{Object.keys(UnitType).map(key => {
+											const isMeter = key === UnitType.meter;
+											const disableMeter = isMeter && inConversions()
 											return (
 												<option
 													value={key}
 													key={key}
-													disabled={state.suffix !== '' && key !== UnitType.suffix}
+													disabled={(state.suffix !== '' && key !== UnitType.suffix) || disableMeter}
 												>
 													{translate(`UnitType.${key}`)}
 												</option>
@@ -472,7 +474,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 										type='select'
 										value={state.unitRepresent}
 										disabled={inConversions()}
-										onChange={e => {handleStringChange(e);}}
+										onChange={e => { handleStringChange(e); }}
 									>
 										{Object.keys(UnitRepresentType).map(key => {
 											return (
@@ -494,7 +496,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 										name='displayable'
 										type='select'
 										value={state.displayable}
-										onChange={e => {handleStringChange(e);}}
+										onChange={e => { handleStringChange(e); }}
 										invalid={
 											state.displayable !== DisplayableType.none &&
 											(state.typeOfUnit === UnitType.meter || state.suffix !== '')
@@ -532,7 +534,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 										name='preferredDisplay'
 										type='select'
 										value={state.preferredDisplay.toString()}
-										onChange={e => {handleBooleanChange(e);}}>
+										onChange={e => { handleBooleanChange(e); }}>
 										{Object.keys(TrueFalseType).map(key => {
 											return (
 												<option value={key} key={key}>
@@ -554,7 +556,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 										name='secInRate'
 										type='select'
 										value={rate}
-										onChange={e => {handleRateChange(e);}}>
+										onChange={e => { handleRateChange(e); }}>
 										{Object.entries(LineGraphRates).map(
 											([rateKey, rateValue]) => (
 												<option value={rateValue * 3600} key={rateKey}>
@@ -578,7 +580,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 												value={customRate}
 												min={1}
 												invalid={!customRateValid(customRate)}
-												onChange={e => {handleCustomRateChange(e);}}
+												onChange={e => { handleCustomRateChange(e); }}
 												// This grabs each key hit and then finishes input when hit enter.
 												onKeyDown={e => { handleEnter(e.key); }}
 											/>
@@ -599,7 +601,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 										name='suffix'
 										type='text'
 										value={state.suffix}
-										onChange={e => {handleStringChange(e);}}
+										onChange={e => { handleStringChange(e); }}
 										invalid={state.typeOfUnit === UnitType.suffix && state.suffix === ''} />
 									<FormFeedback>
 										<FormattedMessage id="error.required" />
@@ -612,7 +614,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 							<Col><FormGroup>
 								<Label for='minVal'>{translate('min.value')}</Label>
 								<Input id='minVal' name='minVal' type='number'
-									onChange={e => {handleNumberChange(e);}}
+									onChange={e => { handleNumberChange(e); }}
 									min={MIN_VAL}
 									max={state.maxVal}
 									required value={state.minVal}
@@ -625,7 +627,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 							<Col><FormGroup>
 								<Label for='maxVal'>{translate('max.value')}</Label>
 								<Input id='maxVal' name='maxVal' type='number'
-									onChange={e => {handleNumberChange(e);}}
+									onChange={e => { handleNumberChange(e); }}
 									min={state.minVal}
 									max={MAX_VAL}
 									required value={state.maxVal}
@@ -640,7 +642,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 							<Col><FormGroup>
 								<Label for='disableChecks'>{translate('disable.checks')}</Label>
 								<Input id='disableChecks' name='disableChecks' type='select'
-									onChange={e => {handleStringChange(e);}}
+									onChange={e => { handleStringChange(e); }}
 									value={state.disableChecks}>
 									{Object.keys(DisableChecksType).map(key => {
 										return (<option value={key} key={key} >
@@ -657,7 +659,7 @@ export default function EditUnitModalComponent(props: EditUnitModalComponentProp
 								name='note'
 								type='textarea'
 								value={state.note}
-								onChange={e => {handleStringChange(e);}}
+								onChange={e => { handleStringChange(e); }}
 							/>
 						</FormGroup>
 					</Container></ModalBody>


### PR DESCRIPTION

# Description

Disable meter unit from the menu options if the unit is used in any conversion as a source or destination.

Fixes #1521

<img width="1010" height="1006" alt="disable meter" src="https://github.com/user-attachments/assets/583b5d92-77ab-4a4a-8250-36812ff8e3a5" />

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [ ] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

None
