### PR TITLE
Second Docker File for Development

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,7 +2,6 @@
 # * This Source Code Form is subject to the terms of the Mozilla Public
 # * License, v. 2.0. If a copy of the MPL was not distributed with this
 # * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-# *
 
 # *****************************************************************
 # This is the DEVELOPER Docker configuration file that is used for
@@ -21,7 +20,6 @@ services:
         # They can be commented out to close that port but it will stop that type of debugging.
         ports:
            - "5432:5432"
-
     web:
         environment:
             # Set this value to yes or no, other values wil result in a configuration error.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -25,6 +25,12 @@ services:
             # Set this value to yes or no, other values wil result in a configuration error.
             # Unless you are testing a production setup, this is normally no.
             - OED_PRODUCTION=no
+            # This is to let the install know that the second, developer docker file was used.
+            # It is mostly as a safety check and during the transition to warn developers to
+            # transition to the new system. It should NOT be changed.
+            # The value is not set in the production config file to avoid someone wanting to
+            # set it there and that is not desired.
+            - OED_DOCKER_CONFIG_DEV=yes
         ports:
             # If you are experiencing port conflicts with 3000 then you can modify this to
             # use another port. For example, to switch to port xxxx you would do:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -4,11 +4,65 @@
 # * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # *
 
+# *****************************************************************
+# This is the DEVELOPER Docker configuration file that is used for
+# developers. It should NOT be used for production sites as that
+# can introduce security issues. Developers should start OED with:
+# docker compose -f docker-compose.yml -f docker-compose-dev.yml up
+# or an appropriate variant to cause the values in this file to override
+# the ones in the default docker file.
+# *****************************************************************
+
 version: "3.8"
 services:
+    database:
+        # The next lines enable access to the PostgreSQL server from the host machine.
+        # It can be very valuable for debugging the database via tools such as PGAdmin.
+        # They can be commented out to close that port but it will stop that type of debugging.
+        ports:
+           - "5432:5432"
+
     web:
         environment:
+            # Set this value to yes or no, other values wil result in a configuration error.
+            # Unless you are testing a production setup, this is normally no.
             - OED_PRODUCTION=no
         ports:
+            # If you are experiencing port conflicts with 3000 then you can modify this to
+            # use another port. For example, to switch to port xxxx you would do:
+            # "xxxx:3000"
             - "3000:3000"
+            # This enables debugging as a developer.
             - "9229:9229"
+        command:
+            [
+                "bash",
+                "./src/scripts/installOED.sh",
+                # This allows for starting OED with special values for a developer.
+                # See developer docs for details.
+                "${install_args:-}"
+            ]
+
+    # Cypress testing service
+    # This is used for UI testing and normally only creates this Docker container
+    # if you specially start up UI testing.
+    cypress:
+      image: cypress/included
+      profiles:
+        - ui-testing
+      environment:
+        - CYPRESS_BASE_URL=http://web:3000
+        - DISPLAY=:99
+      working_dir: /usr/src/app
+      depends_on:
+        web:
+          condition: service_healthy
+      volumes:
+        - ./:/usr/src/app
+      entrypoint: >
+        /bin/sh -c "
+        rm -f /tmp/.X99-lock &&
+        Xvfb :99 -screen 0 1024x768x16"
+      read_only: true
+      security_opt:
+        - no-new-privileges:true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,14 @@
+# *
+# * This Source Code Form is subject to the terms of the Mozilla Public
+# * License, v. 2.0. If a copy of the MPL was not distributed with this
+# * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# *
+
+version: "3.8"
+services:
+    web:
+        environment:
+            - OED_PRODUCTION=no
+        ports:
+            - "3000:3000"
+            - "9229:9229"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,13 @@ services:
         environment:
             # Custom PGDATA per recommendations from official Docker page
             - PGDATA=/var/lib/postgresql/data/pgdata
-            - POSTGRES_PASSWORD=pleaseChange # default postgres password that should be changed for security.
+            # The postgres database will only pull from this value on the first
+            # startup of OED. If a change is desired after this, one must 
+            # run the following command in the docker web terminal:
+            # "npm run changePostgresPassword -- postgrespassword oedpassword"
+            # Replace "postgrespassword" with your desired postgres user password
+            # and "oedpassword" with your desired oed user password.
+            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pleaseChange}
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:
@@ -29,15 +35,15 @@ services:
     web:
         # Configuration variables for the app.
         environment:
