### PR TITLE
remove done test comments

### DIFF
--- a/src/server/test/web/readingsBarGroupFlow.js
+++ b/src/server/test/web/readingsBarGroupFlow.js
@@ -480,8 +480,6 @@ mocha.describe('readings API', () => {
 					expectReadingToEqualExpected(res, expected, GROUP_ID);
 				});
 
-				// Add BG20 here
-
 				mocha.it('BG20: 75 day bars for 15 + 20 minute reading intervals and flow units with +-inf start/end time & kW as kW', async () => {
 					const unitDatakW = [
 						{

--- a/src/server/test/web/readingsLineMeterRangeQuantity.js
+++ b/src/server/test/web/readingsLineMeterRangeQuantity.js
@@ -55,7 +55,6 @@ mocha.describe('readings API', () => {
 						expectRangeToEqualExpected(res, expected);
 					});
 
-					// Add LR3 here
 					mocha.it('LR3: range should have daily points for middle readings of 15 minute for a 61 day period and quantity units with kWh as kWh', async () => {
 						// 1) Seed DB with the standard unit/meter data for kWh
 						await prepareTest(unitDatakWh, conversionDatakWh, meterDatakWh);


### PR DESCRIPTION
# Description

Remove all (two) comments (``// Add xxxx here``) that indicated to add a test case because they are already done. All remaining ones should indicate tests that are not yet done. This is strictly cleanup of comments that were missed in the past.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

None.
