### PR TITLE
put back CG12 test

### DIFF
--- a/src/server/test/web/readingsCompareGroupQuantity.js
+++ b/src/server/test/web/readingsCompareGroupQuantity.js
@@ -332,8 +332,75 @@ mocha.describe('readings API', () => {
 
 				});
 
-				// Add CG12 here
+				mocha.it('CG12: 1 day shift end 2022-10-31 17:00:00 for 15 minute reading intervals and quantity units & kWh as kg of CO2', async () => {
+					const unitData = unitDatakWh.concat([
+						{
+							name: 'kg',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: '',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: false,
+							note: 'OED created standard unit'
+						},
+						{
+							name: 'kg CO₂',
+							identifier: '',
+							unitRepresent: Unit.unitRepresentType.QUANTITY,
+							secInRate: 3600,
+							typeOfUnit: Unit.unitType.UNIT,
+							suffix: 'CO₂',
+							displayable: Unit.displayableType.ALL,
+							preferredDisplay: false,
+							note: 'special unit'
+						}
+					]);
 
+					const conversionData = conversionDatakWh.concat([
+						{
+							sourceName: 'Electric_Utility',
+							destinationName: 'kg CO₂',
+							bidirectional: false,
+							slope: 0.709,
+							intercept: 0,
+							note: 'Electric_Utility → kg CO₂'
+						},
+						{
+							sourceName: 'kg CO₂',
+							destinationName: 'kg',
+							bidirectional: false,
+							slope: 1,
+							intercept: 0,
+							note: 'CO₂ → kg'
+						}
+					]);
+
+					await prepareTest(
+						unitData,
+						conversionData,
+						meterDatakWhGroups,
+						groupDatakWh
+					);
+
+					const unitId = await getUnitId('kg of CO₂');
+
+					const expected = [
+						4017.44423365639,
+						4163.5451722303
+					];
+
+					const res = await chai.request(app)
+						.get(`/api/compareReadings/groups/${GROUP_ID}`)
+						.query({
+							curr_start: '2022-10-31 00:00:00',
+							curr_end: '2022-10-31 17:00:00',
+							shift: 'P1D',
+							graphicUnitId: unitId
+						});
+					expectCompareToEqualExpected(res, expected, GROUP_ID);
+				});
 				// Add CG13 here
 
 				// Add CG14 here


### PR DESCRIPTION
# Description

PR #1639 somehow removed this test. I checked out src/server/test/web/readingsCompareGroupQuantity.js at commit 61dcdc9a684eb066d6d9e8b8c6c68c88ba4bfe0f which had the last changes of PR #1629 that added this test. I'm hoping it shows the git record as them doing it but am unsure.

I want to clearly state that the work was done by @KJeansGR & @AaronB22.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

If this does not show them as the author of the lines then I'm sorry my attempts to get git to do that failed.
