### PR TITLE
Bump morgan ~1.10.0 → ~1.11.0 (GHSA-4vj7-5mj6-jm8m)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"md5": "~2.3.0",
 				"moment": "~2.30.1",
 				"moment-timezone": "~0.5.45",
-				"morgan": "~1.10.0",
+				"morgan": "~1.11.0",
 				"multer": "~1.4.5-lts.1",
 				"ngraph.graph": "~20.0.0",
 				"ngraph.path": "~1.5.0",
@@ -7059,18 +7059,23 @@
 			}
 		},
 		"node_modules/morgan": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+			"integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
+			"license": "MIT",
 			"dependencies": {
 				"basic-auth": "~2.0.1",
 				"debug": "2.6.9",
 				"depd": "~2.0.0",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.2"
+				"on-finished": "~2.4.1",
+				"on-headers": "~1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/morgan/node_modules/debug": {
@@ -7085,17 +7090,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-		},
-		"node_modules/morgan/node_modules/on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/mouse-change": {
 			"version": "1.4.0",
@@ -7457,9 +7451,10 @@
 			}
 		},
 		"node_modules/on-headers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+			"integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"md5": "~2.3.0",
 		"moment": "~2.30.1",
 		"moment-timezone": "~0.5.45",
-		"morgan": "~1.10.0",
+		"morgan": "~1.11.0",
 		"multer": "~1.4.5-lts.1",
 		"ngraph.graph": "~20.0.0",
 		"ngraph.path": "~1.5.0",


### PR DESCRIPTION
Bumps morgan from 1.10.0 to 1.11.0 to address GHSA-4vj7-5mj6-jm8m (log forging via unneutralized control characters in `:remote-user`, CVSS 5.3, CWE-117).

**Affected range:** `>=1.2.0 <=1.10.1`
**Fix:** 1.11.0

Changes `package.json` and `package-lock.json` only — no source changes.

**Scanner verification:**
- `npm audit`: morgan vulnerability cleared after update
- `osv-scanner`: GHSA-4vj7-5mj6-jm8m no longer reported

Remaining unrelated advisories (webpack, yaml) are not addressed by this PR.