### PR TITLE
fix meter date validation

### DIFF
--- a/src/server/routes/baseline.js
+++ b/src/server/routes/baseline.js
@@ -63,6 +63,7 @@ router.post('/new', adminAuthMiddleware('create baselines'), async (req, res) =>
 		return;
 	}
 	// baseline.js does not use moment; validate date strings directly
+	// TODO This might not stay and is not used in OED now but need to see if it has a timezone for the check.
 	if (!isValidIsoDateTime(req.body.applyStart) || !isValidIsoDateTime(req.body.applyEnd) ||
 		!isValidIsoDateTime(req.body.calcStart) || !isValidIsoDateTime(req.body.calcEnd)) {
 		res.sendStatus(HTTP_CODES.BAD_REQUEST);

--- a/src/server/routes/maps.js
+++ b/src/server/routes/maps.js
@@ -154,6 +154,9 @@ router.post('/create', adminAuthMiddleware('create maps'), async (req, res) => {
 		}
 	};
 	const validationResult = validate(req.body, validMap);
+	// TODO It is uncertain if the date has a timezone since map creation was not working when that was tested.
+	// This is a comment so if if fails someone knows to see if the second parameter should be false. If it works
+	// then this can be removed.
 	if (!validationResult.valid || !isValidIsoDateTime(req.body.modifiedDate)) {
 		log.error(`Invalid input for mapAPI. ${validationResult.errors}`);
 		res.sendStatus(HTTP_CODES.BAD_REQUEST);

--- a/src/server/routes/meters.js
+++ b/src/server/routes/meters.js
@@ -282,8 +282,8 @@ router.post('/edit', adminAuthMiddleware('edit meters'), async (req, res) => {
 		log.warn(`Got request to edit a meter with invalid meter data, errors: ${response.errors}`);
 		failure(res, HTTP_CODES.BAD_REQUEST, 'validation failed with ' + response.errors.toString());
 	} else if (
-		(req.body.startTimestamp && !isValidIsoDateTime(req.body.startTimestamp)) ||
-		(req.body.endTimestamp && !isValidIsoDateTime(req.body.endTimestamp)) ||
+		(req.body.startTimestamp && !isValidIsoDateTime(req.body.startTimestamp, false)) ||
+		(req.body.endTimestamp && !isValidIsoDateTime(req.body.endTimestamp, false)) ||
 		(req.body.previousEnd && !isValidIsoDateTime(req.body.previousEnd)) ||
 		(req.body.minDate && !isValidIsoDateTime(req.body.minDate)) ||
 		(req.body.maxDate && !isValidIsoDateTime(req.body.maxDate))
@@ -355,8 +355,10 @@ router.post('/addMeter', adminAuthMiddleware('add meter'), async (req, res) => {
 		log.warn(`Got request to create a meter with invalid meter data, errors: ${response.errors}`);
 		failure(res, HTTP_CODES.BAD_REQUEST, 'validation failed with ' + response.errors.toString());
 	} else if (
-		(req.body.startTimestamp && !isValidIsoDateTime(req.body.startTimestamp)) ||
-		(req.body.endTimestamp && !isValidIsoDateTime(req.body.endTimestamp)) ||
+		// The default value for start/endTimestamp does have a timezone but it is not required nor put
+		// in when OED sets the value later so not checked here.
+		(req.body.startTimestamp && !isValidIsoDateTime(req.body.startTimestamp, false)) ||
+		(req.body.endTimestamp && !isValidIsoDateTime(req.body.endTimestamp, false)) ||
 		(req.body.previousEnd && !isValidIsoDateTime(req.body.previousEnd)) ||
 		(req.body.minDate && !isValidIsoDateTime(req.body.minDate)) ||
 		(req.body.maxDate && !isValidIsoDateTime(req.body.maxDate))

--- a/src/server/util/timeValidation.js
+++ b/src/server/util/timeValidation.js
@@ -8,15 +8,21 @@ const ISO_DURATION_REGEX = /^P(?!$)(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+(\.\
 const ISO_DATETIME_WITH_TIMEZONE_REGEX = /^\d{4}-\d{2}-\d{2}T.+(?:Z|[+-]\d{2}:?\d{2})$/;
 
 /**
- * Returns true if value is a strictly valid ISO 8601 datetime string (with timezone).
- * @param {string} value
+ * Returns true if value is a strictly valid ISO 8601 datetime string. If hasTimezone is true then it also
+ * checks for a valid timezone.
+ * @param {string} value date/time string to validate
+ * @param {boolean} hasTimezone true (default) if check timezone and false if don't
  * @returns {boolean}
  */
-function isValidIsoDateTime(value) {
+function isValidIsoDateTime(value, hasTimezone = true) {
 	if (typeof value !== 'string') {
 		return false;
 	}
-	return ISO_DATETIME_WITH_TIMEZONE_REGEX.test(value) && moment.parseZone(value, moment.ISO_8601, true).isValid();
+	// Always check that moment thinks is it ISO.
+	let isValid = moment.parseZone(value, moment.ISO_8601, true).isValid();
+	// If requested, check if has timezone.
+	isValid = hasTimezone ? isValid && ISO_DATETIME_WITH_TIMEZONE_REGEX.test(value) : isValid;
+	return isValid;
 }
 
 /**


### PR DESCRIPTION
# Description

Two meter date values on create & edit should not check for a timezone. All other uses checked except map & baseline. Map because the create is currently broken and baseline since not in use. Thus, a comment was left in those in case they break. Other routes using the same function worked fine with timezone check.

## Type of change

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

None known other than unchecked tests that are noted above.
