### PR TITLE
Add configurable trusted origins for clickjacking protection

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -155,6 +155,13 @@ router.get('*', (req, res) => {
 	fs.readFile(path.resolve(__dirname, '..', 'client', 'index.html'), (err, html) => {
 		const subdir = config.subdir || '/';
 		let htmlPlusData = html.toString().replace('SUBDIR', subdir);
+
+		// Clickjacking protection: restrict framing to same-origin by default,
+		// with optional admin-configurable trusted origins via environment variable.
+		// This preserves OED's chart embedding functionality while mitigating UI redress attacks.
+		const frameAncestors = ["'self'", ...config.trustedFrameAncestors].join(' ');
+		res.setHeader('Content-Security-Policy', `frame-ancestors ${frameAncestors};`);
+
 		res.send(htmlPlusData);
 	});
 });

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -49,4 +49,13 @@ config.serverPort = process.env.OED_SERVER_PORT;
 config.logFile = process.env.OED_LOG_FILE || 'log.txt';
 config.subdir = process.env.OED_SUBDIR || '';
 
+// Parse trusted frame ancestors for clickjacking protection.
+// Comma-separated list of allowed origins (e.g., https://example.com)
+
+const trustedFrameAncestors = process.env.OED_TRUSTED_FRAME_ANCESTORS || '';
+config.trustedFrameAncestors = trustedFrameAncestors
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(origin => origin.length > 0);
+
 module.exports = config;


### PR DESCRIPTION
Description

This change extends clickjacking protection by allowing trusted framing origins to be configured.

Previously, enforcing strict framing protection (e.g., frame-ancestors 'self') could break valid use cases such as embedding charts via generated links. This update introduces a configuration-based approach that preserves security while allowing controlled embedding.

Changes:
	•	Added support for OED_TRUSTED_FRAME_ANCESTORS environment variable
	•	Parsed and exposed trusted origins via server configuration
	•	Updated CSP header to include 'self' plus configured trusted origins

Security impact:
	•	Maintains clickjacking protection by default
	•	Allows controlled embedding without breaking expected behavior
	•	Avoids hard-coded origins

Testing:
	•	Verified default: `frame-ancestors 'self'`
	•	Verified configured: frame-ancestors 'self' https://example.com

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the OED pull request ideas
- [x] I have removed text in ( ) from the issue request
- [x] All contributors have signed the OED CLA and are listed

Limitations
	•	Trusted origins are environment-based (no admin UI yet)
	•	Minimal validation of origin format
	•	Changes require restart to take effect