### PR TITLE
Refactor test parameter validation into shared helpers

### DIFF
--- a/src/server/test/routes/compareReadingsParamsTest.js
+++ b/src/server/test/routes/compareReadingsParamsTest.js
@@ -79,8 +79,7 @@ mocha.describe('Compare Readings Parameter Validation', () => {
 				await validateRequiredQueryParams({
 					endpoint: `${BASE_METER_ENDPOINT}/1`,
 					baseQuery: validQuery,
-					requiredParams: ['curr_start', 'curr_end', 'shift', 'graphicUnitId'],
-					expectedStatus: HTTP_CODE.BAD_REQUEST
+					requiredParams: ['curr_start', 'curr_end', 'shift', 'graphicUnitId']
 				});
 			});
 
@@ -228,8 +227,7 @@ mocha.describe('Compare Readings Parameter Validation', () => {
 				await validateRequiredQueryParams({
 					endpoint: `${BASE_GROUP_ENDPOINT}/1`,
 					baseQuery: validQuery,
-					requiredParams: ['curr_start', 'curr_end', 'shift', 'graphicUnitId'],
-					expectedStatus: HTTP_CODE.BAD_REQUEST
+					requiredParams: ['curr_start', 'curr_end', 'shift', 'graphicUnitId']
 				});
 			});
 

--- a/src/server/test/routes/compareReadingsParamsTest.js
+++ b/src/server/test/routes/compareReadingsParamsTest.js
@@ -8,7 +8,8 @@ const { expect } = require('chai');
 const { chai, mocha, app } = require('../common');
 const {
 	validateCommaSeparatedIdPatterns,
-	expectValidCommaSeparatedIds
+	expectValidCommaSeparatedIds,
+	validateRequiredQueryParams
 } = require('../util/validationHelpers');
 const { HTTP_CODE } = require('../../util/readingsUtils');
 const {	STRING_GENERAL_MAX_LENGTH } = require('../../util/validationConstants');
