### PR TITLE
Adding LR15 Testcase

### DIFF
--- a/src/server/test/web/readingsLineMeterRangeRaw.js
+++ b/src/server/test/web/readingsLineMeterRangeRaw.js
@@ -179,8 +179,94 @@ mocha.describe('readings API', () => {
                         //check if response from api call matches values in expected readings csv using expectRangeToEqualExpected()
                         expectRangeToEqualExpected(res, expected);
                     });
-                    // Add LR15 here
+                    mocha.it('LR15: range should have daily points for 15 minute reading intervals and raw units with +-inf start/end time & C as F with intercept reverse conversion', async () => {
+                        const unitData = [
+                            {
+                                // u6, used for conversion instead of display
+                                name: 'C',
+                                identifier: '',
+                                unitRepresent: Unit.unitRepresentType.RAW,
+                                secInRate: 3600,
+                                typeOfUnit: Unit.unitType.UNIT,
+                                suffix: '',
+                                displayable: Unit.displayableType.NONE,
+                                preferredDisplay: false,
+                                note: 'Celsius'
+                            },
+                            {
+                                // u7, raw units stored in meter
+                                name: 'Degrees',
+                                identifier: '',
+                                unitRepresent: Unit.unitRepresentType.RAW,
+                                secInRate: 3600,
+                                typeOfUnit: Unit.unitType.METER,
+                                suffix: '',
+                                displayable: Unit.displayableType.NONE,
+                                preferredDisplay: false,
+                                note: 'special unit'
+                            },
+                            {
+                                // u8, display unit for graph
+                                name: 'F',
+                                identifier: '',
+                                unitRepresent: Unit.unitRepresentType.RAW,
+                                secInRate: 3600,
+                                typeOfUnit: Unit.unitType.UNIT,
+                                suffix: '',
+                                displayable: Unit.displayableType.ALL,
+                                preferredDisplay: false,
+                                note: 'OED created standard unit unit'
+                            }
 
+                        ];
+                        const conversionData = [
+                            {
+                                // c5
+                                sourceName: 'Degrees',
+                                destinationName: 'C',
+                                bidirectional: false,
+                                slope: 1,
+                                intercept: 0,
+                                note: 'Degrees → C'
+                            },
+                            {
+                                // c8
+                                sourceName: 'F',
+                                destinationName: 'C',
+                                bidirectional: true,
+                                slope: 1 / 1.8,
+                                intercept: -32 / 1.8,
+                                note: 'Fahrenheit → Celsius'
+                            }
+                        ];
+
+                        //const variable for meter metadata here
+                        const meterDataDegrees = [
+                            {
+                                name: 'Temp Fahrenheit Meter',
+                                unit: 'Degrees',
+                                defaultGraphicUnit: 'F',
+                                displayable: true,
+                                gps: undefined,
+                                note: 'special meter for raw temp data',
+                                file: 'test/web/readingsData/readings_ri_15_days_75.csv',
+                                deleteFile: false,
+                                readingFrequency: '15 minutes',
+                                id: METER_ID
+                            }
+                        ];
+                        //fill emptied database with test units/data defined above using prepareTest()
+                        await prepareTest(unitData, conversionData, meterDataDegrees);
+                        //Get the graphic unit ID for 'F'
+                        const graphicUnitIdF = await getUnitId('F');
+                        //load expected readings into variable using parseExpectedCsv()
+                        const expected = await parseExpectedCsv('src/server/test/web/readingsData/expected_line_range_ri_15_mu_C_gu_F_st_-inf_et_inf.csv');
+                        //api call to get line chart readings from meter using METER_ID, convert to graphic unit defined above, then store in variable
+                        const res = await chai.request(app).get(`/api/unitReadings/line/meters/${METER_ID}`)
+                            .query({ timeInterval: ETERNITY.toString(), graphicUnitId: graphicUnitIdF });
+                        //check if response from api call matches values in expected readings csv using expectRangeToEqualExpected()
+                        expectRangeToEqualExpected(res, expected);
+                    });
                     // Add LR16 here
 
                     // Add LR17 here


### PR DESCRIPTION
# Description

This PR adds the test case LR15. This test is identical to LR14, with the exception of the conversion (it uses c8 instead of c7).

Partially Addresses #[962]

Contributors:

- Adrien Schildwachter — @AdrienSch
- Ermiyas Hailemichael — @ErmiyasHailemichael

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

The test file still needs implementation of LR16, LR17, LR22.