-            - OED_PRODUCTION=no
+            - OED_PRODUCTION=yes # Set this value to yes or no, other values will result in a configuration error
             - OED_SERVER_PORT=3000
             - OED_DB_USER=oed
             - OED_DB_DATABASE=oed
             - OED_DB_TEST_DATABASE=oed_testing
-            - OED_DB_PASSWORD=opened
+            - OED_DB_PASSWORD=${OED_DB_PASSWORD:-opened} # See comment regarding POSTGRES_PASSWORD above, same situation
             - OED_DB_HOST=database # Docker will set this hostname
             - OED_DB_PORT=5432
-            - OED_TOKEN_SECRET=?
+            - OED_TOKEN_SECRET=${OED_TOKEN_SECRET:-?} #Automatically generated when OED is run in production
             - OED_LOG_FILE=log.txt
             - OED_MAIL_METHOD=none # Method of sending mail. Supports "secure-smtp", "none". Case insensitive.
             - OED_MAIL_SMTP=smtp.example.com # Edit this
@@ -54,6 +60,7 @@ services:
             # If in a subdirectory, set it here
             # - OED_SUBDIR=/subdir/
             # Set the correct build environment.
+            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pleaseChange}
         build:
             context: ./
             dockerfile: ./containers/web/Dockerfile
@@ -67,7 +74,7 @@ services:
         # Map the default port.
         ports:
             - "3000:3000" # Should be commented out if you uncomment 80:3000 below.
-            - "9229:9229" # Debug port, should be commented out for production
+            # - "9229:9229" # Debug port, should be commented out for production
             # For production you might want something like:
             # - "80:3000"
             # and comment out the debug port and 3000:3000 line above
@@ -111,7 +118,3 @@ services:
         /bin/sh -c "
         rm -f /tmp/.X99-lock &&
         Xvfb :99 -screen 0 1024x768x16"
-      read_only: true
-      security_opt:
-        - no-new-privileges:true
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@
 # * This Source Code Form is subject to the terms of the Mozilla Public
 # * License, v. 2.0. If a copy of the MPL was not distributed with this
 # * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-# *
 
 # *****************************************************************
 # This is the default Docker configuration file that is used for
@@ -17,17 +16,20 @@ version: "3.8"
 services:
     # Database service. It's PostgreSQL, see the Dockerfile in ./database.
     database:
-        build: ./containers/database/
         environment:
-            # Custom PGDATA per recommendations from official Docker page
-            - PGDATA=/var/lib/postgresql/data/pgdata
             # Default postgres password that should be changed for security.
             # The OED install process will not allow this password and it will
-            # be replaced with a random, secure password if not changed here. That is fine as
-            # many sites do not need access to the database.
+            # be replaced with a random, secure password if not changed here.
+            # That is fine as many sites do not need regular access to the
+            # database so a password they created is not important. OED will
+            # provide the password created for future use.
             # If the password is changed then it is important to make it secure to
             # avoid unauthorized access.
             - POSTGRES_PASSWORD=pleaseChange
+            # Custom PGDATA per recommendations from official Docker page
+            - PGDATA=/var/lib/postgresql/data/pgdata
+        # Location of database Docker configuration and startup files.
+        build: ./containers/database/
         volumes:
             # This maps the proper Docker database directory back to the local file
             # system. It is critical that the changes actually be written back to
@@ -41,11 +43,41 @@ services:
             interval: 10s
             timeout: 10s
             retries: 3
-        # Web service runs Node
+    # Web service runs Node
     web:
         # Configuration variables for the app.
         environment:
