### PR TITLE
fix: enhanced CSV readings upload for new meter values

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@
 # * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # *
 
-version: "3.8"
 services:
     # Database service. It's PostgreSQL, see the
     # Dockerfile in ./database
@@ -21,8 +20,8 @@ services:
             interval: 10s
             timeout: 10s
             retries: 3
-        # ports:
-        #    - "5432:5432"
+        ports:
+        - "5432:5432"
         # Uncomment the above lines to enable access to the PostgreSQL server
         # from the host machine.
         # Web service runs Node
@@ -33,9 +32,9 @@ services:
             - OED_SERVER_PORT=3000
             - OED_DB_USER=oed
             - OED_DB_DATABASE=oed
-            - OED_DB_TEST_DATABASE=oed_testing
+            - OED_DB_TEST_DATABASE=oed
             - OED_DB_PASSWORD=opened
-            - OED_DB_HOST=database # Docker will set this hostname
+            - OED_DB_HOST=database # Docker service name inside the compose network
             - OED_DB_PORT=5432
             - OED_TOKEN_SECRET=?
             - OED_LOG_FILE=log.txt

--- a/src/client/app/components/csv/ReadingsCSVUploadComponent.tsx
+++ b/src/client/app/components/csv/ReadingsCSVUploadComponent.tsx
@@ -187,13 +187,6 @@ export default function ReadingsCSVUploadComponent() {
 			lengthVariation: selectedMeter.readingVariation,
 			endOnly: selectedMeter.endOnlyTime,
 			timeSort: MeterTimeSortType[selectedMeter.timeSort as keyof typeof MeterTimeSortType],
-			timeZone: selectedMeter.timeZone ?? '',
-			minVal: selectedMeter.minVal.toString(),
-			maxVal: selectedMeter.maxVal.toString(),
-			minDate: selectedMeter.minDate,
-			maxDate: selectedMeter.maxDate,
-			maxError: selectedMeter.maxError.toString(),
-			disableChecks: selectedMeter.disableChecks,
 			useMeterZone: false,
 			warnOnCumulativeReset: false
 		}));
@@ -299,16 +292,9 @@ export default function ReadingsCSVUploadComponent() {
 			|| readingsData.refreshReadings !== ReadingsCSVUploadDefaults.refreshReadings
 			|| readingsData.relaxedParsing !== ReadingsCSVUploadDefaults.relaxedParsing
 			|| readingsData.timeSort !== ReadingsCSVUploadDefaults.timeSort
-			|| readingsData.timeZone !== ReadingsCSVUploadDefaults.timeZone
-			|| readingsData.minVal !== ReadingsCSVUploadDefaults.minVal
-			|| readingsData.maxVal !== ReadingsCSVUploadDefaults.maxVal
-			|| readingsData.minDate !== ReadingsCSVUploadDefaults.minDate
-			|| readingsData.maxDate !== ReadingsCSVUploadDefaults.maxDate
-			|| readingsData.maxError !== ReadingsCSVUploadDefaults.maxError
-			|| readingsData.disableChecks !== ReadingsCSVUploadDefaults.disableChecks
 			|| readingsData.update !== ReadingsCSVUploadDefaults.update
-			|| readingsData.useMeterZone !== ReadingsCSVUploadDefaults.useMeterZone
-			|| readingsData.warnOnCumulativeReset !== ReadingsCSVUploadDefaults.warnOnCumulativeReset
+			|| readingsData.useMeterZone !== readingsData.useMeterZone
+			|| readingsData.warnOnCumulativeReset !== readingsData.warnOnCumulativeReset
 			// If any file is added, it will count as edit made.
 			|| selectedFile !== null
 			|| invalidFileEntry === true;
@@ -695,8 +681,6 @@ export default function ReadingsCSVUploadComponent() {
 											</Input>
 										</FormGroup>
 									</Col>
-								</Row>
-								<Row xs='1' lg='2'>
 									<Col>
 										<FormGroup>
 											<Label>
@@ -705,28 +689,6 @@ export default function ReadingsCSVUploadComponent() {
 												</div>
 											</Label>
 											<TimeZoneSelect current={readingsData.timeZone ?? null} handleClick={timeZone => handleTimeZoneChange(timeZone)} />
-										</FormGroup>
-									</Col>
-									<Col>
-										<FormGroup>
-											<Label for='disableChecks'>
-												<div className='pb-1'>
-													{translate('meter.disableChecks')}
-												</div>
-											</Label>
-											<Input
-												type='select'
-												id='disableChecks'
-												name='disableChecks'
-												value={readingsData.disableChecks || DisableChecksType.reject_all}
-												onChange={e => {handleChange(e);}}
-											>
-												{Object.values(DisableChecksType).map(disableChecks => {
-													return (
-														<option value={disableChecks} key={disableChecks}>{translate(`DisableChecksType.${disableChecks}`)}</option>
-													);
-												})}
-											</Input>
 										</FormGroup>
 									</Col>
 								</Row>
@@ -815,6 +777,28 @@ export default function ReadingsCSVUploadComponent() {
 											/>
 										</FormGroup>
 									</Col>
+									<Col>
+										<FormGroup>
+											<Label for='disableChecks'>
+												<div className='pb-1'>
+													{translate('meter.disableChecks')}
+												</div>
+											</Label>
+											<Input
+												type='select'
+												id='disableChecks'
+												name='disableChecks'
+												value={readingsData.disableChecks || DisableChecksType.reject_all}
+												onChange={e => {handleChange(e);}}
+											>
+												{Object.values(DisableChecksType).map(disableChecks => {
+													return (
+														<option value={disableChecks} key={disableChecks}>{translate(`DisableChecksType.${disableChecks}`)}</option>
+													);
+												})}
+											</Input>
+										</FormGroup>
+									</Col>
 								</Row>
 								{/* TODO This feature is not working perfectly so disabling from web page but allowing in curl.
 									Rest of changes left so easy to add back in.
@@ -823,7 +807,7 @@ export default function ReadingsCSVUploadComponent() {
 									originally added to the web page input of import but decided to not allow
 									it at this time. Thus, the code was commented out. As of now
 									there is no plan to make this generally available due to its limitations.*/}
-								{/*
+								{/**
 									<Label check>
 										<Input
 											checked={useMeterZone}
@@ -832,11 +816,11 @@ export default function ReadingsCSVUploadComponent() {
 											onChange={handleCheckboxChange}
 										/>
 										<div className='ps-2'>
-											{translate('csv.readings.param.use.meter.zone' />
+											{translate('csv.readings.param.use.meter.zone')}
 										</div>
 									</Label>
 								*/}
-								{/*
+								{/**
 									<Label check>
 										<Input
 											checked={warnOnCumulativeReset}
@@ -845,7 +829,7 @@ export default function ReadingsCSVUploadComponent() {
 											onChange={handleCheckboxChange}
 										/>
 										<div className='ps-2'>
-											{translate('csv.readings.param.use.meter.zone' />
+											{translate('csv.readings.param.use.meter.zone')}
 										</div>
 									</Label>
 								*/}
@@ -863,11 +847,11 @@ export default function ReadingsCSVUploadComponent() {
 								</div>
 								<div className='pb-5'>
 								</div>
-							</Col>
-						</Row>
-					</Form>
-				</>)}
-			</Container>
-		</>
-	);
-}
+								</Col>
+							</Row>
+						</Form>
+					</>)}
+				</Container>
+			</>
+		);
+	}

