### PR TITLE
created a working test for CG12 | Group: "TeamExtreme"

### DIFF
--- a/src/server/test/web/readingsCompareGroupQuantity.js
+++ b/src/server/test/web/readingsCompareGroupQuantity.js
@@ -406,7 +406,7 @@ mocha.describe('readings API', () => {
 						});
 
 					expectCompareToEqualExpected(res, expected, GROUP_ID);
-				//run with docker compose exec web npm test -- --grep "CG12"
+				
 				
 				});
 				// Add CG13 here

--- a/src/server/test/web/readingsCompareGroupQuantity.js
+++ b/src/server/test/web/readingsCompareGroupQuantity.js
@@ -333,7 +333,82 @@ mocha.describe('readings API', () => {
 				});
 
 				// Add CG12 here
+				mocha.it('CG12: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as kg of CO2', async () => {
+					const unitData = unitDatakWh.concat([
+						{
+							// u10
+							name: 'kg',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: '',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: false,
+							note: 'OED created standard unit'
+						},
+						{
+							// u12
+							name: 'kg CO₂',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: 'CO₂',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: false,
+							note: 'special unit'
+						}
+					]);
 
+					const conversionData = conversionDatakWh.concat([
+						{
+							// c11
+							sourceName: 'Electric_Utility',
+							destinationName: 'kg CO₂',
+							bidirectional: false,
+							slope: 0.709,
+							intercept: 0,
+							note: 'Electric_Utility → kg CO₂'
+						},
+						{
+							// c12
+							sourceName: 'kg CO₂',
+							destinationName: 'kg',
+							bidirectional: false,
+							slope: 1,
+							intercept: 0,
+							note: 'CO₂ → kg'
+						}
+					]);
+
+					await prepareTest(
+						unitData,
+						conversionData,
+						meterDatakWhGroups,
+						groupDatakWh
+					);
+
+					const unitId = await getUnitId('kg of CO₂');
+
+					const expected = [
+						4017.44423365639,
+						4163.5451722303
+					];
+
+					const res = await chai.request(app)
+						.get(`/api/compareReadings/groups/${GROUP_ID}`)
+						.query({
+							curr_start: '2022-10-31 00:00:00',
+							curr_end: '2022-10-31 17:00:00',
+							shift: 'P1D',
+							graphicUnitId: unitId
+						});
+
+					expectCompareToEqualExpected(res, expected, GROUP_ID);
+				//run with docker compose exec web npm test -- --grep "CG12"
+				
+				});
 				// Add CG13 here
 
 				// Add CG14 here

--- a/src/server/test/web/readingsCompareGroupQuantity.js
+++ b/src/server/test/web/readingsCompareGroupQuantity.js
@@ -332,11 +332,10 @@ mocha.describe('readings API', () => {
 
 				});
 
-				// Add CG12 here
+				
 				mocha.it('CG12: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as kg of CO2', async () => {
 					const unitData = unitDatakWh.concat([
 						{
-							// u10
 							name: 'kg',
 							identifier: '',
 							unitRepresent: Unit.unitRepresentType.QUANTITY,
@@ -348,7 +347,6 @@ mocha.describe('readings API', () => {
 							note: 'OED created standard unit'
 						},
 						{
-							// u12
 							name: 'kg CO₂',
 							identifier: '',
 							unitRepresent: Unit.unitRepresentType.QUANTITY,
@@ -363,7 +361,6 @@ mocha.describe('readings API', () => {
 
 					const conversionData = conversionDatakWh.concat([
 						{
-							// c11
 							sourceName: 'Electric_Utility',
 							destinationName: 'kg CO₂',
 							bidirectional: false,
@@ -372,7 +369,6 @@ mocha.describe('readings API', () => {
 							note: 'Electric_Utility → kg CO₂'
 						},
 						{
-							// c12
 							sourceName: 'kg CO₂',
 							destinationName: 'kg',
 							bidirectional: false,

--- a/src/server/test/web/readingsCompareGroupQuantity.js
+++ b/src/server/test/web/readingsCompareGroupQuantity.js
@@ -404,10 +404,7 @@ mocha.describe('readings API', () => {
 							shift: 'P1D',
 							graphicUnitId: unitId
 						});
-
 					expectCompareToEqualExpected(res, expected, GROUP_ID);
-				
-				
 				});
 				// Add CG13 here
 


### PR DESCRIPTION
# Description

Adds CG12 compare group quantity test coverage for kWh to kg CO₂ conversion behavior in readingsCompareGroupQuantity.js.

This test validates that compare readings for groups correctly return converted quantity values when using the kg CO₂ graphic unit.

Partly Addresses #[issue]

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [ x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [ x] I have removed text in ( ) from the issue request
- [x ] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

The test currently inserts the required cik conversion row directly during setup to ensure the compare readings query has access to the expected conversion path.