-            # OED_PRODUCTION should NEVER be changed here. If this is for an OED site then
+            # Default oed user postgres password that should be changed for security.
+            # The OED install process will not allow this password and it will
+            # be replaced with a random, secure password if not changed here.
+            # That is fine as many sites do not need regular access to the
+            # database so a password they created is not important. OED will
+            # provide the password created for future use.
+            # If the password is changed then it is important to make it secure to
+            # avoid unauthorized access.
+            - OED_DB_PASSWORD=opened
+            # Default web token that should be changed for security.
+            # The OED install process will not allow this token and it will
+            # be replaced with a random, secure token if not changed.
+            # That is fine as there is normally no usage outside of the OED app for this.
+            # OED will provide the token created for future use.
+            # If the taken is changed here then it is important to make it secure to
+            # avoid unauthorized access.
+            - OED_TOKEN_SECRET=?
+            # The OED_MAIL_... values are set to enable OED to send email about issues.
+            - OED_MAIL_METHOD=none # Method of sending mail. Supports "secure-smtp", "none". Case insensitive.
+            - OED_MAIL_SMTP=smtp.example.com # Edit this
+            - OED_MAIL_SMTP_PORT=465 # Edit this
+            - OED_MAIL_IDENT=someone@example.com # The user email that is used for sending emails (SMTP)
+            - OED_MAIL_CREDENTIAL=credential # Set the email password for sending email here
+            - OED_MAIL_FROM=mydomain@example.com # The email address that the email will come from
+            - OED_MAIL_TO=someone@example.com # Set the destination address here for where to send emails
+            - OED_MAIL_ORG=My Organization Name # Org name for mail that is included in the subject
+            # Changing this value does not impact what OED displays.
+            # What it will change is the date/time stamp on logs, notes and change dates that place the current date/time.
+            # It can also impact the interpretation of readings sent to OED such as Unix timestamps.
+            - TZ=Etc/UTC # Set the timezone of the Docker container where OED runs the web services.
+              # OED_PRODUCTION should NEVER be changed here. If this is for an OED site then
             # it is VERY important that it be yes for security reasons. If you are doing
             # development then you should be changing the other docker file as per the help
             # page for developers.
@@ -60,39 +92,14 @@ services:
             # This user is used when the standard OED testing is run. It is left in this Docker
             # config file in case sites want to run the test suite.
             - OED_DB_TEST_DATABASE=oed_testing
-            # Default oed user postgres password that should be changed for security.
-            # The OED install process will not allow this password and it will
-            # be replaced with a random, secure password if not changed here. That is fine as
-            # many sites do not need access to the database.
-            # If the password is changed then it is important to make it secure to
-            # avoid unauthorized access.
-            - OED_DB_PASSWORD=opened
             # Docker will set this hostname.
             - OED_DB_HOST=database
             # This is the standard postgres port. At a site this should not cause issues as it
             # is only used within the Docker container.
             - OED_DB_PORT=5432
-            # Default web token that should be changed for security.
-            # The OED install process will not allow this token and it will
-            # be replaced with a random, secure token if not changed. That is fine as
-            # there is normally no usage outside of the OED app for this.
-            # If the taken is changed here then it is important to make it secure to
-            # avoid unauthorized access.
-            - OED_TOKEN_SECRET=?
+            # This is the file where OED log messages are stored. It is now a backup location for
+            # messages since all should be logged to the database and available via an OED web page.
             - OED_LOG_FILE=log.txt
-            # The OED_MAIL_... values are set to enable OED to send email about issues.
-            - OED_MAIL_METHOD=none # Method of sending mail. Supports "secure-smtp", "none". Case insensitive.
-            - OED_MAIL_SMTP=smtp.example.com # Edit this
-            - OED_MAIL_SMTP_PORT=465 # Edit this
-            - OED_MAIL_IDENT=someone@example.com # The user email that is used for sending emails (SMTP)
-            - OED_MAIL_CREDENTIAL=credential # Set the email password for sending email here
-            - OED_MAIL_FROM=mydomain@example.com # The email address that the email will come from
-            - OED_MAIL_TO=someone@example.com # Set the destination address here for where to send emails
-            - OED_MAIL_ORG=My Organization Name # Org name for mail that is included in the subject
-            # Changing this value does not impact what OED displays.
-            # What it will change is the date/time stamp on logs, notes and change dates that place the current date/time.
-            # It can also impact the interpretation of readings sent to OED such as Unix timestamps.
-            - TZ=Etc/UTC # Set the timezone of the Docker container where OED runs the web services.
             # If in a subdirectory, set it here
             # - OED_SUBDIR=/subdir/
             # Set the correct build environment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,11 +77,16 @@ services:
             # What it will change is the date/time stamp on logs, notes and change dates that place the current date/time.
             # It can also impact the interpretation of readings sent to OED such as Unix timestamps.
             - TZ=Etc/UTC # Set the timezone of the Docker container where OED runs the web services.
-              # OED_PRODUCTION should NEVER be changed here. If this is for an OED site then
+            # OED_PRODUCTION should NEVER be changed here. If this is for an OED site then
             # it is VERY important that it be yes for security reasons. If you are doing
             # development then you should be changing the other docker file as per the help
             # page for developers.
