### PR TITLE
Remove duplicate group unauthenticated tests

### DIFF
--- a/src/server/test/web/groups.js
+++ b/src/server/test/web/groups.js
@@ -104,10 +104,7 @@ mocha.describe('groups API', () => {
 			token = res.body.token;
 		});
 		mocha.describe('create endpoint', () => {
-			mocha.it('rejects all requests without a token with 403', async () => {
-				const res = await chai.request(app).post('/api/groups/create').type('json').send({});
-				expect(res).to.have.status(HTTP_CODES.FORBIDDEN);
-			});
+
 			mocha.it('rejects all requests with an invalid token with 401', async () => {
 				const res = await chai.request(app).post('/api/groups/create').set('token', token + 'nope').type('json').send({});
 				expect(res).to.have.status(HTTP_CODES.UNAUTHORIZED);
@@ -164,10 +161,7 @@ mocha.describe('groups API', () => {
 			});
 		});
 		mocha.describe('edit endpoint', () => {
-			mocha.it('rejects all requests without a token with 403', async () => {
-				const res = await chai.request(app).put('/api/groups/edit').type('json').send({});
-				expect(res).to.have.status(HTTP_CODES.FORBIDDEN);
-			});
+
 			mocha.it('rejects all requests with an invalid token with 401', async () => {
 				const res = await chai.request(app).put('/api/groups/edit').set('token', token + 'nope').type('json').send({});
 				expect(res).to.have.status(HTTP_CODES.UNAUTHORIZED);


### PR DESCRIPTION
# Description

This PR is a clean replacement for my previous PR that showed many unrelated changed files because it was based on an older fork/branch. I recreated the work from an up-to-date `development` branch so this PR should only include the intended change.

This PR removes duplicate unauthenticated request tests from `src/server/test/web/groups.js` for the group create and edit endpoints.

These unauthenticated request cases are already covered in the centralized route parameter tests in `src/server/test/routes/groupsParamsTest.js`, so the older overlapping tests in `web/groups.js` were removed.

The invalid token, role authorization, and valid create/edit behavior tests were kept because they test different behavior.

Partly Addresses #1575

## Type of change

* [ ] Note merging this changes the database configuration.
* [ ] This change requires a documentation update

## Checklist

* [x] I have followed the [[OED pull request](https://openenergydashboard.org/developer/pr/)](https://openenergydashboard.org/developer/pr/) ideas
* [x] I have removed text in ( ) from the issue request
* [x] You acknowledge that every person contributing to this work has signed the [[OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/)](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Testing

* `npm run testsome src/server/test/web/groups.js`
* 17 passing

## Limitations

This PR only addresses the duplicate unauthenticated tests for the group create and edit endpoints. Additional route test cleanup may still be needed for other files as part of #1575.