### PR TITLE
fix bar graph's bar labels not switching language issue#1506

### DIFF
--- a/src/client/app/redux/selectors/barChartSelectors.ts
+++ b/src/client/app/redux/selectors/barChartSelectors.ts
@@ -12,13 +12,15 @@ import getGraphColor from '../../utils/getGraphColor';
 import { createAppSelector } from './selectors';
 import { selectAreaScalingFromEntity, selectNameFromEntity } from './entitySelectors';
 import { selectPlotlyMeterDeps, selectPlotlyGroupDeps } from './plotlyDataSelectors';
+import { selectSelectedLanguage } from '../../redux/slices/appStateSlice';
 
 type PlotlyBarDeps = ReturnType<typeof selectPlotlyMeterDeps> & { barDuration: moment.Duration }
 export const selectPlotlyBarDeps = createAppSelector(
 	[
 		selectPlotlyMeterDeps,
 		selectPlotlyGroupDeps,
-		selectWidthDays
+		selectWidthDays,
+		selectSelectedLanguage
 	],
 	(meterDeps, groupDeps, barDuration) => {
 		const barMeterDeps = { ...meterDeps, barDuration };


### PR DESCRIPTION
# Description
@skhaterina
@shunkhaing
@jdang90
This PR fixes an issue where bar chart labels and hover labels remained in the old language after the user changed the app language. The problem was reported in issue #1506: when the bar graph is rendered in one language and the language is then switched to another, the bar labels do not refresh until the data is manually re-fetched. The fix makes the bar graph selector depend on the selected language so that memorization is invalidated and chart formatting updates automatically. 

Fixes #1506


## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

This PR only affects bar chart recomputation. Other charts already react to language changes automatically.

# Summary of changes

Import selected language selector: Added selectSelectedLanguage import from appStateSlice.

Add selected language dependency: Updated the dependency array for selectPlotlyBarDeps to include the selected language. This ensures that reselect recomputes bar chart dependencies whenever the language changes.

Adjust selector projector signature: The projector function now accepts a fourth argument corresponding to the selected language (unused), ensuring alignment with the dependency array.

# Rationale

The bar chart uses a custom selector selectPlotlyBarDeps built with createAppSelector. Previously, the dependencies included only bar meter/group dependencies and the bar duration; the selected language was not part of the selector’s inputs. As a result, the selector’s result was memorized and reused across language changes. By importing selectSelectedLanguage and adding it to the dependency array, we ensure that reselect re-runs the selector whenever the language changes. 