-            - OED_PRODUCTION=yes
+            # - OED_PRODUCTION=yes
+            # TODO THIS VALUE IS TEMPORARILY BEING SET TO no DURING THE TRANSITION TO THE NEW SETUP WHERE
+            #       THERE IS A SEPARATE DOCKER CONFIGURATION FILE FOR DEVELOPERS. THIS ALLOWS DEVELOPERS
+            #       TO CONTINUE TO USE THE CURRENT COMMAND TO START UP OED. THE PLAN IS TO REMOVE THIS
+            #       AFTER THE PHASE IN PERIOD.
+            - OED_PRODUCTION=no
             # See the ports mapping below to change the port used on your system.
             # Normally OED_SERVER_PORT is not modified.
             - OED_SERVER_PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         environment:
             # Custom PGDATA per recommendations from official Docker page
             - PGDATA=/var/lib/postgresql/data/pgdata
-            - POSTGRES_PASSWORD=pleaseChange
+            - POSTGRES_PASSWORD=pleaseChange # default postgres password that should be changed for security.
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:
@@ -54,7 +54,6 @@ services:
             # If in a subdirectory, set it here
             # - OED_SUBDIR=/subdir/
             # Set the correct build environment.
-            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pleaseChange}
         build:
             context: ./
             dockerfile: ./containers/web/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,41 +4,83 @@
 # * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # *
 
+# *****************************************************************
+# This is the default Docker configuration file that is used for
+# OED sites. Normally only places with comments indicating possible
+# changes should be modified as described.
+#
+# OED developers should change the other docker file and start OED
+# with a modified command. OED sites should NEVER do this.
+# *****************************************************************
+
 version: "3.8"
 services:
-    # Database service. It's PostgreSQL, see the
-    # Dockerfile in ./database
+    # Database service. It's PostgreSQL, see the Dockerfile in ./database.
     database:
         build: ./containers/database/
         environment:
             # Custom PGDATA per recommendations from official Docker page
             - PGDATA=/var/lib/postgresql/data/pgdata
-            - POSTGRES_PASSWORD=pleaseChange # default postgres password that should be changed for security.
+            # Default postgres password that should be changed for security.
+            # The OED install process will not allow this password and it will
+            # be replaced with a random, secure password if not changed here. That is fine as
+            # many sites do not need access to the database.
+            # If the password is changed then it is important to make it secure to
+            # avoid unauthorized access.
+            - POSTGRES_PASSWORD=pleaseChange
         volumes:
+            # This maps the proper Docker database directory back to the local file
+            # system. It is critical that the changes actually be written back to
+            # a non-docker file location so they will continue to exist between
+            # OED startups and not lost since Docker container information is reset.
             - ./postgres-data:/var/lib/postgresql/data/pgdata
+        # Tries to make sure postgres is running properly. For example, the DB can be
+        # running but not ready to accept connections.
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U postgres"]
             interval: 10s
             timeout: 10s
             retries: 3
-        # ports:
-        #    - "5432:5432"
-        # Uncomment the above lines to enable access to the PostgreSQL server
-        # from the host machine.
         # Web service runs Node
     web:
         # Configuration variables for the app.
         environment:
-            - OED_PRODUCTION=yes # Set this value to yes or no, other values will result in a configuration error
+            # OED_PRODUCTION should NEVER be changed here. If this is for an OED site then
+            # it is VERY important that it be yes for security reasons. If you are doing
+            # development then you should be changing the other docker file as per the help
+            # page for developers.
+            - OED_PRODUCTION=yes
+            # See the ports mapping below to change the port used on your system.
+            # Normally OED_SERVER_PORT is not modified.
             - OED_SERVER_PORT=3000
+            # Normally these users are fine and there should be no reason to change the next
+            # three items.
             - OED_DB_USER=oed
             - OED_DB_DATABASE=oed
+            # This user is used when the standard OED testing is run. It is left in this Docker
+            # config file in case sites want to run the test suite.
             - OED_DB_TEST_DATABASE=oed_testing
+            # Default oed user postgres password that should be changed for security.
+            # The OED install process will not allow this password and it will
+            # be replaced with a random, secure password if not changed here. That is fine as
+            # many sites do not need access to the database.
+            # If the password is changed then it is important to make it secure to
+            # avoid unauthorized access.
             - OED_DB_PASSWORD=opened