--- a/src/client/app/components/csv/ReadingsCSVUploadComponent.tsx
+++ b/src/client/app/components/csv/ReadingsCSVUploadComponent.tsx
@@ -13,11 +13,13 @@ import { selectIsAdmin } from '../../redux/slices/currentUserSlice';
 import { ReadingsCSVUploadPreferences } from '../../types/csvUploadForm';
 import { TrueFalseType } from '../../types/items';
 import { MeterData, MeterTimeSortType } from '../../types/redux/meters';
+import { DisableChecksType } from '../../types/redux/units';
 import { submitReadings } from '../../utils/api/UploadCSVApi';
 import { ReadingsCSVUploadDefaults } from '../../utils/csvUploadDefaults';
 import { showErrorNotification, showSuccessNotification } from '../../utils/notifications';
 import { useTranslate } from '../../redux/componentHooks';
 import FormFileUploaderComponent from '../FormFileUploaderComponent';
+import TimeZoneSelect from '../TimeZoneSelect';
 import TooltipHelpComponent from '../TooltipHelpComponent';
 import TooltipMarkerComponent from '../TooltipMarkerComponent';
 import CreateMeterModalComponent from '../meters/CreateMeterModalComponent';
@@ -116,7 +118,7 @@ export default function ReadingsCSVUploadComponent() {
 		}));
 	};
 
-	const handleFileChange = (file: File) => {
+	const handleFileChange = (file: File | null) => {
 		if (file) {
 			setSelectedFile(file);
 			if (file.name.slice(-4) === '.csv' || file.name.slice(-3) === '.gz') {
@@ -131,6 +133,13 @@ export default function ReadingsCSVUploadComponent() {
 				setInvalidFileEntry(true);
 			}
 		}
+	};
+
+	const handleTimeZoneChange = (timeZone: string) => {
+		setReadingsData(prevData => ({
+			...prevData,
+			timeZone: timeZone || ''
+		}));
 	};
 	/* END of Handlers for each type of input change */
 
@@ -178,6 +187,13 @@ export default function ReadingsCSVUploadComponent() {
 			lengthVariation: selectedMeter.readingVariation,
 			endOnly: selectedMeter.endOnlyTime,
 			timeSort: MeterTimeSortType[selectedMeter.timeSort as keyof typeof MeterTimeSortType],
+			timeZone: selectedMeter.timeZone ?? '',
+			minVal: selectedMeter.minVal.toString(),
+			maxVal: selectedMeter.maxVal.toString(),
+			minDate: selectedMeter.minDate,
+			maxDate: selectedMeter.maxDate,
+			maxError: selectedMeter.maxError.toString(),
+			disableChecks: selectedMeter.disableChecks,
 			useMeterZone: false,
 			warnOnCumulativeReset: false
 		}));
@@ -283,9 +299,16 @@ export default function ReadingsCSVUploadComponent() {
 			|| readingsData.refreshReadings !== ReadingsCSVUploadDefaults.refreshReadings
 			|| readingsData.relaxedParsing !== ReadingsCSVUploadDefaults.relaxedParsing
 			|| readingsData.timeSort !== ReadingsCSVUploadDefaults.timeSort
+			|| readingsData.timeZone !== ReadingsCSVUploadDefaults.timeZone
+			|| readingsData.minVal !== ReadingsCSVUploadDefaults.minVal
+			|| readingsData.maxVal !== ReadingsCSVUploadDefaults.maxVal
+			|| readingsData.minDate !== ReadingsCSVUploadDefaults.minDate
+			|| readingsData.maxDate !== ReadingsCSVUploadDefaults.maxDate
+			|| readingsData.maxError !== ReadingsCSVUploadDefaults.maxError
+			|| readingsData.disableChecks !== ReadingsCSVUploadDefaults.disableChecks
 			|| readingsData.update !== ReadingsCSVUploadDefaults.update
-			|| readingsData.useMeterZone !== readingsData.useMeterZone
-			|| readingsData.warnOnCumulativeReset !== readingsData.warnOnCumulativeReset
+			|| readingsData.useMeterZone !== ReadingsCSVUploadDefaults.useMeterZone
+			|| readingsData.warnOnCumulativeReset !== ReadingsCSVUploadDefaults.warnOnCumulativeReset
 			// If any file is added, it will count as edit made.
 			|| selectedFile !== null
 			|| invalidFileEntry === true;
@@ -670,6 +693,126 @@ export default function ReadingsCSVUploadComponent() {
 													return (<option value={key} key={key}>{translate(`TimeSortTypes.${key}`)}</option>);
 												})}
 											</Input>
