### PR TITLE
Fix unit route so not overwrite unspecified values - Team B

### DIFF
--- a/src/server/routes/units.js
+++ b/src/server/routes/units.js
@@ -100,8 +100,8 @@ router.post('/edit', adminAuthMiddleware('edit units'), async (req, res) => {
 				// Suffix changes so some conversions and units need to be removed.
 				await removeAdditionalConversionsAndUnits(unit, conn);
 			}
-			for (const key of Object.keys(unit)){
-				if (Object.prototype.hasOwnProperty.call(req.body, key) && !['id'].includes(key)){
+			for (const key of Object.keys(unit)) {
+				if (Object.hasOwn(req.body, key)) {
 					unit[key] = req.body[key]
 				}
 			}

--- a/src/server/routes/units.js
+++ b/src/server/routes/units.js
@@ -100,18 +100,11 @@ router.post('/edit', adminAuthMiddleware('edit units'), async (req, res) => {
 				// Suffix changes so some conversions and units need to be removed.
 				await removeAdditionalConversionsAndUnits(unit, conn);
 			}
-			unit.name = req.body.name;
-			unit.displayable = req.body.displayable;
-			unit.identifier = req.body.identifier;
-			unit.unitRepresent = req.body.unitRepresent;
-			unit.typeOfUnit = req.body.typeOfUnit;
-			unit.preferredDisplay = req.body.preferredDisplay;
-			unit.secInRate = req.body.secInRate;
-			unit.suffix = req.body.suffix;
-			unit.note = req.body.note;
-			unit.minVal = req.body.minVal;
-			unit.maxVal = req.body.maxVal;
-			unit.disableChecks = req.body.disableChecks;
+			for (const key of Object.keys(unit)){
+				if (Object.prototype.hasOwnProperty.call(req.body, key) && !['id'].includes(key)){
+					unit[key] = req.body[key]
+				}
+			}
 			// TODO Consider if this might be a better way.
 			// Object.assign(unit, req.body);
 			await unit.update(conn);

--- a/src/server/test/routes/unitsRouteTests.js
+++ b/src/server/test/routes/unitsRouteTests.js
@@ -22,14 +22,16 @@ mocha.describe('Units Route', () => {
 			const unit = new Unit(undefined, 'Unit', 'Unit Id', Unit.unitRepresentType.QUANTITY,
 				1000, Unit.unitType.UNIT, 'Suffix', Unit.displayableType.ALL, true, 'Note');
 			await unit.insert(conn);
+			const beforeSuffix = unit.suffix;
 			const res = await chai.request(app).post('/api/units/edit').set('token', token).send({
-				...unit,
 				id: unit.id,
 				name: 'New name',
+				identifier: unit.identifier,
 			});
 			expect(res).to.have.status(200);
 			const updatedUnit = await Unit.getById(unit.id, conn);
 			expect(updatedUnit.name).to.equal('New name');
+			expect(updatedUnit.suffix).to.equal(beforeSuffix);
 		});
 	
 	});

--- a/src/server/test/routes/unitsRouteTests.js
+++ b/src/server/test/routes/unitsRouteTests.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { mocha, expect, testDB, app, testUser } = require('../common');
+const chai = require('chai');
+const Unit = require('../../models/Unit');
+
+mocha.describe('Units Route', () => {
+	let token;
+
+	mocha.before(async () => {
+		const res = await chai.request(app).post('/api/login')
+			.send({ username: testUser.username, password: testUser.password });
+		token = res.body.token;
+	});
+
+	mocha.describe('Edit endpoint', () => {
+
+		mocha.it('returns 200 and updates the database for valid request', async () => {
+			const conn = testDB.getConnection();
+			const unit = new Unit(undefined, 'Unit', 'Unit Id', Unit.unitRepresentType.QUANTITY,
+				1000, Unit.unitType.UNIT, 'Suffix', Unit.displayableType.ALL, true, 'Note');
+			await unit.insert(conn);
+			const res = await chai.request(app).post('/api/units/edit').set('token', token).send({
+				...unit,
+				id: unit.id,
+				name: 'New name',
+			});
+			expect(res).to.have.status(200);
+			const updatedUnit = await Unit.getById(unit.id, conn);
+			expect(updatedUnit.name).to.equal('New name');
+		});
+	
+	});
+
+});

--- a/src/server/test/routes/unitsRouteTests.js
+++ b/src/server/test/routes/unitsRouteTests.js
@@ -22,7 +22,7 @@ mocha.describe('Units Route', () => {
 			const unit = new Unit(undefined, 'Unit', 'Unit Id', Unit.unitRepresentType.QUANTITY,
 				1000, Unit.unitType.UNIT, 'Suffix', Unit.displayableType.ALL, true, 'Note');
 			await unit.insert(conn);
-			const beforeSuffix = unit.suffix;
+			const beforeNote = unit.note;
 			const res = await chai.request(app).post('/api/units/edit').set('token', token).send({
 				id: unit.id,
 				name: 'New name',
@@ -31,9 +31,9 @@ mocha.describe('Units Route', () => {
 			expect(res).to.have.status(200);
 			const updatedUnit = await Unit.getById(unit.id, conn);
 			expect(updatedUnit.name).to.equal('New name');
-			expect(updatedUnit.suffix).to.equal(beforeSuffix);
+			expect(updatedUnit.note).to.equal(beforeNote);
 		});
-	
+
 	});
 
 });


### PR DESCRIPTION
# Description

(This PR updates the /edit route in units.js so that unit fields are only updated when those parameters are specifically provided. Previously, the route set all unit values even when some were not passed in the request body, which could result in unintended changes.

Contributors

Thien An Truong, @AndrewTr0612 email: [andrewtruong0612@gmail.com](mailto:andrewtruong0612@gmail.com)
Anthony Duenez Ramirez, @anthonyduenez email: [duenezanthony67@gmail.com](mailto:duenezanthony67@gmail.com)
Nathan Espina, @Nespina24, email: [nespina1@toromail.csudh.edu](mailto:nespina1@toromail.csudh.edu)
Princeton Nguyen, @princetonn, email: [princeton.nguyen13@gmail.com](mailto:princeton.nguyen13@gmail.com)
Fixes #1534 

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

This change addresses only the behavior of the /edit route in units.js. No additional validation are included.