-            - OED_DB_HOST=database # Docker will set this hostname
+            # Docker will set this hostname.
+            - OED_DB_HOST=database
+            # This is the standard postgres port. At a site this should not cause issues as it
+            # is only used within the Docker container.
             - OED_DB_PORT=5432
+            # Default web token that should be changed for security.
+            # The OED install process will not allow this token and it will
+            # be replaced with a random, secure token if not changed. That is fine as
+            # there is normally no usage outside of the OED app for this.
+            # If the taken is changed here then it is important to make it secure to
+            # avoid unauthorized access.
             - OED_TOKEN_SECRET=?
             - OED_LOG_FILE=log.txt
+            # The OED_MAIL_... values are set to enable OED to send email about issues.
             - OED_MAIL_METHOD=none # Method of sending mail. Supports "secure-smtp", "none". Case insensitive.
             - OED_MAIL_SMTP=smtp.example.com # Edit this
             - OED_MAIL_SMTP_PORT=465 # Edit this
@@ -57,7 +99,7 @@ services:
         build:
             context: ./
             dockerfile: ./containers/web/Dockerfile
-        # Link to the database so the app can persist data
+        # Link to the database so the app can persist data.
         links:
             - database
         # Load the source code into the container.
@@ -67,16 +109,16 @@ services:
         # Map the default port.
         ports:
             - "3000:3000" # Should be commented out if you uncomment 80:3000 below.
-            # - "9229:9229" # Debug port, should be commented out for production
             # For production you might want something like:
             # - "80:3000"
             # and comment out the debug port and 3000:3000 line above
-            # Don't bring this up without the DB
+        # Don't bring this up without the DB
         depends_on:
             # - database
             database:
               # We need the database and it has to be ready for work (see healthcheck above).
               condition: service_healthy
+        # As with the DB above, this tries to ensure all is okay.
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:3000"]
             interval: 10s
@@ -88,29 +130,4 @@ services:
             [
                 "bash",
                 "./src/scripts/installOED.sh",
-                "${install_args:-}"
             ]
-        # Use this if you are using a docker-compose that is earlier than version 2 and comment out the one above.
-        # command: ["bash", "./src/scripts/installOED.sh"]
-
-    # Cypress testing service
-    cypress:
-      image: cypress/included
-      profiles:
-        - ui-testing
-      environment:
-        - CYPRESS_BASE_URL=http://web:3000
-        - DISPLAY=:99
-      working_dir: /usr/src/app
-      depends_on:
-        web:
-          condition: service_healthy
-      volumes:
-        - ./:/usr/src/app
-      entrypoint: >
-        /bin/sh -c "
-        rm -f /tmp/.X99-lock &&
-        Xvfb :99 -screen 0 1024x768x16"
-      read_only: true
-      security_opt:
-        - no-new-privileges:true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,7 @@ services:
         environment:
             # Custom PGDATA per recommendations from official Docker page
             - PGDATA=/var/lib/postgresql/data/pgdata
-            # The postgres database will only pull from this value on the first
-            # startup of OED. If a change is desired after this, one must 
-            # run the following command in the docker web terminal:
-            # "npm run changePostgresPassword -- postgrespassword oedpassword"
-            # Replace "postgrespassword" with your desired postgres user password
-            # and "oedpassword" with your desired oed user password.
-            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pleaseChange}
+            - POSTGRES_PASSWORD=pleaseChange
         volumes:
             - ./postgres-data:/var/lib/postgresql/data/pgdata
         healthcheck:
@@ -40,10 +34,10 @@ services:
             - OED_DB_USER=oed
             - OED_DB_DATABASE=oed
             - OED_DB_TEST_DATABASE=oed_testing
-            - OED_DB_PASSWORD=${OED_DB_PASSWORD:-opened} # See comment regarding POSTGRES_PASSWORD above, same situation
+            - OED_DB_PASSWORD=opened
             - OED_DB_HOST=database # Docker will set this hostname
             - OED_DB_PORT=5432
-            - OED_TOKEN_SECRET=${OED_TOKEN_SECRET:-?} #Automatically generated when OED is run in production
+            - OED_TOKEN_SECRET=?
             - OED_LOG_FILE=log.txt
             - OED_MAIL_METHOD=none # Method of sending mail. Supports "secure-smtp", "none". Case insensitive.
             - OED_MAIL_SMTP=smtp.example.com # Edit this
@@ -118,3 +112,6 @@ services:
         /bin/sh -c "
         rm -f /tmp/.X99-lock &&
         Xvfb :99 -screen 0 1024x768x16"