+										</FormGroup>
+									</Col>
+								</Row>
+								<Row xs='1' lg='2'>
+									<Col>
+										<FormGroup>
+											<Label>
+												<div className='pb-1'>
+													{translate('meter.time.zone')}
+												</div>
+											</Label>
+											<TimeZoneSelect current={readingsData.timeZone ?? null} handleClick={timeZone => handleTimeZoneChange(timeZone)} />
+										</FormGroup>
+									</Col>
+									<Col>
+										<FormGroup>
+											<Label for='disableChecks'>
+												<div className='pb-1'>
+													{translate('meter.disableChecks')}
+												</div>
+											</Label>
+											<Input
+												type='select'
+												id='disableChecks'
+												name='disableChecks'
+												value={readingsData.disableChecks || DisableChecksType.reject_all}
+												onChange={e => {handleChange(e);}}
+											>
+												{Object.values(DisableChecksType).map(disableChecks => {
+													return (
+														<option value={disableChecks} key={disableChecks}>{translate(`DisableChecksType.${disableChecks}`)}</option>
+													);
+												})}
+											</Input>
+										</FormGroup>
+									</Col>
+								</Row>
+								<Row xs='1' lg='2'>
+									<Col>
+										<FormGroup>
+											<Label for='minVal'>
+												<div className='pb-1'>
+													{translate('meter.minVal')}
+												</div>
+											</Label>
+											<Input
+												type='number'
+												id='minVal'
+												name='minVal'
+												value={readingsData.minVal || ''}
+												onChange={e => {handleChange(e);}}
+											/>
+										</FormGroup>
+									</Col>
+									<Col>
+										<FormGroup>
+											<Label for='maxVal'>
+												<div className='pb-1'>
+													{translate('meter.maxVal')}
+												</div>
+											</Label>
+											<Input
+												type='number'
+												id='maxVal'
+												name='maxVal'
+												value={readingsData.maxVal || ''}
+												onChange={e => {handleChange(e);}}
+											/>
+										</FormGroup>
+									</Col>
+								</Row>
+								<Row xs='1' lg='2'>
+									<Col>
+										<FormGroup>
+											<Label for='minDate'>
+												<div className='pb-1'>
+													{translate('meter.minDate')}
+												</div>
+											</Label>
+											<Input
+												type='text'
+												id='minDate'
+												name='minDate'
+												value={readingsData.minDate || ''}
+												onChange={e => {handleChange(e);}}
+											/>
+										</FormGroup>
+									</Col>
+									<Col>
+										<FormGroup>
+											<Label for='maxDate'>
+												<div className='pb-1'>
+													{translate('meter.maxDate')}
+												</div>
+											</Label>
+											<Input
+												type='text'
+												id='maxDate'
+												name='maxDate'
+												value={readingsData.maxDate || ''}
+												onChange={e => {handleChange(e);}}
+											/>
+										</FormGroup>
+									</Col>
+								</Row>
+								<Row xs='1' lg='2'>
+									<Col>
+										<FormGroup>
+											<Label for='maxError'>
+												<div className='pb-1'>
+													{translate('meter.maxError')}
+												</div>
+											</Label>
+											<Input
+												type='number'
+												id='maxError'
+												name='maxError'
+												value={readingsData.maxError || ''}
+												onChange={e => {handleChange(e);}}
+											/>
 										</FormGroup>
 									</Col>
 								</Row>