@@ -75,18 +76,12 @@ mocha.describe('Compare Readings Parameter Validation', () => {
 
 		mocha.describe('Query Parameter Validation', () => {
 			mocha.it('should require all query parameters', async () => {
-				const requiredParams = ['curr_start', 'curr_end', 'shift', 'graphicUnitId'];
-
-				for (const param of requiredParams) {
-					const incompleteQuery = { ...validQuery };
-					delete incompleteQuery[param];
-
-					const res = await chai.request(app)
-						.get(`${BASE_METER_ENDPOINT}/1`)
-						.query(incompleteQuery);
-
-					expect(res.status).to.equal(HTTP_CODE.BAD_REQUEST);
-				}
+				await validateRequiredQueryParams({
+					endpoint: `${BASE_METER_ENDPOINT}/1`,
+					baseQuery: validQuery,
+					requiredParams: ['curr_start', 'curr_end', 'shift', 'graphicUnitId'],
+					expectedStatus: HTTP_CODE.BAD_REQUEST
+				});
 			});
 
 			mocha.it('should reject extra query parameters (parameter injection prevention)', async () => {
@@ -230,18 +225,12 @@ mocha.describe('Compare Readings Parameter Validation', () => {
 
 		mocha.describe('Query Parameter Validation', () => {
 			mocha.it('should require all query parameters', async () => {
-				const requiredParams = ['curr_start', 'curr_end', 'shift', 'graphicUnitId'];
-
-				for (const param of requiredParams) {
-					const incompleteQuery = { ...validQuery };
-					delete incompleteQuery[param];
-
-					const res = await chai.request(app)
-						.get(`${BASE_GROUP_ENDPOINT}/1`)
-						.query(incompleteQuery);
-
-					expect(res.status).to.equal(HTTP_CODE.BAD_REQUEST);
-				}
+				await validateRequiredQueryParams({
+					endpoint: `${BASE_GROUP_ENDPOINT}/1`,
+					baseQuery: validQuery,
+					requiredParams: ['curr_start', 'curr_end', 'shift', 'graphicUnitId'],
+					expectedStatus: HTTP_CODE.BAD_REQUEST
+				});
 			});
 
 			mocha.it('should reject extra query parameters (parameter injection prevention)', async () => {

--- a/src/server/test/routes/conversionsParamsTest.js
+++ b/src/server/test/routes/conversionsParamsTest.js
@@ -6,7 +6,7 @@
 
 const { expect } = require('chai');
 const { chai, mocha, app } = require('../common');
-const { testInvalidField } = require('../util/validationHelpers');
+const { testInvalidField, validateInt, validateBool, validateNoExtraFields } = require('../util/validationHelpers');
 const { STRING_GENERAL_MAX_LENGTH } = require('../../util/validationConstants');
 const { HTTP_CODE } = require('../../util/readingsUtils');
 
@@ -60,33 +60,23 @@ mocha.describe('Conversions Parameter Validation', () => {
 		});
 
 		mocha.it('should validate integer field constraints', async () => {
-			// Test negative sourceId (minimum: 1)
-			await testInvalidField({
+			await validateInt({
 				field: 'sourceId',
-				invalidValue: 0,
 				endpoint: EDIT_ENDPOINT,
 				basePayload: baseConversionData,
+				min: 1,
 				expectedStatus: HTTP_CODE.FORBIDDEN
 			});
 
-			await testInvalidField({
-				field: 'sourceId',
-				invalidValue: -1,
-				endpoint: EDIT_ENDPOINT,
-				basePayload: baseConversionData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
-			// Test negative destinationId (minimum: 1)
-			await testInvalidField({
+			await validateInt({
 				field: 'destinationId',
-				invalidValue: 0,
 				endpoint: EDIT_ENDPOINT,
 				basePayload: baseConversionData,
+				min: 1,
 				expectedStatus: HTTP_CODE.FORBIDDEN
 			});
 
-			// Test oversized integers (exceeds MAX_SAFE_INTEGER)
+			// Test oversized integers (exceeds MAX_SAFE_INTEGER) - not covered by validateInt
 			await testInvalidField({
 				field: 'sourceId',
 				invalidValue: Number.MAX_SAFE_INTEGER + 1,
@@ -95,18 +85,9 @@ mocha.describe('Conversions Parameter Validation', () => {
 				expectedStatus: HTTP_CODE.FORBIDDEN
 			});
 
-			// Test non-integer values
-			await testInvalidField({
-				field: 'sourceId',
-				invalidValue: 'not_a_number',
-				endpoint: EDIT_ENDPOINT,
-				basePayload: baseConversionData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
+			// Test float instead of integer
 			await testInvalidField({
 				field: 'destinationId',
-				// Float instead of integer
 				invalidValue: 1.5,
 				endpoint: EDIT_ENDPOINT,
 				basePayload: baseConversionData,
@@ -146,26 +127,20 @@ mocha.describe('Conversions Parameter Validation', () => {
 		});
 
 		mocha.it('should validate boolean field types', async () => {
-			const invalidBooleanValues = ['yes', 'no', '1', '0', 'on', 'off', 'true', 'false', 1, 0];
+			await validateBool({
+				field: 'bidirectional',
+				endpoint: EDIT_ENDPOINT,
+				basePayload: baseConversionData,
+				expectedStatus: HTTP_CODE.FORBIDDEN
+			});
 
-			for (const invalidValue of invalidBooleanValues) {
-				await testInvalidField({
-					field: 'bidirectional',
-					invalidValue: invalidValue,
-					endpoint: EDIT_ENDPOINT,
-					basePayload: baseConversionData,
-					expectedStatus: HTTP_CODE.FORBIDDEN
-				});
-			}
-
-			// Test valid boolean values
+			// Test valid boolean values pass validation (fail auth)
 			const validBooleanValues = [true, false];
 			for (const validValue of validBooleanValues) {
 				const res = await chai.request(app)
 					.post(EDIT_ENDPOINT)
 					.send({ ...baseConversionData, bidirectional: validValue });
 
-				// Should pass validation but fail auth
 				expect(res.status).to.equal(HTTP_CODE.FORBIDDEN);
 			}
 		});
@@ -198,22 +173,18 @@ mocha.describe('Conversions Parameter Validation', () => {
 		});
 
 		mocha.it('should reject parameter injection', async () => {
-			const payloadWithExtra = {
-				...baseConversionData,
-				maliciousField: 'injection attempt',
-				isAdmin: true,
-				deleteAll: true,
-				executeCommand: 'rm -rf /',
-				extraProperty: 'should be rejected',
-				anotherField: 'more injection'
-			};
-
-			const res = await chai.request(app)
-				.post(EDIT_ENDPOINT)
-				.send(payloadWithExtra);
-
-			// Should fail due to maxProperties: 6 (validation catches before auth)
-			expect(res.status).to.equal(HTTP_CODE.FORBIDDEN);
+			await validateNoExtraFields({
+				endpoint: EDIT_ENDPOINT,
+				basePayload: baseConversionData,
+				extraFields: {
+					maliciousField: 'injection attempt',
+					isAdmin: true,
+					deleteAll: true,
+					executeCommand: 'rm -rf /',
+					extraProperty: 'should be rejected'
+				},
+				expectedStatus: HTTP_CODE.FORBIDDEN
+			});
 		});
 
 		mocha.it('should handle malicious string inputs in note field', async () => {
@@ -387,39 +358,19 @@ mocha.describe('Conversions Parameter Validation', () => {
 		});
 
 		mocha.it('should validate ID constraints for deletion', async () => {
-			// Test negative sourceId
-			await testInvalidField({
+			await validateInt({
 				field: 'sourceId',
-				invalidValue: -1,
 				endpoint: DELETE_ENDPOINT,
 				basePayload: baseDeleteData,
+				min: 1,
 				expectedStatus: HTTP_CODE.FORBIDDEN
 			});
 
-			// Test zero destinationId
-			await testInvalidField({
+			await validateInt({
 				field: 'destinationId',
-				invalidValue: 0,
 				endpoint: DELETE_ENDPOINT,
 				basePayload: baseDeleteData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
-			// Test non-integer ID
-			await testInvalidField({
-				field: 'sourceId',
-				invalidValue: 'not_a_number',
-				endpoint: DELETE_ENDPOINT,
-				basePayload: baseDeleteData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
-			// Test float ID
-			await testInvalidField({
-				field: 'destinationId',
-				invalidValue: 2.5,
-				endpoint: DELETE_ENDPOINT,
-				basePayload: baseDeleteData,
+				min: 1,
 				expectedStatus: HTTP_CODE.FORBIDDEN
 			});
 		});

--- a/src/server/test/routes/conversionsParamsTest.js
+++ b/src/server/test/routes/conversionsParamsTest.js
@@ -75,24 +75,6 @@ mocha.describe('Conversions Parameter Validation', () => {
 				min: 1,
 				expectedStatus: HTTP_CODE.FORBIDDEN
 			});
-
-			// Test oversized integers (exceeds MAX_SAFE_INTEGER) - not covered by validateInt
-			await testInvalidField({
-				field: 'sourceId',
-				invalidValue: Number.MAX_SAFE_INTEGER + 1,
-				endpoint: EDIT_ENDPOINT,
-				basePayload: baseConversionData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
-			// Test float instead of integer
-			await testInvalidField({
-				field: 'destinationId',
-				invalidValue: 1.5,
-				endpoint: EDIT_ENDPOINT,
-				basePayload: baseConversionData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
 		});
 
 		mocha.it('should validate number field types', async () => {
@@ -131,18 +113,9 @@ mocha.describe('Conversions Parameter Validation', () => {
 				field: 'bidirectional',
 				endpoint: EDIT_ENDPOINT,
 				basePayload: baseConversionData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
+				expectedStatus: HTTP_CODE.FORBIDDEN,
+				verifyValidBooleanValues: true
 			});
-
-			// Test valid boolean values pass validation (fail auth)
-			const validBooleanValues = [true, false];
-			for (const validValue of validBooleanValues) {
-				const res = await chai.request(app)
-					.post(EDIT_ENDPOINT)
-					.send({ ...baseConversionData, bidirectional: validValue });
-
-				expect(res.status).to.equal(HTTP_CODE.FORBIDDEN);
-			}
 		});
 
 		mocha.it('should validate note field (oneOf string/null)', async () => {
@@ -406,15 +379,6 @@ mocha.describe('Conversions Parameter Validation', () => {
 			expect(res.status).to.equal(HTTP_CODE.FORBIDDEN);
 		});
 
-		mocha.it('should handle oversized integer values', async () => {
-			await testInvalidField({
-				field: 'sourceId',
-				invalidValue: Number.MAX_SAFE_INTEGER + 1,
-				endpoint: DELETE_ENDPOINT,
-				basePayload: baseDeleteData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-		});
 	});
 
 	mocha.describe('Cross-Endpoint Security Tests', () => {

--- a/src/server/test/routes/groupsParamsTest.js
+++ b/src/server/test/routes/groupsParamsTest.js
@@ -9,7 +9,9 @@ const { chai, mocha, app } = require('../common');
 const { HTTP_CODE } = require('../../util/readingsUtils');
 const {
 	testInvalidField,
-	validateNoExtraFields
+	validateNoExtraFields,
+	validateNumericIdInPath,
+	expectValidNumericIdInPath
 } = require('../util/validationHelpers');
 const {
 	STRING_GENERAL_MAX_LENGTH,
@@ -19,97 +21,79 @@ const {
 mocha.describe('Groups Parameter Validation', () => {
 
 	mocha.describe('GET /api/groups/deep/groups/:group_id - Deep Groups Validation', () => {
-		const DEEP_GROUPS_ENDPOINT = '/api/groups/deep/groups/123';
+		const BASE_ENDPOINT = '/api/groups/deep/groups';
 
 		mocha.it('should validate group_id parameter', async () => {
-			// Test invalid group ID patterns (non-numeric)
-			const invalidIds = ['abc', '12abc', 'group123', 'null', ''];
-
-			for (const invalidId of invalidIds) {
-				const res = await chai.request(app)
-					.get(`/api/groups/deep/groups/${invalidId}`);
-
-				// TODO: Some invalid IDs like 'abc' return 200 instead of expected 400
-				// This suggests path parameter validation may not be working as intended
-				// or Express is interpreting these as valid somehow. Needs investigation.
-				expect([HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]).to.include(res.status);
-			}
+			// TODO: Some invalid IDs may return 200 - path param validation may need investigation
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: ['abc', '12abc', 'group123', 'null', ''],
+				expectedStatus: [HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]
+			});
 		});
 
 		mocha.it('should handle extremely long group IDs', async () => {
-			const longId = '1'.repeat(25);
-			const res = await chai.request(app)
-				.get(`/api/groups/deep/groups/${longId}`);
-
-			expect(res.status).to.equal(HTTP_CODE.BAD_REQUEST);
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: ['1'.repeat(25)],
+				expectedStatus: HTTP_CODE.BAD_REQUEST
+			});
 		});
 
 		mocha.it('should handle SQL injection in group ID', async () => {
-			const sqlInjection = encodeURIComponent("1' OR '1'='1");
-			const res = await chai.request(app)
-				.get(`/api/groups/deep/groups/${sqlInjection}`);
-
-			expect(res.status).to.equal(HTTP_CODE.BAD_REQUEST);
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: [encodeURIComponent("1' OR '1'='1")],
+				expectedStatus: HTTP_CODE.BAD_REQUEST
+			});
 		});
 
 		mocha.it('should accept valid numeric group IDs', async () => {
-			const validIds = ['1', '123', '999999'];
-
-			for (const validId of validIds) {
-				const res = await chai.request(app)
-					.get(`/api/groups/deep/groups/${validId}`);
-
-				// Valid numeric IDs should pass validation - may return 200 (success), 
-				// 404 (not found) or 500 (DB error) depending on data existence
-				expect([HTTP_CODE.OK, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
-			}
+			await expectValidNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				validValues: ['1', '123', '999999']
+			});
 		});
 	});
 
 	mocha.describe('GET /api/groups/deep/meters/:group_id - Deep Meters Validation', () => {
+		const BASE_ENDPOINT = '/api/groups/deep/meters';
+
 		mocha.it('should validate group_id parameter', async () => {
-			const invalidIds = ['abc', '12abc', 'group123', 'null', ''];
-
-			for (const invalidId of invalidIds) {
-				const res = await chai.request(app)
-					.get(`/api/groups/deep/meters/${invalidId}`);
-
-				// Should return 400 for validation error or HTTP_CODE.OK if somehow valid
-				expect([HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]).to.include(res.status);
-			}
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: ['abc', '12abc', 'group123', 'null', ''],
+				expectedStatus: [HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]
+			});
 		});
 
 		mocha.it('should handle path traversal attempts', async () => {
-			const pathTraversalAttempts = ['../123', '../../admin', '../../../etc/passwd'];
-
-			for (const maliciousPath of pathTraversalAttempts) {
-				const res = await chai.request(app)
-					.get(`/api/groups/deep/meters/${encodeURIComponent(maliciousPath)}`);
-
-				expect(res.status).to.equal(HTTP_CODE.BAD_REQUEST);
-			}
+			const pathTraversalAttempts = ['../123', '../../admin', '../../../etc/passwd'].map(p => encodeURIComponent(p));
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: pathTraversalAttempts,
+				expectedStatus: HTTP_CODE.BAD_REQUEST
+			});
 		});
 	});
 
 	mocha.describe('GET /api/groups/parents/:group_id - Parents Validation', () => {
+		const BASE_ENDPOINT = '/api/groups/parents';
+
 		mocha.it('should validate group_id parameter', async () => {
-			const invalidIds = ['abc', '12abc', 'group123', 'null', ''];
-
-			for (const invalidId of invalidIds) {
-				const res = await chai.request(app)
-					.get(`/api/groups/parents/${invalidId}`);
-
-				// Should return 400 for validation error or 200 if somehow valid
-				expect([HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]).to.include(res.status);
-			}
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: ['abc', '12abc', 'group123', 'null', ''],
+				expectedStatus: [HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]
+			});
 		});
 
 		mocha.it('should handle oversized group IDs', async () => {
-			const oversizedId = '9'.repeat(50);
-			const res = await chai.request(app)
-				.get(`/api/groups/parents/${oversizedId}`);
-
-			expect(res.status).to.equal(HTTP_CODE.BAD_REQUEST);
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: ['9'.repeat(50)],
+				expectedStatus: HTTP_CODE.BAD_REQUEST
+			});
 		});
 	});
 

--- a/src/server/test/routes/groupsParamsTest.js
+++ b/src/server/test/routes/groupsParamsTest.js
@@ -18,18 +18,26 @@ const {
 	STRING_SHORT_MAX_LENGTH
 } = require('../../util/validationConstants');
 
+/** Non-numeric path values reused across group_id route tests. */
+const INVALID_GROUP_ID_PATH_VALUES = ['abc', '12abc', 'group123', 'null', ''];
+/** Some group routes still return HTTP_CODE.OK for malformed group_id until path validation is strict; test encodes current behavior. */
+const GROUP_ID_MALFORMED_EXPECTED_STATUSES = [HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST];
+
+async function expectMalformedGroupIdRejectedOrOk(baseEndpoint) {
+	await validateNumericIdInPath({
+		baseEndpoint,
+		invalidValues: INVALID_GROUP_ID_PATH_VALUES,
+		expectedStatus: GROUP_ID_MALFORMED_EXPECTED_STATUSES
+	});
+}
+
 mocha.describe('Groups Parameter Validation', () => {
 
 	mocha.describe('GET /api/groups/deep/groups/:group_id - Deep Groups Validation', () => {
 		const BASE_ENDPOINT = '/api/groups/deep/groups';
 
 		mocha.it('should validate group_id parameter', async () => {
-			// TODO: Some invalid IDs may return 200 - path param validation may need investigation
-			await validateNumericIdInPath({
-				baseEndpoint: BASE_ENDPOINT,
-				invalidValues: ['abc', '12abc', 'group123', 'null', ''],
-				expectedStatus: [HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]
-			});
+			await expectMalformedGroupIdRejectedOrOk(BASE_ENDPOINT);
 		});
 
 		mocha.it('should handle extremely long group IDs', async () => {
@@ -60,11 +68,7 @@ mocha.describe('Groups Parameter Validation', () => {
 		const BASE_ENDPOINT = '/api/groups/deep/meters';
 
 		mocha.it('should validate group_id parameter', async () => {
-			await validateNumericIdInPath({
-				baseEndpoint: BASE_ENDPOINT,
-				invalidValues: ['abc', '12abc', 'group123', 'null', ''],
-				expectedStatus: [HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]
-			});
+			await expectMalformedGroupIdRejectedOrOk(BASE_ENDPOINT);
 		});
 
 		mocha.it('should handle path traversal attempts', async () => {
@@ -81,11 +85,7 @@ mocha.describe('Groups Parameter Validation', () => {
 		const BASE_ENDPOINT = '/api/groups/parents';
 
 		mocha.it('should validate group_id parameter', async () => {
-			await validateNumericIdInPath({
-				baseEndpoint: BASE_ENDPOINT,
-				invalidValues: ['abc', '12abc', 'group123', 'null', ''],
-				expectedStatus: [HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST]
-			});
+			await expectMalformedGroupIdRejectedOrOk(BASE_ENDPOINT);
 		});
 
 		mocha.it('should handle oversized group IDs', async () => {

--- a/src/server/test/routes/mapsParamsTest.js
+++ b/src/server/test/routes/mapsParamsTest.js
@@ -6,7 +6,12 @@
 
 const { expect } = require('chai');
 const { chai, mocha, app } = require('../common');
-const { testInvalidField } = require('../util/validationHelpers');
+const {
+	testInvalidField,
+	validateNumericIdInPath,
+	expectValidNumericIdInPath,
+	validateNoExtraFields
+} = require('../util/validationHelpers');
 const { HTTP_CODE } = require('../../util/readingsUtils');
 const {
 	NUMERIC_ID_MAX_LENGTH,
@@ -30,38 +35,27 @@ mocha.describe('Maps Parameter Validation', () => {
 		const BASE_ENDPOINT = '/api/maps';
 
 		mocha.it('should accept valid map ID', async () => {
-			const res = await chai.request(app)
-				.get(`${BASE_ENDPOINT}/1`);
-
-			// Should return 200 or 500 (DB error) - no auth required for reading
-			expect([HTTP_CODE.OK, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
+			await expectValidNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				validValues: ['1'],
+				expectedStatuses: [HTTP_CODE.OK, HTTP_CODE.INTERNAL_SERVER_ERROR]
+			});
 		});
 
 		mocha.it('should reject invalid map ID patterns', async () => {
-			const invalidPatterns = [
-				'abc',           // Non-numeric
-				'1.5',           // Decimal
-				'-1',            // Negative
-				'1a',            // Mixed alphanumeric
-				'0',             // Zero
-			];
-
-			for (const invalidPattern of invalidPatterns) {
-				const res = await chai.request(app)
-					.get(`${BASE_ENDPOINT}/${invalidPattern}`);
-
-				//TODO
-				expect([HTTP_CODE.BAD_REQUEST, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
-			}
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: ['abc', '1.5', '-1', '1a', '0'],
+				expectedStatus: [HTTP_CODE.BAD_REQUEST, HTTP_CODE.INTERNAL_SERVER_ERROR]
+			});
 		});
 
 		mocha.it('should reject extremely long map ID strings (DoS prevention)', async () => {
-			const longMapId = 'x'.repeat(NUMERIC_ID_MAX_LENGTH + 1);
-
-			const res = await chai.request(app)
-				.get(`${BASE_ENDPOINT}/${longMapId}`);
-
-			expect(res.status).to.equal(HTTP_CODE.BAD_REQUEST);
+			await validateNumericIdInPath({
+				baseEndpoint: BASE_ENDPOINT,
+				invalidValues: ['x'.repeat(NUMERIC_ID_MAX_LENGTH + 1)],
+				expectedStatus: HTTP_CODE.BAD_REQUEST
+			});
 		});
 	});
 
@@ -100,17 +94,12 @@ mocha.describe('Maps Parameter Validation', () => {
 		});
 
 		mocha.it('should reject extra fields (parameter injection prevention)', async () => {
-			const payloadWithExtra = {
-				...baseMapData,
-				maliciousField: 'injection_attempt'
-			};
-
-			const res = await chai.request(app)
-				.post(CREATE_ENDPOINT)
-				.send(payloadWithExtra);
-
-			// Will fail auth before validation
-			expect(res.status).to.equal(HTTP_CODE.FORBIDDEN);
+			await validateNoExtraFields({
+				endpoint: CREATE_ENDPOINT,
+				basePayload: baseMapData,
+				extraFields: { maliciousField: 'injection_attempt' },
+				expectedStatus: HTTP_CODE.FORBIDDEN
+			});
 		});
 
 		mocha.it('should validate string field lengths (DoS prevention)', async () => {
@@ -261,16 +250,12 @@ mocha.describe('Maps Parameter Validation', () => {
 		});
 
 		mocha.it('should reject extra fields (parameter injection prevention)', async () => {
-			const payloadWithExtra = {
-				...baseEditData,
-				maliciousField: 'injection_attempt'
-			};
-
-			const res = await chai.request(app)
-				.post(EDIT_ENDPOINT)
-				.send(payloadWithExtra);
-
-			expect(res.status).to.equal(HTTP_CODE.FORBIDDEN);
+			await validateNoExtraFields({
+				endpoint: EDIT_ENDPOINT,
+				basePayload: baseEditData,
+				extraFields: { maliciousField: 'injection_attempt' },
+				expectedStatus: HTTP_CODE.FORBIDDEN
+			});
 		});
 
 		mocha.it('should validate ID bounds', async () => {
@@ -329,16 +314,12 @@ mocha.describe('Maps Parameter Validation', () => {
 		});
 
 		mocha.it('should reject extra fields (parameter injection prevention)', async () => {
-			const payloadWithExtra = {
-				...baseDeleteData,
-				maliciousField: 'injection_attempt'
-			};
-
-			const res = await chai.request(app)
-				.post(DELETE_ENDPOINT)
-				.send(payloadWithExtra);
-
-			expect(res.status).to.equal(HTTP_CODE.FORBIDDEN);
+			await validateNoExtraFields({
+				endpoint: DELETE_ENDPOINT,
+				basePayload: baseDeleteData,
+				extraFields: { maliciousField: 'injection_attempt' },
+				expectedStatus: HTTP_CODE.FORBIDDEN
+			});
 		});
 
 		mocha.it('should validate ID bounds', async () => {

--- a/src/server/test/routes/readingsParamsTest.js
+++ b/src/server/test/routes/readingsParamsTest.js
@@ -15,12 +15,16 @@ const {
 	validateNumericIdInPath
 } = require('../util/validationHelpers');
 
+/** Shared valid timeInterval for line reading routes (used in multiple tests in this file). */
+const READINGS_LINE_TIME_INTERVAL = '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z';
+const INT32_MAX = 2147483647;
+
 mocha.describe('Readings Route Parameter Validation', () => {
 
 	const LINE_COUNT_BASE_ENDPOINT = '/api/readings/line/count/meters';
 	const RAW_READINGS_BASE_ENDPOINT = '/api/readings/line/raw/meter';
 
-	const lineCountValidQuery = { timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' };
+	const lineCountValidQuery = { timeInterval: READINGS_LINE_TIME_INTERVAL };
 
 	mocha.describe(`GET ${LINE_COUNT_BASE_ENDPOINT}/:meter_ids`, () => {
 
@@ -49,8 +53,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 				await validateRequiredQueryParams({
 					endpoint: `${LINE_COUNT_BASE_ENDPOINT}/1`,
 					baseQuery: lineCountValidQuery,
-					requiredParams: ['timeInterval'],
-					expectedStatus: HTTP_CODE.BAD_REQUEST
+					requiredParams: ['timeInterval']
 				});
 			});
 
@@ -66,7 +69,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 			mocha.it('should accept valid timeInterval format', async () => {
 				const res = await chai.request(app)
 					.get(`${LINE_COUNT_BASE_ENDPOINT}/1`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
+					.query({ timeInterval: READINGS_LINE_TIME_INTERVAL });
 
 				// May return 200, 404, or 500 if meters/data don't exist
 				expect([HTTP_CODE.OK, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
@@ -76,7 +79,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 				const res = await chai.request(app)
 					.get(`${LINE_COUNT_BASE_ENDPOINT}/1`)
 					.query({
-						timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z',
+						timeInterval: READINGS_LINE_TIME_INTERVAL,
 						maliciousParam: 'injection_attempt'
 					});
 
@@ -89,7 +92,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 				const sqlInjection = "1'; DROP TABLE readings; --";
 				const res = await chai.request(app)
 					.get(`${LINE_COUNT_BASE_ENDPOINT}/${encodeURIComponent(sqlInjection)}`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
+					.query({ timeInterval: READINGS_LINE_TIME_INTERVAL });
 
 				// Should not crash server, may return 200, 400 or 500
 				expect([HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
@@ -107,7 +110,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 		});
 	});
 
-	const rawReadingsValidQuery = { timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' };
+	const rawReadingsValidQuery = { timeInterval: READINGS_LINE_TIME_INTERVAL };
 
 	mocha.describe(`GET ${RAW_READINGS_BASE_ENDPOINT}/:meter_id`, () => {
 
@@ -124,7 +127,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 			mocha.it('should reject invalid meter_id patterns', async () => {
 				await validateNumericIdInPath({
 					baseEndpoint: RAW_READINGS_BASE_ENDPOINT,
-					invalidValues: ['not_a_number', '0', '-1', '1.5', '2147483648', encodeURIComponent("1'; DROP TABLE readings; --"), '99999999999999999999999999999999'],
+					invalidValues: ['not_a_number', '0', '-1', '1.5', String(INT32_MAX + 1), encodeURIComponent("1'; DROP TABLE readings; --"), '9'.repeat(32)],
 					query: rawReadingsValidQuery,
 					expectedStatus: HTTP_CODE.BAD_REQUEST
 				});
@@ -136,8 +139,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 				await validateRequiredQueryParams({
 					endpoint: `${RAW_READINGS_BASE_ENDPOINT}/1`,
 					baseQuery: rawReadingsValidQuery,
-					requiredParams: ['timeInterval'],
-					expectedStatus: HTTP_CODE.BAD_REQUEST
+					requiredParams: ['timeInterval']
 				});
 			});
 
@@ -153,7 +155,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 			mocha.it('should accept valid timeInterval format', async () => {
 				const res = await chai.request(app)
 					.get(`${RAW_READINGS_BASE_ENDPOINT}/1`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
+					.query({ timeInterval: READINGS_LINE_TIME_INTERVAL });
 
 				// May return 400, 404, or 500 if meters/data don't exist
 				expect([HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
@@ -163,7 +165,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 				const res = await chai.request(app)
 					.get(`${RAW_READINGS_BASE_ENDPOINT}/1`)
 					.query({
-						timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z',
+						timeInterval: READINGS_LINE_TIME_INTERVAL,
 						maliciousParam: 'injection_attempt'
 					});
 
@@ -173,7 +175,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 
 		mocha.describe('Malicious Input Tests', () => {
 			mocha.it('should handle special characters in timeInterval', async () => {
-				const specialChars = '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z&cmd=ls';
+				const specialChars = `${READINGS_LINE_TIME_INTERVAL}&cmd=ls`;
 				const res = await chai.request(app)
 					.get(`${RAW_READINGS_BASE_ENDPOINT}/1`)
 					.query({ timeInterval: specialChars });
@@ -188,7 +190,7 @@ mocha.describe('Readings Route Parameter Validation', () => {
 		mocha.it('should handle empty meter_ids string', async () => {
 			const res = await chai.request(app)
 				.get(`${LINE_COUNT_BASE_ENDPOINT}/`)
-				.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
+				.query({ timeInterval: READINGS_LINE_TIME_INTERVAL });
 
 			// Empty meter_ids may return 200 (empty result) or 404 depending on routing
 			expect([HTTP_CODE.OK, HTTP_CODE.NOT_FOUND]).to.include(res.status);

--- a/src/server/test/routes/readingsParamsTest.js
+++ b/src/server/test/routes/readingsParamsTest.js
@@ -7,49 +7,51 @@
 const { chai, mocha, expect, app } = require('../common');
 const { HTTP_CODE } = require('../../util/readingsUtils');
 const { STRING_GENERAL_MAX_LENGTH } = require('../../util/validationConstants');
+const {
+	expectValidCommaSeparatedIds,
+	expectValidNumericIdInPath,
+	validateCommaSeparatedIdPatterns,
+	validateRequiredQueryParams,
+	validateNumericIdInPath
+} = require('../util/validationHelpers');
 
 mocha.describe('Readings Route Parameter Validation', () => {
 
 	const LINE_COUNT_BASE_ENDPOINT = '/api/readings/line/count/meters';
 	const RAW_READINGS_BASE_ENDPOINT = '/api/readings/line/raw/meter';
 
+	const lineCountValidQuery = { timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' };
+
 	mocha.describe(`GET ${LINE_COUNT_BASE_ENDPOINT}/:meter_ids`, () => {
 
 		mocha.describe('URL Parameter Validation (meter_ids)', () => {
 			mocha.it('should accept valid comma-separated meter IDs', async () => {
-				const res = await chai.request(app)
-					.get(`${LINE_COUNT_BASE_ENDPOINT}/1,2,3`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				// May return 200, 404, or 500 if meters/data don't exist
-				expect([HTTP_CODE.OK, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
+				await expectValidCommaSeparatedIds({
+					baseEndpoint: LINE_COUNT_BASE_ENDPOINT,
+					validValues: ['1,2,3', '1'],
+					query: lineCountValidQuery,
+					expectedStatuses: [HTTP_CODE.OK, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]
+				});
 			});
 
 			mocha.it('should reject extremely long meter_ids string (DoS prevention)', async () => {
-				const hugeMeterIds = '1,'.repeat(STRING_GENERAL_MAX_LENGTH + 1);
-				const res = await chai.request(app)
-					.get(`${LINE_COUNT_BASE_ENDPOINT}/${hugeMeterIds}`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
-			});
-
-			mocha.it('should accept single meter ID', async () => {
-				const res = await chai.request(app)
-					.get(`${LINE_COUNT_BASE_ENDPOINT}/1`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				// May return 200, 404, or 500 if meters/data don't exist
-				expect([HTTP_CODE.OK, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
+				await validateCommaSeparatedIdPatterns({
+					baseEndpoint: LINE_COUNT_BASE_ENDPOINT,
+					invalidValues: ['1,'.repeat(STRING_GENERAL_MAX_LENGTH + 1)],
+					query: lineCountValidQuery,
+					expectedStatus: HTTP_CODE.BAD_REQUEST
+				});
 			});
 		});
 
 		mocha.describe('Query Parameter Validation (timeInterval)', () => {
 			mocha.it('should require timeInterval parameter', async () => {
-				const res = await chai.request(app)
-					.get(`${LINE_COUNT_BASE_ENDPOINT}/1`);
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
+				await validateRequiredQueryParams({
+					endpoint: `${LINE_COUNT_BASE_ENDPOINT}/1`,
+					baseQuery: lineCountValidQuery,
+					requiredParams: ['timeInterval'],
+					expectedStatus: HTTP_CODE.BAD_REQUEST
+				});
 			});
 
 			mocha.it('should reject extremely long timeInterval string (DoS prevention)', async () => {
@@ -105,65 +107,38 @@ mocha.describe('Readings Route Parameter Validation', () => {
 		});
 	});
 
+	const rawReadingsValidQuery = { timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' };
+
 	mocha.describe(`GET ${RAW_READINGS_BASE_ENDPOINT}/:meter_id`, () => {
 
 		mocha.describe('URL Parameter Validation (meter_id)', () => {
 			mocha.it('should accept valid integer meter ID', async () => {
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/1`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				// May return 400, 404, or 500 if meters/data don't exist
-				expect([HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]).to.include(res.status);
+				await expectValidNumericIdInPath({
+					baseEndpoint: RAW_READINGS_BASE_ENDPOINT,
+					validValues: ['1'],
+					query: rawReadingsValidQuery,
+					expectedStatuses: [HTTP_CODE.OK, HTTP_CODE.BAD_REQUEST, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]
+				});
 			});
 
-			mocha.it('should reject non-integer meter_id', async () => {
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/not_a_number`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
-			});
-
-			mocha.it('should reject meter_id below minimum (1)', async () => {
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/0`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
-			});
-
-			mocha.it('should reject meter_id above maximum (2147483647)', async () => {
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/2147483648`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
-			});
-
-			mocha.it('should reject negative meter_id', async () => {
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/-1`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
-			});
-
-			mocha.it('should reject floating point meter_id', async () => {
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/1.5`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
+			mocha.it('should reject invalid meter_id patterns', async () => {
+				await validateNumericIdInPath({
+					baseEndpoint: RAW_READINGS_BASE_ENDPOINT,
+					invalidValues: ['not_a_number', '0', '-1', '1.5', '2147483648', encodeURIComponent("1'; DROP TABLE readings; --"), '99999999999999999999999999999999'],
+					query: rawReadingsValidQuery,
+					expectedStatus: HTTP_CODE.BAD_REQUEST
+				});
 			});
 		});
 
 		mocha.describe('Query Parameter Validation (timeInterval)', () => {
 			mocha.it('should require timeInterval parameter', async () => {
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/1`);
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
+				await validateRequiredQueryParams({
+					endpoint: `${RAW_READINGS_BASE_ENDPOINT}/1`,
+					baseQuery: rawReadingsValidQuery,
+					requiredParams: ['timeInterval'],
+					expectedStatus: HTTP_CODE.BAD_REQUEST
+				});
 			});
 
 			mocha.it('should reject extremely long timeInterval string (DoS prevention)', async () => {
@@ -197,24 +172,6 @@ mocha.describe('Readings Route Parameter Validation', () => {
 		});
 
 		mocha.describe('Malicious Input Tests', () => {
-			mocha.it('should handle SQL injection attempts in meter_id', async () => {
-				const sqlInjection = "1'; DROP TABLE readings; --";
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/${encodeURIComponent(sqlInjection)}`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
-			});
-
-			mocha.it('should handle overflow attempts', async () => {
-				const overflowAttempt = '99999999999999999999999999999999';
-				const res = await chai.request(app)
-					.get(`${RAW_READINGS_BASE_ENDPOINT}/${overflowAttempt}`)
-					.query({ timeInterval: '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z' });
-
-				expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
-			});
-
 			mocha.it('should handle special characters in timeInterval', async () => {
 				const specialChars = '2020-01-01T00:00:00.000Z_2020-01-02T00:00:00.000Z&cmd=ls';
 				const res = await chai.request(app)

--- a/src/server/test/routes/unitAddParamsTest.js
+++ b/src/server/test/routes/unitAddParamsTest.js
@@ -9,7 +9,9 @@ const { chai, mocha, app } = require('../common');
 const { HTTP_CODE } = require('../../util/readingsUtils');
 const {
 	testInvalidField,
-	validateNoExtraFields
+	validateNoExtraFields,
+	validateString,
+	validateBool
 } = require('../util/validationHelpers');
 const {
 	STRING_GENERAL_MAX_LENGTH,
@@ -62,59 +64,26 @@ mocha.describe('Units Add Parameter Validation', () => {
 		});
 
 		mocha.it('should validate string field lengths', async () => {
-			// Test name field length (minLength: 1)
-			await testInvalidField({
-				field: 'name',
-				invalidValue: '',
-				endpoint: ADD_ENDPOINT,
-				basePayload: baseUnitData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
+			const stringFields = [
+				{ field: 'name', maxLength: STRING_SHORT_MAX_LENGTH },
+				{ field: 'identifier', maxLength: STRING_GENERAL_MAX_LENGTH },
+				{ field: 'unitRepresent', maxLength: STRING_GENERAL_MAX_LENGTH },
+				{ field: 'typeOfUnit', maxLength: STRING_GENERAL_MAX_LENGTH },
+				{ field: 'displayable', maxLength: STRING_GENERAL_MAX_LENGTH },
+				{ field: 'disableChecks', maxLength: STRING_GENERAL_MAX_LENGTH }
+			];
 
-			// Test identifier field length (minLength: 1)
-			await testInvalidField({
-				field: 'identifier',
-				invalidValue: '',
-				endpoint: ADD_ENDPOINT,
-				basePayload: baseUnitData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
-			// Test unitRepresent field length (minLength: 1)
-			await testInvalidField({
-				field: 'unitRepresent',
-				invalidValue: '',
-				endpoint: ADD_ENDPOINT,
-				basePayload: baseUnitData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
-			// Test typeOfUnit field length (minLength: 1)
-			await testInvalidField({
-				field: 'typeOfUnit',
-				invalidValue: '',
-				endpoint: ADD_ENDPOINT,
-				basePayload: baseUnitData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
-			// Test displayable field length (minLength: 1)
-			await testInvalidField({
-				field: 'displayable',
-				invalidValue: '',
-				endpoint: ADD_ENDPOINT,
-				basePayload: baseUnitData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
-
-			// Test disableChecks field length (minLength: 1)
-			await testInvalidField({
-				field: 'disableChecks',
-				invalidValue: '',
-				endpoint: ADD_ENDPOINT,
-				basePayload: baseUnitData,
-				expectedStatus: HTTP_CODE.FORBIDDEN
-			});
+			for (const { field, maxLength } of stringFields) {
+				await validateString({
+					field,
+					endpoint: ADD_ENDPOINT,
+					basePayload: baseUnitData,
+					minLength: 1,
+					maxLength,
+					enumValues: null,
+					expectedStatus: HTTP_CODE.FORBIDDEN
+				});
+			}
 		});
 
 		mocha.it('should validate enum fields', async () => {
@@ -197,17 +166,12 @@ mocha.describe('Units Add Parameter Validation', () => {
 		});
 
 		mocha.it('should validate boolean field types', async () => {
-			const invalidBooleanValues = ['yes', 'no', '1', '0', 'on', 'off', 'true', 'false'];
-
-			for (const invalidValue of invalidBooleanValues) {
-				await testInvalidField({
-					field: 'preferredDisplay',
-					invalidValue: invalidValue,
-					endpoint: ADD_ENDPOINT,
-					basePayload: baseUnitData,
-					expectedStatus: HTTP_CODE.FORBIDDEN
-				});
-			}
+			await validateBool({
+				field: 'preferredDisplay',
+				endpoint: ADD_ENDPOINT,
+				basePayload: baseUnitData,
+				expectedStatus: HTTP_CODE.FORBIDDEN
+			});
 		});
 
 		mocha.it('should handle oneOf nullable fields correctly', async () => {

--- a/src/server/test/routes/unitAddParamsTest.js
+++ b/src/server/test/routes/unitAddParamsTest.js
@@ -64,73 +64,60 @@ mocha.describe('Units Add Parameter Validation', () => {
 		});
 
 		mocha.it('should validate string field lengths', async () => {
-			const stringFields = [
+			const lengthOnlyFields = [
 				{ field: 'name', maxLength: STRING_SHORT_MAX_LENGTH },
-				{ field: 'identifier', maxLength: STRING_GENERAL_MAX_LENGTH },
-				{ field: 'unitRepresent', maxLength: STRING_GENERAL_MAX_LENGTH },
-				{ field: 'typeOfUnit', maxLength: STRING_GENERAL_MAX_LENGTH },
-				{ field: 'displayable', maxLength: STRING_GENERAL_MAX_LENGTH },
-				{ field: 'disableChecks', maxLength: STRING_GENERAL_MAX_LENGTH }
+				{ field: 'identifier', maxLength: STRING_GENERAL_MAX_LENGTH }
 			];
 
-			for (const { field, maxLength } of stringFields) {
+			for (const { field, maxLength } of lengthOnlyFields) {
 				await validateString({
 					field,
 					endpoint: ADD_ENDPOINT,
 					basePayload: baseUnitData,
 					minLength: 1,
 					maxLength,
-					enumValues: null,
 					expectedStatus: HTTP_CODE.FORBIDDEN
 				});
 			}
 		});
 
-		mocha.it('should validate enum fields', async () => {
-			// Test invalid unitRepresent (valid: quantity, flow, raw)
-			const invalidUnitRepresents = ['INVALID', 'invalid', 'volume', 'rate', ''];
-			for (const invalidValue of invalidUnitRepresents) {
-				await testInvalidField({
+		mocha.it('should validate enum-like string fields', async () => {
+			const enumLikeFields = [
+				{
 					field: 'unitRepresent',
-					invalidValue: invalidValue,
-					endpoint: ADD_ENDPOINT,
-					basePayload: baseUnitData,
-					expectedStatus: HTTP_CODE.FORBIDDEN
-				});
-			}
-
-			// Test invalid typeOfUnit (valid: unit, meter, suffix)
-			const invalidTypeOfUnits = ['INVALID', 'invalid', 'group', 'reading', ''];
-			for (const invalidValue of invalidTypeOfUnits) {
-				await testInvalidField({
+					maxLength: STRING_GENERAL_MAX_LENGTH,
+					enumValues: ['quantity', 'flow', 'raw'],
+					additionalInvalidEnumValues: ['INVALID', 'invalid', 'volume', 'rate', '']
+				},
+				{
 					field: 'typeOfUnit',
-					invalidValue: invalidValue,
-					endpoint: ADD_ENDPOINT,
-					basePayload: baseUnitData,
-					expectedStatus: HTTP_CODE.FORBIDDEN
-				});
-			}
-
-			// Test invalid displayable (valid: none, all, admin)
-			const invalidDisplayables = ['INVALID', 'invalid', 'public', 'private', ''];
-			for (const invalidValue of invalidDisplayables) {
-				await testInvalidField({
+					maxLength: STRING_GENERAL_MAX_LENGTH,
+					enumValues: ['unit', 'meter', 'suffix'],
+					additionalInvalidEnumValues: ['INVALID', 'invalid', 'group', 'reading', '']
+				},
+				{
 					field: 'displayable',
-					invalidValue: invalidValue,
-					endpoint: ADD_ENDPOINT,
-					basePayload: baseUnitData,
-					expectedStatus: HTTP_CODE.FORBIDDEN
-				});
-			}
-
-			// Test invalid disableChecks (valid: reject_disabled, reject_bad, reject_all, reject_none)
-			const invalidDisableChecks = ['INVALID', 'invalid', 'reject', 'disable', ''];
-			for (const invalidValue of invalidDisableChecks) {
-				await testInvalidField({
+					maxLength: STRING_GENERAL_MAX_LENGTH,
+					enumValues: ['none', 'all', 'admin'],
+					additionalInvalidEnumValues: ['INVALID', 'invalid', 'public', 'private', '']
+				},
+				{
 					field: 'disableChecks',
-					invalidValue: invalidValue,
+					maxLength: STRING_GENERAL_MAX_LENGTH,
+					enumValues: ['reject_disabled', 'reject_bad', 'reject_all', 'reject_none'],
+					additionalInvalidEnumValues: ['INVALID', 'invalid', 'reject', 'disable', '']
+				}
+			];
+
+			for (const { field, maxLength, enumValues, additionalInvalidEnumValues } of enumLikeFields) {
+				await validateString({
+					field,
 					endpoint: ADD_ENDPOINT,
 					basePayload: baseUnitData,
+					minLength: 1,
+					maxLength,
+					enumValues,
+					additionalInvalidEnumValues,
 					expectedStatus: HTTP_CODE.FORBIDDEN
 				});
 			}

--- a/src/server/test/util/validationHelpers.js
+++ b/src/server/test/util/validationHelpers.js
@@ -64,26 +64,36 @@ async function validateMinMaxRelation({ endpoint, basePayload }) {
  * @param minLength the minimum length allowed for the string (default: 1)
  * @param maxLength the maximum length allowed for the string (default: 255)
  * @param enumValues optional array of valid enum values to test against
+ * @param expectedStatus expected HTTP status code(s) (default: 400)
  */
-async function validateString({ field, endpoint, basePayload, required = true, minLength = 1, maxLength = 255, enumValues = null }) {
+async function validateString({
+	field,
+	endpoint,
+	basePayload,
+	required = true,
+	minLength = 1,
+	maxLength = 255,
+	enumValues = null,
+	expectedStatus = HTTP_CODE.BAD_REQUEST
+}) {
 
 	if (required) {
-		await testInvalidField({ field, invalidValue: undefined, endpoint, basePayload });
+		await testInvalidField({ field, invalidValue: undefined, endpoint, basePayload, expectedStatus });
 	}
 
 	if (minLength > 0) {
-		await testInvalidField({ field, invalidValue: 'x'.repeat(minLength - 1), endpoint, basePayload });
+		await testInvalidField({ field, invalidValue: 'x'.repeat(minLength - 1), endpoint, basePayload, expectedStatus });
 	}
 
-	await testInvalidField({ field, invalidValue: 'x'.repeat(maxLength + 1), endpoint, basePayload });
+	await testInvalidField({ field, invalidValue: 'x'.repeat(maxLength + 1), endpoint, basePayload, expectedStatus });
 
 	if (enumValues) {
-		await testInvalidField({ field, invalidValue: 'INVALID_ENUM', endpoint, basePayload });
+		await testInvalidField({ field, invalidValue: 'INVALID_ENUM', endpoint, basePayload, expectedStatus });
 	}
 }
 
 /**
- * Validates an integer field by testing for presence (if required), 
+ * Validates an integer field by testing for presence (if required),
  * numeric bounds (min and max), and type correctness.
  *
  * @param field the name of the integer field to validate
@@ -92,22 +102,23 @@ async function validateString({ field, endpoint, basePayload, required = true, m
  * @param required whether the field is required (default: true)
  * @param min the minimum allowed integer value (optional)
  * @param max the maximum allowed integer value (optional)
+ * @param expectedStatus expected HTTP status code(s) (default: 400)
  */
-async function validateInt({ field, endpoint, basePayload, required = true, min = null, max = null }) {
+async function validateInt({ field, endpoint, basePayload, required = true, min = null, max = null, expectedStatus = HTTP_CODE.BAD_REQUEST }) {
 
 	if (required) {
-		await testInvalidField({ field, invalidValue: undefined, endpoint, basePayload });
+		await testInvalidField({ field, invalidValue: undefined, endpoint, basePayload, expectedStatus });
 	}
 
 	if (typeof min === 'number') {
-		await testInvalidField({ field, invalidValue: min - 1, endpoint, basePayload });
+		await testInvalidField({ field, invalidValue: min - 1, endpoint, basePayload, expectedStatus });
 	}
 
 	if (typeof max === 'number') {
-		await testInvalidField({ field, invalidValue: max + 1, endpoint, basePayload });
+		await testInvalidField({ field, invalidValue: max + 1, endpoint, basePayload, expectedStatus });
 	}
 
-	await testInvalidField({ field, invalidValue: 'notAnInteger', endpoint, basePayload });
+	await testInvalidField({ field, invalidValue: 'notAnInteger', endpoint, basePayload, expectedStatus });
 }
 
 /**
@@ -118,13 +129,14 @@ async function validateInt({ field, endpoint, basePayload, required = true, min 
  * @param endpoint the API endpoint to test (e.g., /api/units/addUnit)
  * @param basePayload a valid base object used to construct requests
  * @param required whether the field is required (default: true)
+ * @param expectedStatus expected HTTP status code(s) (default: 400)
  */
-async function validateBool({ field, endpoint, basePayload, required = true }) {
+async function validateBool({ field, endpoint, basePayload, required = true, expectedStatus = HTTP_CODE.BAD_REQUEST }) {
 	if (required) {
-		await testInvalidField({ field, invalidValue: undefined, endpoint, basePayload });
+		await testInvalidField({ field, invalidValue: undefined, endpoint, basePayload, expectedStatus });
 	}
 
-	await testInvalidField({ field, invalidValue: 'notABool', endpoint, basePayload });
+	await testInvalidField({ field, invalidValue: 'notABool', endpoint, basePayload, expectedStatus });
 }
 
 /**
@@ -225,6 +237,93 @@ async function expectValidCommaSeparatedIds({
 }
 
 /**
+ * Validates that endpoints reject invalid single numeric IDs in path parameters.
+ * Convenience wrapper around validateCommaSeparatedIdPatterns for routes like
+ * /api/maps/:map_id or /api/groups/deep/groups/:group_id.
+ *
+ * @param baseEndpoint the base endpoint path before the id segment (e.g., '/api/maps')
+ * @param invalidValues array of invalid id strings to test
+ * @param query optional query parameters to include (for GET requests)
+ * @param method HTTP method (default 'get')
+ * @param expectedStatus expected status code (default 400)
+ */
+async function validateNumericIdInPath({
+	baseEndpoint,
+	invalidValues,
+	query = {},
+	method = 'get',
+	expectedStatus = HTTP_CODE.BAD_REQUEST
+}) {
+	for (const invalidValue of invalidValues) {
+		let request = chai.request(app)[method](`${baseEndpoint}/${invalidValue}`);
+
+		if (method.toLowerCase() === 'get') {
+			request = request.query(query);
+		} else {
+			request = request.send(query);
+		}
+
+		const res = await request;
+		const expectedStatuses = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
+		expect(expectedStatuses).to.include(res.status);
+	}
+}
+
+/**
+ * Verifies that endpoints accept valid single numeric IDs in path parameters.
+ * Convenience wrapper around expectValidCommaSeparatedIds for routes like
+ * /api/maps/:map_id or /api/groups/deep/groups/:group_id.
+ *
+ * @param baseEndpoint the base endpoint path before the id segment
+ * @param validValues array of valid id strings to test
+ * @param query optional query parameters to include (for GET requests)
+ * @param method HTTP method (default 'get')
+ * @param expectedStatuses allowable response status codes (defaults to 200/404/500)
+ */
+async function expectValidNumericIdInPath({
+	baseEndpoint,
+	validValues,
+	query = {},
+	method = 'get',
+	expectedStatuses = [HTTP_CODE.OK, HTTP_CODE.NOT_FOUND, HTTP_CODE.INTERNAL_SERVER_ERROR]
+}) {
+	return expectValidCommaSeparatedIds({ baseEndpoint, validValues, query, method, expectedStatuses });
+}
+
+/**
+ * Validates that GET endpoints require specified query parameters.
+ *
+ * @param endpoint the full endpoint URL including path (e.g., '/api/readings/line/count/meters/1')
+ * @param baseQuery object with all valid query parameters
+ * @param requiredParams array of param names that must be present
+ * @param method HTTP method (default 'get')
+ * @param expectedStatus expected status when param is missing (default 400)
+ */
+async function validateRequiredQueryParams({
+	endpoint,
+	baseQuery,
+	requiredParams,
+	method = 'get',
+	expectedStatus = HTTP_CODE.BAD_REQUEST
+}) {
+	for (const param of requiredParams) {
+		const incompleteQuery = { ...baseQuery };
+		delete incompleteQuery[param];
+
+		let request = chai.request(app)[method](endpoint);
+		if (method.toLowerCase() === 'get') {
+			request = request.query(incompleteQuery);
+		} else {
+			request = request.send(incompleteQuery);
+		}
+
+		const res = await request;
+		const expectedStatuses = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
+		expect(expectedStatuses).to.include(res.status);
+	}
+}
+
+/**
  * Validates that additional properties are rejected when payloads exceed
  * the defined schema.
  *
@@ -252,5 +351,8 @@ module.exports = {
 	validateToken,
 	validateCommaSeparatedIdPatterns,
 	expectValidCommaSeparatedIds,
+	validateNumericIdInPath,
+	expectValidNumericIdInPath,
+	validateRequiredQueryParams,
 	validateNoExtraFields
 };

--- a/src/server/test/util/validationHelpers.js
+++ b/src/server/test/util/validationHelpers.js
@@ -20,7 +20,7 @@ chai.use(chaiHttp);
  * @param invalidValue the value to assign to the field for testing; if undefined, the field is removed
  * @param endpoint the API endpoint URL to test (e.g., /api/units/addUnit)
  * @param basePayload the base valid payload object to clone and modify
- * @param expectedStatus the expected HTTP status code (default 400 for validation errors)
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses
  */
 async function testInvalidField({ field, invalidValue, endpoint, basePayload, expectedStatus = HTTP_CODE.BAD_REQUEST }) {
 	const payload = { ...basePayload };
@@ -51,7 +51,7 @@ async function validateMinMaxRelation({ endpoint, basePayload }) {
 		.post(endpoint)
 		.send(invalidPayload);
 
-	expect(res).to.have.status(400);
+	expect(res).to.have.status(HTTP_CODE.BAD_REQUEST);
 }
 
 /**
@@ -63,8 +63,9 @@ async function validateMinMaxRelation({ endpoint, basePayload }) {
  * @param required whether the field is required (default: true)
  * @param minLength the minimum length allowed for the string (default: 1)
  * @param maxLength the maximum length allowed for the string (default: 255)
- * @param enumValues optional array of valid enum values to test against
- * @param expectedStatus expected HTTP status code(s) (default: 400)
+ * @param enumValues optional array of valid enum values (documents allowed set; tests a bogus enum value)
+ * @param additionalInvalidEnumValues optional extra invalid values to POST when enumValues is set
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses
  */
 async function validateString({
 	field,
@@ -74,6 +75,7 @@ async function validateString({
 	minLength = 1,
 	maxLength = 255,
 	enumValues = null,
+	additionalInvalidEnumValues = null,
 	expectedStatus = HTTP_CODE.BAD_REQUEST
 }) {
 
@@ -89,12 +91,17 @@ async function validateString({
 
 	if (enumValues) {
 		await testInvalidField({ field, invalidValue: 'INVALID_ENUM', endpoint, basePayload, expectedStatus });
+		if (additionalInvalidEnumValues) {
+			for (const invalidValue of additionalInvalidEnumValues) {
+				await testInvalidField({ field, invalidValue, endpoint, basePayload, expectedStatus });
+			}
+		}
 	}
 }
 
 /**
  * Validates an integer field by testing for presence (if required),
- * numeric bounds (min and max), and type correctness.
+ * numeric bounds (min and max), type correctness, and common boundary mistakes.
  *
  * @param field the name of the integer field to validate
  * @param endpoint the API endpoint to test (e.g., /api/units/addUnit)
@@ -102,7 +109,7 @@ async function validateString({
  * @param required whether the field is required (default: true)
  * @param min the minimum allowed integer value (optional)
  * @param max the maximum allowed integer value (optional)
- * @param expectedStatus expected HTTP status code(s) (default: 400)
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses
  */
 async function validateInt({ field, endpoint, basePayload, required = true, min = null, max = null, expectedStatus = HTTP_CODE.BAD_REQUEST }) {
 
@@ -112,6 +119,12 @@ async function validateInt({ field, endpoint, basePayload, required = true, min 
 
 	if (typeof min === 'number') {
 		await testInvalidField({ field, invalidValue: min - 1, endpoint, basePayload, expectedStatus });
+		if (min > 0) {
+			await testInvalidField({ field, invalidValue: -1, endpoint, basePayload, expectedStatus });
+		}
+		if (min > 1) {
+			await testInvalidField({ field, invalidValue: 0, endpoint, basePayload, expectedStatus });
+		}
 	}
 
 	if (typeof max === 'number') {
@@ -119,6 +132,8 @@ async function validateInt({ field, endpoint, basePayload, required = true, min 
 	}
 
 	await testInvalidField({ field, invalidValue: 'notAnInteger', endpoint, basePayload, expectedStatus });
+	await testInvalidField({ field, invalidValue: 1.5, endpoint, basePayload, expectedStatus });
+	await testInvalidField({ field, invalidValue: Number.MAX_SAFE_INTEGER + 1, endpoint, basePayload, expectedStatus });
 }
 
 /**
@@ -129,14 +144,35 @@ async function validateInt({ field, endpoint, basePayload, required = true, min 
  * @param endpoint the API endpoint to test (e.g., /api/units/addUnit)
  * @param basePayload a valid base object used to construct requests
  * @param required whether the field is required (default: true)
- * @param expectedStatus expected HTTP status code(s) (default: 400)
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses
+ * @param verifyValidBooleanValues if true, also sends true and false and asserts they match expectedStatus (e.g. pass validation, fail auth)
  */
-async function validateBool({ field, endpoint, basePayload, required = true, expectedStatus = HTTP_CODE.BAD_REQUEST }) {
+async function validateBool({
+	field,
+	endpoint,
+	basePayload,
+	required = true,
+	expectedStatus = HTTP_CODE.BAD_REQUEST,
+	verifyValidBooleanValues = false
+}) {
 	if (required) {
 		await testInvalidField({ field, invalidValue: undefined, endpoint, basePayload, expectedStatus });
 	}
 
-	await testInvalidField({ field, invalidValue: 'notABool', endpoint, basePayload, expectedStatus });
+	const invalidBools = ['notABool', 'true', 'false', 'yes', 'no', '', 1, 0, 2];
+	for (const invalidValue of invalidBools) {
+		await testInvalidField({ field, invalidValue, endpoint, basePayload, expectedStatus });
+	}
+
+	if (verifyValidBooleanValues) {
+		const expectedStatuses = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
+		for (const validValue of [true, false]) {
+			const res = await chai.request(app)
+				.post(endpoint)
+				.send({ ...basePayload, [field]: validValue });
+			expect(expectedStatuses).to.include(res.status);
+		}
+	}
 }
 
 /**
@@ -160,7 +196,7 @@ async function validateToken({ endpoint, method = 'post', sendTokenIn = 'header'
 	}
 
 	const res = await request;
-	expect(res).to.have.status(403);
+	expect(res).to.have.status(HTTP_CODE.FORBIDDEN);
 
 	// Test invalid token format
 	request = chai.request(app)[method](endpoint);
@@ -173,25 +209,27 @@ async function validateToken({ endpoint, method = 'post', sendTokenIn = 'header'
 	}
 
 	const res2 = await request;
-	expect(res2).to.have.status(403);
+	expect(res2).to.have.status(HTTP_CODE.FORBIDDEN);
 }
 
 /**
- * Validates that endpoints reject malformed comma-separated identifier lists.
+ * Shared implementation: request baseEndpoint/:invalidValue with optional query/body and
+ * assert the response status is one of the expected values.
  *
  * @param baseEndpoint the base endpoint path before the id segment
  * @param invalidValues array of invalid id strings to test
  * @param query optional query parameters to include (for GET requests)
  * @param method HTTP method (default 'get')
- * @param expectedStatus expected status code (default 400)
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses
  */
-async function validateCommaSeparatedIdPatterns({
+async function validatePathIdSegmentPatterns({
 	baseEndpoint,
 	invalidValues,
 	query = {},
 	method = 'get',
 	expectedStatus = HTTP_CODE.BAD_REQUEST
 }) {
+	const expectedStatuses = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
 	for (const invalidValue of invalidValues) {
 		let request = chai.request(app)[method](`${baseEndpoint}/${invalidValue}`);
 
@@ -202,8 +240,35 @@ async function validateCommaSeparatedIdPatterns({
 		}
 
 		const res = await request;
-		expect(res.status).to.equal(expectedStatus);
+		expect(expectedStatuses).to.include(res.status);
 	}
+}
+
+/**
+ * Validates that endpoints reject malformed comma-separated identifier lists in a path segment.
+ *
+ * @param baseEndpoint the base endpoint path before the id segment
+ * @param invalidValues array of invalid id strings to test
+ * @param query optional query parameters to include (for GET requests)
+ * @param method HTTP method (default 'get')
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses
+ */
+async function validateCommaSeparatedIdPatterns(opts) {
+	return validatePathIdSegmentPatterns(opts);
+}
+
+/**
+ * Validates that endpoints reject invalid single numeric IDs in path parameters
+ * (same request pattern as comma-separated lists: one path segment after baseEndpoint).
+ *
+ * @param baseEndpoint the base endpoint path before the id segment (e.g., '/api/maps')
+ * @param invalidValues array of invalid id strings to test
+ * @param query optional query parameters to include (for GET requests)
+ * @param method HTTP method (default 'get')
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses
+ */
+async function validateNumericIdInPath(opts) {
+	return validatePathIdSegmentPatterns(opts);
 }
 
 /**
@@ -213,7 +278,7 @@ async function validateCommaSeparatedIdPatterns({
  * @param validValues array of valid id strings to test
  * @param query optional query parameters to include (for GET requests)
  * @param method HTTP method (default 'get')
- * @param expectedStatuses allowable response status codes (defaults to 200/500)
+ * @param expectedStatuses allowable response status codes (defaults to HTTP_CODE.OK / INTERNAL_SERVER_ERROR)
  */
 async function expectValidCommaSeparatedIds({
 	baseEndpoint,
@@ -237,48 +302,14 @@ async function expectValidCommaSeparatedIds({
 }
 
 /**
- * Validates that endpoints reject invalid single numeric IDs in path parameters.
- * Convenience wrapper around validateCommaSeparatedIdPatterns for routes like
- * /api/maps/:map_id or /api/groups/deep/groups/:group_id.
- *
- * @param baseEndpoint the base endpoint path before the id segment (e.g., '/api/maps')
- * @param invalidValues array of invalid id strings to test
- * @param query optional query parameters to include (for GET requests)
- * @param method HTTP method (default 'get')
- * @param expectedStatus expected status code (default 400)
- */
-async function validateNumericIdInPath({
-	baseEndpoint,
-	invalidValues,
-	query = {},
-	method = 'get',
-	expectedStatus = HTTP_CODE.BAD_REQUEST
-}) {
-	for (const invalidValue of invalidValues) {
-		let request = chai.request(app)[method](`${baseEndpoint}/${invalidValue}`);
-
-		if (method.toLowerCase() === 'get') {
-			request = request.query(query);
-		} else {
-			request = request.send(query);
-		}
-
-		const res = await request;
-		const expectedStatuses = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
-		expect(expectedStatuses).to.include(res.status);
-	}
-}
-
-/**
  * Verifies that endpoints accept valid single numeric IDs in path parameters.
- * Convenience wrapper around expectValidCommaSeparatedIds for routes like
- * /api/maps/:map_id or /api/groups/deep/groups/:group_id.
+ * Delegates to expectValidCommaSeparatedIds (one URL segment, same HTTP shape).
  *
  * @param baseEndpoint the base endpoint path before the id segment
  * @param validValues array of valid id strings to test
  * @param query optional query parameters to include (for GET requests)
  * @param method HTTP method (default 'get')
- * @param expectedStatuses allowable response status codes (defaults to 200/404/500)
+ * @param expectedStatuses allowable response status codes (defaults to OK / NOT_FOUND / INTERNAL_SERVER_ERROR)
  */
 async function expectValidNumericIdInPath({
 	baseEndpoint,
@@ -297,7 +328,7 @@ async function expectValidNumericIdInPath({
  * @param baseQuery object with all valid query parameters
  * @param requiredParams array of param names that must be present
  * @param method HTTP method (default 'get')
- * @param expectedStatus expected status when param is missing (default 400)
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses when a param is omitted
  */
 async function validateRequiredQueryParams({
 	endpoint,
@@ -330,7 +361,7 @@ async function validateRequiredQueryParams({
  * @param endpoint the API endpoint URL to test
  * @param basePayload a baseline valid payload object
  * @param extraFields an object containing the extra fields to send
- * @param expectedStatus expected HTTP status code (default 400)
+ * @param {number|number[]} [expectedStatus=HTTP_CODE.BAD_REQUEST] expected status or list of acceptable statuses
  */
 async function validateNoExtraFields({ endpoint, basePayload, extraFields = {}, expectedStatus = HTTP_CODE.BAD_REQUEST }) {
 	const payload = {


### PR DESCRIPTION
# Description

- Refactors multiple `ParamsTest.js` files to use shared helpers from src/server/test/util/validationHelpers.js instead of duplicating validation logic.
- Adds/extends helpers for common patterns: string/int/bool validation with configurable expected status, numeric path IDs, required query parameters, and extra-field (parameter injection) checks.
- Keeps test behavior consistent while reducing duplication and making it easier to add new tests.

Details:
- Updates `validationHelpers.js`:
   - Extends validateString, validateInt, and validateBool to accept an expectedStatus parameter.
   - Adds validateNumericIdInPath, expectValidNumericIdInPath, and validateRequiredQueryParams helpers for common ID and query validation patterns.
- Refactors the following tests to use the helpers:
`compareReadingsParamsTest.js`
`conversionsParamsTest.js`
`groupsParamsTest.js`
`mapsParamsTest.js`
`readingsParamsTest.js`
`unitAddParamsTest.js`

Fixes #1572 

Author: Kaulan Serzhanuly

(In general, OED likes to have at least one issue associated with each pull request. Replace [issue] with the OED GitHub issue number. In the preview you will see an issue description if you hover over that number. You can create one yourself before doing this pull request. This is where details are normally given on what is being addressed. Note you should not use the word "Fixes" if it does not completely address the issue since the issue would automatically be closed on merging the pull request. In that case use "Partly Addresses #[issue].)

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [ ] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

(Describe any issues that remain or work that should still be done.)