+      read_only: true
+      security_opt:
+        - no-new-privileges:true

--- a/src/scripts/installOED.sh
+++ b/src/scripts/installOED.sh
@@ -58,6 +58,39 @@ if [ -f ".env" ]; then
 	source .env
 fi
 
+# Creating a centralized variable to keep track of the type of installation. 
+INSTALL_MODE="production"
+
+if [ "$production" = "yes" ] || [ "$OED_PRODUCTION" = "yes" ]; then
+	INSTALL_MODE="production"
+elif [ "$production" = "no" ] || [ "$OED_PRODUCTION" = "no" ]; then
+	INSTALL_MODE="development"
+else
+	printf "\nFailure: Invalid or missing environment configuration."
+	printf "\nSet OED_PRODUCTION to 'yes' for production or 'no' for development."
+	exit 10
+fi
+
+# Warn installer of unusual or incorrect installation settings.
+# OED_DOCKER_CONFIG_DEV should either be yes or not set in the config files.
+if [ "$INSTALL_MODE" = "production" ] && [ "$OED_DOCKER_CONFIG_DEV" = "yes" ]; then
+	printf "\n\n%s\n" "***************************************************************************************************"
+	printf "%s\n" "Warning: OED_PRODUCTION is set to 'yes' and the Docker developer configuration file is being used."
+	printf "%s\n" "    This should ONLY be done by OED developers for testing and NEVER by an actual OED site."
+	printf "%s\n" "    If this is for an OED site then it can introduce security issues and this should NOT be done."
+	printf "%s\n\n" "***************************************************************************************************"
+elif [ "$INSTALL_MODE" = "development" ] && [ ! "$OED_DOCKER_CONFIG_DEV" = "yes" ]; then
+	printf "\n\n%s\n" "***************************************************************************************************"
+	printf "%s\n" "Warning: OED_PRODUCTION is set to 'no' but the Docker developer configuration file is NOT being used."
+	printf "\n%s\n\n" "    If you are installing OED for a site then you are doing something the is STRONGLY discouraged due to security risks."
+	printf "%s\n" "    If you are an OED developer, an older method to install OED is being used that will stop working in the near future."
+	printf "%s\n" "    You should convert to the new way to use the docker-compose-dev.yml and use this command to start OED:"
+	printf "%s\n" "    docker compose -f docker-compose.yml -f docker-compose-dev.yml up"
+	printf "%s\n" "    Changes to the OED setup for development should ALWAYS be done in docker-compose-dev.yml"
+	printf "%s\n" "    Note the option to not initialize the database will not work with the method you are using."
+	printf "%s\n\n" "***************************************************************************************************"
+fi
+
 # Skip the install if the node_modules were installed before the package files.
 # The two package files
 packageFile="package.json"

--- a/src/scripts/installOED.sh
+++ b/src/scripts/installOED.sh
@@ -82,7 +82,7 @@ if [ "$INSTALL_MODE" = "production" ] && [ "$OED_DOCKER_CONFIG_DEV" = "yes" ]; t
 elif [ "$INSTALL_MODE" = "development" ] && [ ! "$OED_DOCKER_CONFIG_DEV" = "yes" ]; then
 	printf "\n\n%s\n" "***************************************************************************************************"
 	printf "%s\n" "Warning: OED_PRODUCTION is set to 'no' but the Docker developer configuration file is NOT being used."
-	printf "\n%s\n\n" "    If you are installing OED for a site then you are doing something the is STRONGLY discouraged due to security risks."
+	printf "\n%s\n\n" "    If you are installing OED for a site then you are doing something that is STRONGLY discouraged due to security risks."
 	printf "%s\n" "    If you are an OED developer, an older method to install OED is being used that will stop working in the near future."
 	printf "%s\n" "    You should convert to the new way to use the docker-compose-dev.yml and use this command to start OED:"
 	printf "%s\n" "    docker compose -f docker-compose.yml -f docker-compose-dev.yml up"


### PR DESCRIPTION
# Description

This PR adds a second docker compose file specifically for running in development, to eliminate the risk of a production site accidentally running in the less secure development mode because it's the default. This change means that in order to run in development the command to compose is now "docker compose -f docker-compose.yml -f docker-compose-dev.yml up" which will make the development file override the main one. 

Fixes Security Issue 2

## Type of change

- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

This will be intrusive for every OED developer as it requires a new way of running OED, but it will increase overall security. 
