### PR TITLE
Resolved Time Difference Between Valid and Invalid Users Trying To Log In

### DIFF
--- a/src/server/routes/login.js
+++ b/src/server/routes/login.js
@@ -48,6 +48,7 @@ router.post('/', credentialsRequestValidationMiddleware, async (req, res) => {
 			let isValid;
 			if (user === null) {
 				// User did not exist so return false.
+				isValid = await bcrypt.compare(req.body.password, user.passwordHash);
 				isValid = false;
 			} else {
 				isValid = await bcrypt.compare(req.body.password, user.passwordHash);

--- a/src/server/routes/login.js
+++ b/src/server/routes/login.js
@@ -47,8 +47,8 @@ router.post('/', credentialsRequestValidationMiddleware, async (req, res) => {
 			const user = await User.getByUsername(req.body.username, conn);
 			let isValid;
 			if (user === null) {
-				// User did not exist so return false.
-				isValid = await bcrypt.compare(req.body.password, user.passwordHash);
+				// call the bcrypt.compare() without assigning it valid user to eliminate time differation
+				await bcrypt.compare(req.body.password, user.passwordHash);
 				isValid = false;
 			} else {
 				isValid = await bcrypt.compare(req.body.password, user.passwordHash);


### PR DESCRIPTION
# Description

This change ensures that bcrypt.compare() is invoked for both valid and invalid login attempts. Previously, authentication requests for non-existent users returned faster because the comparison function was not executed, while valid users incurred additional processing time due to the bcrypt.compare() call. This discrepancy created a time difference that could allow attackers to enumerate valid users. By consistently calling bcrypt.compare() in all cases, the response time is normalized, mitigating the risk of user enumeration.


(In general, OED likes to have at least one issue associated with each pull request. Replace [issue] with the OED GitHub issue number. In the preview you will see an issue description if you hover over that number. You can create one yourself before doing this pull request. This is where details are normally given on what is being addressed. Note you should not use the word "Fixes" if it does not completely address the issue since the issue would automatically be closed on merging the pull request. In that case use "Partly Addresses #[issue].)

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

(Describe any issues that remain or work that should still be done.)
