### PR TITLE
Update .gitattributes to Enforce the Correct End of Line Sequence

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+* text=auto eol=lf


### PR DESCRIPTION
# Description

When developing for OED on a Windows machine a common problem is either the IDE or Github itself converting the line endings from LF to CRLF, which then needs to be reverted. I've added a line "* text=auto eol=lf" to the .gitattributes file which will enforce LF line endings on all text files. 

Developed and implemented by:
Zachary Squires - https://github.com/Zachary-Squires

Fixes #1555 

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

N/A