--- a/src/client/app/types/csvUploadForm.ts
+++ b/src/client/app/types/csvUploadForm.ts
@@ -3,12 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { MeterTimeSortType } from '../types/redux/meters';
+import { DisableChecksType } from './redux/units';
 
 export interface CSVUploadPreferences {
 	meterIdentifier: string;
 	gzip: boolean;
 	headerRow: boolean;
 	update: boolean;
+	timeZone?: string;
+	minVal?: string;
+	maxVal?: string;
+	minDate?: string;
+	maxDate?: string;
+	maxError?: string;
+	disableChecks?: DisableChecksType;
 }
 
 export interface ReadingsCSVUploadPreferences extends CSVUploadPreferences {

--- a/src/client/app/utils/api/UploadCSVApi.ts
+++ b/src/client/app/utils/api/UploadCSVApi.ts
@@ -35,7 +35,9 @@ export const submitReadings = async (uploadPreferences: ReadingsCSVUploadPrefere
 		warnOnCumulativeReset: uploadPreferences.warnOnCumulativeReset
 	};
 	for (const [preference, value] of Object.entries(uploadPreferencesForm)) {
-		formData.append(preference, value.toString());
+		if (value !== undefined && value !== null) {
+			formData.append(preference, value.toString());
+		}
 	}
 	formData.append('csvfile', readingsFile); // It is important for the server that the file is attached last.
 
@@ -61,7 +63,9 @@ export const submitMeters = async (uploadPreferences: MetersCSVUploadPreferences
 		update: uploadPreferences.update
 	};
 	for (const [preference, value] of Object.entries(uploadPreferencesForm)) {
-		formData.append(preference, value.toString());
+		if (value !== undefined && value !== null) {
+			formData.append(preference, value.toString());
+		}
 	}
 	formData.append('csvfile', metersFile); // It is important for the server that the file is attached last.
 

--- a/src/client/app/utils/csvUploadDefaults.ts
+++ b/src/client/app/utils/csvUploadDefaults.ts
@@ -2,6 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { DisableChecksType } from 'types/redux/units';
 import { ReadingsCSVUploadPreferences, MetersCSVUploadPreferences } from '../types/csvUploadForm';
 import { MeterTimeSortType } from '../types/redux/meters';
 
@@ -25,7 +26,14 @@ export const ReadingsCSVUploadDefaults: ReadingsCSVUploadPreferences = {
 	timeSort: MeterTimeSortType.increasing,
 	update: false,
 	useMeterZone: false,
-	warnOnCumulativeReset: false
+	warnOnCumulativeReset: false,
+	timeZone: "",
+	minVal: "",
+	maxVal: "",
+	minDate: "",
+	maxDate: "",
+	maxError: "",
+	disableChecks: DisableChecksType.reject_all,
 };
 
 export const MetersCSVUploadDefaults: MetersCSVUploadPreferences = {

--- a/src/client/app/utils/csvUploadDefaults.ts
+++ b/src/client/app/utils/csvUploadDefaults.ts
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { DisableChecksType } from 'types/redux/units';
+import { DisableChecksType } from '../types/redux/units';
 import { ReadingsCSVUploadPreferences, MetersCSVUploadPreferences } from '../types/csvUploadForm';
 import { MeterTimeSortType } from '../types/redux/meters';
 
@@ -27,13 +27,13 @@ export const ReadingsCSVUploadDefaults: ReadingsCSVUploadPreferences = {
 	update: false,
 	useMeterZone: false,
 	warnOnCumulativeReset: false,
-	timeZone: "",
-	minVal: "",
-	maxVal: "",
-	minDate: "",
-	maxDate: "",
-	maxError: "",
-	disableChecks: DisableChecksType.reject_all,
+	timeZone: '',
+	minVal: '',
+	maxVal: '',
+	minDate: '',
+	maxDate: '',
+	maxError: '',
+	disableChecks: DisableChecksType.reject_all
 };
 
 export const MetersCSVUploadDefaults: MetersCSVUploadPreferences = {

--- a/src/scripts/installOED.sh
+++ b/src/scripts/installOED.sh
@@ -52,10 +52,20 @@ while test $# -gt 0; do
 	esac
 done
 
-# Load .env if it exists
-
+# Load .env if it exists, but do not overwrite values already provided by the
+# runtime environment (for example from Docker Compose).
 if [ -f ".env" ]; then
-	source .env
+	while IFS='=' read -r name value; do
+		case "$name" in
+			''|'#'*)
+				continue
+				;;
+		esac
+
+		if [ -z "${!name+x}" ]; then
+			export "$name=$value"
+		fi
+	done < .env
 fi
 
 # Skip the install if the node_modules were installed before the package files.

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -67,7 +67,7 @@ function swapConnection(newConfig, newConnection) {
 	if (newConnection !== null) {
 		connmanager.connection = newConnection;
 	} else {
-		connmanager = getDB(connmanager.config);
+		connmanager.connection = getDB(connmanager.config);
 	}
 }
 

--- a/src/server/log.js
+++ b/src/server/log.js
@@ -4,10 +4,21 @@
 
 const fs = require('fs');
 const logFile = require('./config').logFile;
-const LogEmail = require('./models/LogEmail');
-const LogMsg = require('./models/LogMsg');
-const { getConnection } = require('./db');
 const moment = require('moment');
+
+/**
+ * Get a database connection if the database module is available.
+ * Logging should still work even if the database is unavailable, so this
+ * intentionally falls back to null instead of throwing.
+ * @returns {object|null}
+ */
+function getConnection() {
+	try {
+		return require('./db').getConnection();
+	} catch (err) {
+		return null;
+	}
+}
 
 /**
  * Represents the importance of a message to be logged
@@ -55,6 +66,8 @@ class Logger {
 		let messageToLog = `[${level.name}@${logTime.format('YYYY-MM-DDTHH:mm:ss.SSSZ')}] ${message}\n`;
 
 		const conn = getConnection();
+		const LogEmail = require('./models/LogEmail');
+		const LogMsg = require('./models/LogMsg');
 
 		// Add a stacktrace to the message if one was provided.
 		if (error !== null) {
@@ -169,10 +182,10 @@ const defaultLogger = new Logger(logFile);
  * Wherever logging is available, the Node.js runtime will call this function to log unhandled rejections.
  * This helps with debugging, especially in tests.
  */
-process.on('unhandledRejection', (reason, p) => {
-	p.catch(e => {
-		defaultLogger.error(`Unhandled Promise Rejection: ${reason}`, e);
-	});
+
+process.on('unhandledRejection', (reason) => {
+	const message = reason instanceof Error ? reason.message : String(reason);
+	defaultLogger.error(`Unhandled Promise Rejection: ${message}`, reason instanceof Error ? reason : null);
 });
 
 defaultLogger.logToDb = true;

--- a/src/server/services/csvPipeline/uploadReadings.js
+++ b/src/server/services/csvPipeline/uploadReadings.js
@@ -18,7 +18,8 @@ const Meter = require('../../models/Meter');
  */
 async function uploadReadings(req, res, filepath, conn) {
 	// extract query parameters
-	const { meterIdentifier, meterName, headerRow, update, honorDst, relaxedParsing, useMeterZone, warnOnCumulativeReset } = req.body;
+	const { meterIdentifier, meterName, headerRow, update, honorDst, relaxedParsing, useMeterZone, warnOnCumulativeReset,
+		timeZone, minVal, maxVal, minDate, maxDate, maxError, disableChecks } = req.body;
 	// The next few have no value in the DB for a meter so always use the value passed.
 	const hasHeaderRow = normalizeBoolean(headerRow);
 	const shouldUpdate = normalizeBoolean(update);
@@ -188,16 +189,25 @@ async function uploadReadings(req, res, filepath, conn) {
 	}
 	const areReadingsEndOnly = readingEndOnly;
 
+	const isMissingParam = param => param === undefined || param === '';
+	const resolvedTimeZone = isMissingParam(timeZone) ? meter.meterTimezone : timeZone;
+	const resolvedMinVal = isMissingParam(minVal) ? meter.minVal : parseFloat(minVal);
+	const resolvedMaxVal = isMissingParam(maxVal) ? meter.maxVal : parseFloat(maxVal);
+	const resolvedMinDate = isMissingParam(minDate) ? meter.minDate : new Date(minDate);
+	const resolvedMaxDate = isMissingParam(maxDate) ? meter.maxDate : new Date(maxDate);
+	const resolvedMaxError = isMissingParam(maxError) ? meter.maxError : parseInt(maxError, 10);
+	const resolvedDisableChecks = isMissingParam(disableChecks) ? meter.disableChecks : disableChecks;
+
 	const mapRowToModel = row => { return row; }; // STUB function to satisfy the parameter of loadCsvInput.
 
 	const conditionSet = {
-		minVal: meter.minVal,
-		maxVal: meter.maxVal,
-		minDate: meter.minDate,
-		maxDate: meter.maxDate,
-		threshold: meter.readingGap,
-		maxError: meter.maxError,
-		disableChecks: meter.disableChecks
+		minVal: resolvedMinVal,
+		maxVal: resolvedMaxVal,
+		minDate: resolvedMinDate,
+		maxDate: resolvedMaxDate,
+		threshold: readingGap,
+		maxError: resolvedMaxError,
+		disableChecks: resolvedDisableChecks
 	}
 
 	return await loadCsvInput(
@@ -220,7 +230,8 @@ async function uploadReadings(req, res, filepath, conn) {
 		shouldHonorDst,
 		shouldRelaxedParsing,
 		shouldUseMeterZone,
-		shouldWarnOnCumulativeReset
+		shouldWarnOnCumulativeReset,
+		resolvedTimeZone
 	); // load csv data
 }
 

--- a/src/server/services/csvPipeline/validateCsvUploadParams.js
+++ b/src/server/services/csvPipeline/validateCsvUploadParams.js
@@ -19,6 +19,13 @@ MeterTimeSortTypesJS = Object.freeze({
 	decreasing: 'decreasing',
 });
 
+DisableChecksTypesJS = Object.freeze({
+	reject_disabled: 'reject_disabled',
+	reject_bad: 'reject_bad',
+	reject_all: 'reject_all',
+	reject_none: 'reject_none'
+});
+
 // This function allows for curl users to continue to use 'yes' or 'no' and also allows string
 // values of true or false if the change is made.
 const normalizeBoolean = (input) => {
@@ -64,6 +71,13 @@ const DEFAULTS = {
 	meters: {
 	},
 	readings: {
+		timeZone: undefined,
+		minVal: undefined,
+		maxVal: undefined,
+		minDate: undefined,
+		maxDate: undefined,
+		maxError: undefined,
+		disableChecks: undefined,
 		cumulative: undefined,
 		cumulativeReset: undefined,
 		cumulativeResetStart: undefined,
@@ -115,6 +129,13 @@ const VALIDATION = {
 		type: 'object',
 		properties: {
 			...COMMON_PROPERTIES,
+			timeZone: new StringParam('timeZone', undefined, undefined),
+			minVal: new StringParam('minVal', undefined, undefined),
+			maxVal: new StringParam('maxVal', undefined, undefined),
+			minDate: new StringParam('minDate', undefined, undefined),
+			maxDate: new StringParam('maxDate', undefined, undefined),
+			maxError: new StringParam('maxError', undefined, undefined),
+			disableChecks: new EnumParam('disableChecks', Object.values(DisableChecksTypesJS)),
 			cumulative: new EnumParam('cumulative', BooleanCheckArray),
 			cumulativeReset: new EnumParam('cumulativeReset', BooleanCheckArray),
 			cumulativeResetStart: new StringParam('cumulativeResetStart', undefined, undefined),
@@ -182,10 +203,32 @@ function validateReadingsCsvUploadParams(req, res, next) {
 	}
 
 	// extract query parameters
-	const { cumulative, cumulativeReset, duplications, gzip, headerRow, timeSort, update, honorDst,
+	const { timeZone, minVal, maxVal, minDate, maxDate, maxError, disableChecks,
+		cumulative, cumulativeReset, duplications, gzip, headerRow, timeSort, update, honorDst,
 		refreshReadings, relaxedParsing, useMeterZone, warnOnCumulativeReset } = req.body;
 
 	// Set default values of not supplied parameters.
+	if (timeZone === undefined) {
+		req.body.timeZone = DEFAULTS.readings.timeZone;
+	}
+	if (minVal === undefined) {
+		req.body.minVal = DEFAULTS.readings.minVal;
+	}
+	if (maxVal === undefined) {
+		req.body.maxVal = DEFAULTS.readings.maxVal;
+	}
+	if (minDate === undefined) {
+		req.body.minDate = DEFAULTS.readings.minDate;
+	}
+	if (maxDate === undefined) {
+		req.body.maxDate = DEFAULTS.readings.maxDate;
+	}
+	if (maxError === undefined) {
+		req.body.maxError = DEFAULTS.readings.maxError;
+	}
+	if (disableChecks === undefined) {
+		req.body.disableChecks = DEFAULTS.readings.disableChecks;
+	}
 	if (cumulative === undefined) {
 		req.body.cumulative = DEFAULTS.readings.cumulative;
 	}

--- a/src/server/services/csvPipeline/validateCsvUploadParams.js
+++ b/src/server/services/csvPipeline/validateCsvUploadParams.js
@@ -7,6 +7,7 @@ const { CSVPipelineError } = require('./CustomErrors');
 const { Param, EnumParam, BooleanParam, StringParam } = require('./ValidationSchemas');
 const failure = require('./failure');
 const validate = require('jsonschema').validate;
+const Unit = require('../../models/Unit');
 
 // This is only used for meter page inputs but put here so next one above that related to.
 /**
@@ -17,13 +18,6 @@ const validate = require('jsonschema').validate;
 MeterTimeSortTypesJS = Object.freeze({
 	increasing: 'increasing',
 	decreasing: 'decreasing',
-});
-
-DisableChecksTypesJS = Object.freeze({
-	reject_disabled: 'reject_disabled',
-	reject_bad: 'reject_bad',
-	reject_all: 'reject_all',
-	reject_none: 'reject_none'
 });
 
 // This function allows for curl users to continue to use 'yes' or 'no' and also allows string
@@ -135,7 +129,7 @@ const VALIDATION = {
 			minDate: new StringParam('minDate', undefined, undefined),
 			maxDate: new StringParam('maxDate', undefined, undefined),
 			maxError: new StringParam('maxError', undefined, undefined),
-			disableChecks: new EnumParam('disableChecks', Object.values(DisableChecksTypesJS)),
+			disableChecks: new EnumParam('disableChecks', Object.values(Unit.disableChecksType)),
 			cumulative: new EnumParam('cumulative', BooleanCheckArray),
 			cumulativeReset: new EnumParam('cumulativeReset', BooleanCheckArray),
 			cumulativeResetStart: new StringParam('cumulativeResetStart', undefined, undefined),

--- a/src/server/services/csvPipeline/validateCsvUploadParams.js
+++ b/src/server/services/csvPipeline/validateCsvUploadParams.js
@@ -65,13 +65,6 @@ const DEFAULTS = {
 	meters: {
 	},
 	readings: {
-		timeZone: undefined,
-		minVal: undefined,
-		maxVal: undefined,
-		minDate: undefined,
-		maxDate: undefined,
-		maxError: undefined,
-		disableChecks: undefined,
 		cumulative: undefined,
 		cumulativeReset: undefined,
 		cumulativeResetStart: undefined,
@@ -85,7 +78,14 @@ const DEFAULTS = {
 		relaxedParsing: false,
 		timeSort: undefined,
 		useMeterZone: false,
-		warnOnCumulativeReset: false
+		warnOnCumulativeReset: false,
+		timeZone: undefined,
+		minVal: undefined,
+		maxVal: undefined,
+		minDate: undefined,
+		maxDate: undefined,
+		maxError: undefined,
+		disableChecks: undefined
 	}
 }
 
@@ -123,13 +123,6 @@ const VALIDATION = {
 		type: 'object',
 		properties: {
 			...COMMON_PROPERTIES,
-			timeZone: new StringParam('timeZone', undefined, undefined),
-			minVal: new StringParam('minVal', undefined, undefined),
-			maxVal: new StringParam('maxVal', undefined, undefined),
-			minDate: new StringParam('minDate', undefined, undefined),
-			maxDate: new StringParam('maxDate', undefined, undefined),
-			maxError: new StringParam('maxError', undefined, undefined),
-			disableChecks: new EnumParam('disableChecks', Object.values(Unit.disableChecksType)),
 			cumulative: new EnumParam('cumulative', BooleanCheckArray),
 			cumulativeReset: new EnumParam('cumulativeReset', BooleanCheckArray),
 			cumulativeResetStart: new StringParam('cumulativeResetStart', undefined, undefined),
@@ -144,6 +137,13 @@ const VALIDATION = {
 			timeSort: new EnumParam('timeSort', [MeterTimeSortTypesJS.increasing, MeterTimeSortTypesJS.decreasing]),
 			useMeterZone: new EnumParam('useMeterZone', BooleanCheckArray),
 			warnOnCumulativeReset: new EnumParam('warnOnCumulativeReset', BooleanCheckArray),
+			timeZone: new StringParam('timeZone', undefined, undefined),
+			minVal: new StringParam('minVal', undefined, undefined),
+			maxVal: new StringParam('maxVal', undefined, undefined),
+			minDate: new StringParam('minDate', undefined, undefined),
+			maxDate: new StringParam('maxDate', undefined, undefined),
+			maxError: new StringParam('maxError', undefined, undefined),
+			disableChecks: new EnumParam('disableChecks', Object.values(Unit.disableChecksType))
 		},
 		anyOf: [
 			{ required: ['meterIdentifier'] },
@@ -197,32 +197,11 @@ function validateReadingsCsvUploadParams(req, res, next) {
 	}
 
 	// extract query parameters
-	const { timeZone, minVal, maxVal, minDate, maxDate, maxError, disableChecks,
-		cumulative, cumulativeReset, duplications, gzip, headerRow, timeSort, update, honorDst,
-		refreshReadings, relaxedParsing, useMeterZone, warnOnCumulativeReset } = req.body;
+	const { cumulative, cumulativeReset, duplications, gzip, headerRow, timeSort, update, honorDst,
+		refreshReadings, relaxedParsing, useMeterZone, warnOnCumulativeReset, timeZone, minVal,
+		maxVal, minDate, maxDate, maxError, disableChecks } = req.body;
 
 	// Set default values of not supplied parameters.
-	if (timeZone === undefined) {
-		req.body.timeZone = DEFAULTS.readings.timeZone;
-	}
-	if (minVal === undefined) {
-		req.body.minVal = DEFAULTS.readings.minVal;
-	}
-	if (maxVal === undefined) {
-		req.body.maxVal = DEFAULTS.readings.maxVal;
-	}
-	if (minDate === undefined) {
-		req.body.minDate = DEFAULTS.readings.minDate;
-	}
-	if (maxDate === undefined) {
-		req.body.maxDate = DEFAULTS.readings.maxDate;
-	}
-	if (maxError === undefined) {
-		req.body.maxError = DEFAULTS.readings.maxError;
-	}
-	if (disableChecks === undefined) {
-		req.body.disableChecks = DEFAULTS.readings.disableChecks;
-	}
 	if (cumulative === undefined) {
 		req.body.cumulative = DEFAULTS.readings.cumulative;
 	}
@@ -258,6 +237,27 @@ function validateReadingsCsvUploadParams(req, res, next) {
 	}
 	if (warnOnCumulativeReset === undefined) {
 		req.body.warnOnCumulativeReset = DEFAULTS.readings.warnOnCumulativeReset;
+	}
+	if (timeZone === undefined) {
+		req.body.timeZone = DEFAULTS.readings.timeZone;
+	}
+	if (minVal === undefined) {
+		req.body.minVal = DEFAULTS.readings.minVal;
+	}
+	if (maxVal === undefined) {
+		req.body.maxVal = DEFAULTS.readings.maxVal;
+	}
+	if (minDate === undefined) {
+		req.body.minDate = DEFAULTS.readings.minDate;
+	}
+	if (maxDate === undefined) {
+		req.body.maxDate = DEFAULTS.readings.maxDate;
+	}
+	if (maxError === undefined) {
+		req.body.maxError = DEFAULTS.readings.maxError;
+	}
+	if (disableChecks === undefined) {
+		req.body.disableChecks = DEFAULTS.readings.disableChecks;
 	}
 	next();
 }

--- a/src/server/services/pipeline-in-progress/loadArrayInput.js
+++ b/src/server/services/pipeline-in-progress/loadArrayInput.js
@@ -33,10 +33,19 @@ const processData = require('./processData');
  * @param {string} timeZone timezone to use while processing data, default is undefined.
  * @returns {object[]} {whether readings were all process (true) or false, all the messages from processing the readings as a string}
  */
+// NOTE (follow-up): Callers of this function sometimes omit optional trailing
+// parameters (for example `timeZone`). This works because JS allows omitted
+// trailing args, but it makes call sites inconsistent and harder to maintain.
+// Suggested follow-up: migrate to a single `options` object (e.g.
+// `loadArrayInput(dataRows, meterID, mapRowToModel, opts)`) or mandate
+// explicitly passing all arguments. Do NOT remove `timeZone` or other
+// parameters here in this PR — perform a backward-compatible refactor in a
+// separate change to avoid regressions.
+
 async function loadArrayInput(dataRows, meterID, mapRowToModel, timeSort, readingRepetition, isCumulative,
 	cumulativeReset, cumulativeResetStart, cumulativeResetEnd, readingGap, readingLengthVariation, isEndOnly,
-	shouldUpdate, conditionSet, conn, honorDst = false, relaxedParsing = false, useMeterZone = 
-	false, warnOnCumulativeReset = false, timeZone = undefined) {
+	shouldUpdate, conditionSet, conn, honorDst = false, relaxedParsing = false, useMeterZone = false,
+	warnOnCumulativeReset = false, timeZone = undefined) {
 	// Get the reading, then process them for acceptance and finally insert into the DB.
 	readingsArray = dataRows.map(mapRowToModel);
 	let { result: readingsToInsert, isAllReadingsOk, msgTotal } = await processData(readingsArray, meterID, timeSort, readingRepetition,

--- a/src/server/services/pipeline-in-progress/loadArrayInput.js
+++ b/src/server/services/pipeline-in-progress/loadArrayInput.js
@@ -30,16 +30,17 @@ const processData = require('./processData');
  * @param {boolean} useMeterZone true if the readings are switched to the time zone (meter then site then server)), default if false.
  *   Should only be true if honorDST is true and reading does not have proper time zone information.
  * @param {boolean} warnOnCumulativeReset true if a warning is shown for each reset with cumulative data. cumulative must be true. default is false.
+ * @param {string} timeZone optional timezone override provided by the upload request.
  * @returns {object[]} {whether readings were all process (true) or false, all the messages from processing the readings as a string}
  */
 async function loadArrayInput(dataRows, meterID, mapRowToModel, timeSort, readingRepetition, isCumulative,
 	cumulativeReset, cumulativeResetStart, cumulativeResetEnd, readingGap, readingLengthVariation, isEndOnly,
-	shouldUpdate, conditionSet, conn, honorDst = false, relaxedParsing = false, useMeterZone = false, warnOnCumulativeReset = false) {
+	shouldUpdate, conditionSet, conn, honorDst = false, relaxedParsing = false, useMeterZone = false, warnOnCumulativeReset = false, timeZone = undefined) {
 	// Get the reading, then process them for acceptance and finally insert into the DB.
 	readingsArray = dataRows.map(mapRowToModel);
 	let { result: readingsToInsert, isAllReadingsOk, msgTotal } = await processData(readingsArray, meterID, timeSort, readingRepetition,
 		isCumulative, cumulativeReset, cumulativeResetStart, cumulativeResetEnd, readingGap, readingLengthVariation, isEndOnly,
-		conditionSet, conn, honorDst, relaxedParsing, useMeterZone, warnOnCumulativeReset);
+		conditionSet, conn, honorDst, relaxedParsing, useMeterZone, warnOnCumulativeReset, timeZone);
 	if (shouldUpdate) {
 		// New readings should replace old ones.
 		await Reading.insertOrUpdateAll(readingsToInsert, conn)

--- a/src/server/services/pipeline-in-progress/loadArrayInput.js
+++ b/src/server/services/pipeline-in-progress/loadArrayInput.js
@@ -30,12 +30,13 @@ const processData = require('./processData');
  * @param {boolean} useMeterZone true if the readings are switched to the time zone (meter then site then server)), default if false.
  *   Should only be true if honorDST is true and reading does not have proper time zone information.
  * @param {boolean} warnOnCumulativeReset true if a warning is shown for each reset with cumulative data. cumulative must be true. default is false.
- * @param {string} timeZone optional timezone override provided by the upload request.
+ * @param {string} timeZone timezone to use while processing data, default is undefined.
  * @returns {object[]} {whether readings were all process (true) or false, all the messages from processing the readings as a string}
  */
 async function loadArrayInput(dataRows, meterID, mapRowToModel, timeSort, readingRepetition, isCumulative,
 	cumulativeReset, cumulativeResetStart, cumulativeResetEnd, readingGap, readingLengthVariation, isEndOnly,
-	shouldUpdate, conditionSet, conn, honorDst = false, relaxedParsing = false, useMeterZone = false, warnOnCumulativeReset = false, timeZone = undefined) {
+	shouldUpdate, conditionSet, conn, honorDst = false, relaxedParsing = false, useMeterZone = 
+	false, warnOnCumulativeReset = false, timeZone = undefined) {
 	// Get the reading, then process them for acceptance and finally insert into the DB.
 	readingsArray = dataRows.map(mapRowToModel);
 	let { result: readingsToInsert, isAllReadingsOk, msgTotal } = await processData(readingsArray, meterID, timeSort, readingRepetition,

--- a/src/server/services/pipeline-in-progress/loadCsvInput.js
+++ b/src/server/services/pipeline-in-progress/loadCsvInput.js
@@ -32,7 +32,7 @@ const { log } = require('../../log');
  * @param {boolean} useMeterZone true if the readings are switched to the time zone (meter then site then server)), default if false.
  *   Should only be true if honorDST is true and reading does not have proper time zone information.
  * @param {boolean} warnOnCumulativeReset true if a warning is shown for each reset with cumulative data. cumulative must be true. default is false.
- * @param {string} timeZone optional timezone override provided by the upload request.
+ * @param {string} timeZone timezone to use while processing data, default is undefined.
  */
 async function loadCsvInput(
 	filePath,

--- a/src/server/services/pipeline-in-progress/loadCsvInput.js
+++ b/src/server/services/pipeline-in-progress/loadCsvInput.js
@@ -32,6 +32,7 @@ const { log } = require('../../log');
  * @param {boolean} useMeterZone true if the readings are switched to the time zone (meter then site then server)), default if false.
  *   Should only be true if honorDST is true and reading does not have proper time zone information.
  * @param {boolean} warnOnCumulativeReset true if a warning is shown for each reset with cumulative data. cumulative must be true. default is false.
+ * @param {string} timeZone optional timezone override provided by the upload request.
  */
 async function loadCsvInput(
 	filePath,
@@ -53,14 +54,15 @@ async function loadCsvInput(
 	honorDst = false,
 	relaxedParsing = false,
 	useMeterZone = false,
-	warnOnCumulativeReset = false
+	warnOnCumulativeReset = false,
+	timeZone = undefined
 ) {
 	try {
 		const dataRows = await readCsv(filePath, headerRow);
 		return loadArrayInput(dataRows, meterID, mapRowToModel, timeSort, readingRepetition,
 			isCumulative, cumulativeReset, cumulativeResetStart, cumulativeResetEnd,
 			readingGap, readingLengthVariation, isEndOnly, shouldUpdate, conditionSet, conn,
-			honorDst, relaxedParsing, useMeterZone, warnOnCumulativeReset);
+			honorDst, relaxedParsing, useMeterZone, warnOnCumulativeReset, timeZone);
 	} catch (err) {
 		log.error(`Error updating meter ${meterID} with data from ${filePath}: ${err}`, err);
 	}

--- a/src/server/services/pipeline-in-progress/processData.js
+++ b/src/server/services/pipeline-in-progress/processData.js
@@ -65,7 +65,8 @@ const E0 = moment(0).utc()
  */
 async function processData(rows, meterID, timeSort = MeterTimeSortTypesJS.increasing, readingRepetition, isCumulative, cumulativeReset,
 	resetStart = '00:00:00.000', resetEnd = '23:59:99.999', readingGap = 0, readingLengthVariation = 0, isEndTime = false,
-	conditionSet, conn, honorDst = false, relaxedParsing = false, useMeterZone = false, warnOnCumulativeReset = false, useMeterFrequency = false, useMeterFrequencyVariation = 0) {
+	conditionSet, conn, honorDst = false, relaxedParsing = false, useMeterZone = false, warnOnCumulativeReset = false,
+	timeZone = undefined, useMeterFrequency = false, useMeterFrequencyVariation = 0) {
 	// Holds all the warning message to pass back to inform user.
 	// Note they use basic HTML because the messages can be long/complex and it was felt it would be easy to put it into a web browser
 	// to make them easier to read.
@@ -125,7 +126,7 @@ async function processData(rows, meterID, timeSort = MeterTimeSortTypesJS.increa
 	// These only happen if worried about DST.
 	if (honorDst) {
 		// Get the meter timezone since the same while processing this data.
-		meterZone = await meterTimezone(meter);
+		meterZone = (timeZone !== undefined && timeZone !== '') ? timeZone : await meterTimezone(meter);
 		// See if were processing a shift from DST (inDst) when last batch of readings ended so need to continue.
 		prevEndTimestamp = moment.parseZone(meter.previousEnd, true);
 		if (!isFirst(prevEndTimestamp)) {

--- a/src/server/services/pipeline-in-progress/processData.js
+++ b/src/server/services/pipeline-in-progress/processData.js
@@ -53,6 +53,7 @@ const E0 = moment(0).utc()
  *   Should only be true if honorDST is true and reading does not have proper time zone information. This feature is not great and should
  *   be avoided except in special circumstances.
  * @param {boolean} warnOnCumulativeReset true if each cumulative reset generates a warning message and false if not. Default is false.
+ * @param {string} timeZone timezone to use while processing data, default is undefined.
  * @param {boolean} useMeterFrequency true if isEndTime is true then any reading found with a different reading length that is longer than the meter
  * 	frequency will make the start time by the end time minus the meter reading frequency. The idea is that a change in the length represents
  * 	missing reading(s) then it will have a longer time but that is not what is desired for this meter. This only happens if the length of the reading


### PR DESCRIPTION
# Description

This PR adds support for overriding meter-based CSV upload parameters (timeZone, minVal, maxVal, minDate, maxDate, maxError, disableChecks) directly from the readings upload UI and ensures these values are respected throughout the backend pipeline.

Previously, the CSV upload pipeline always relied on meter values for validation and condition checks. This change updates the system so that:

Values provided in the request (req.body) are used as the source of truth
Meter values are only used as a fallback when parameters are missing (e.g., direct/script uploads)

Fixes #1519

Status: WIP

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

- Validation behavior for empty strings vs. undefined values is inconsistent across the existing codebase and was not modified in this PR. 
- This may be addressed in a future issue.
- Automated UI testing is not yet available in OED, so frontend behavior was verified manually.
- Documentation updates for the new parameters are out of scope for this PR and can be handled in a future effort.
