### PR TITLE
Issue1665 - Created helper functions that turned multiple schema approach into singular schema on edit/create for all routes

### DIFF
--- a/src/server/routes/conversions.js
+++ b/src/server/routes/conversions.js
@@ -24,23 +24,13 @@ function formatConversionForResponse(item) {
 }
 
 /**
- * Route for getting all conversions.
+ * Validates the body of a conversion create/edit request.
+ * Conversions are keyed by sourceId/destinationId rather than a single id, so the same
+ * schema is valid for both /addConversion and /edit; there is no isEdit distinction needed.
+ * @param params req.body for a conversion create or edit request
+ * @returns {{valid: boolean, errors: array}}
  */
-router.get('/', optionalAuthMiddleware, async (req, res) => {
-	const conn = getConnection();
-	try {
-		const rows = await Conversion.getAll(conn);
-		res.json(rows.map(formatConversionForResponse));
-	} catch (err) {
-		res.sendStatus(HTTP_CODES.INTERNAL_SERVER_ERROR);
-		log.error(`Error while performing GET conversions details query: ${err}`);
-	}
-});
-
-/**
- * Route for POST, edit conversion.
- */
-router.post('/edit', adminAuthMiddleware('edit conversions'), async (req, res) => {
+function validateConversionsParams(params) {
 	const validConversion = {
 		type: 'object',
 		maxProperties: 6,
@@ -76,8 +66,30 @@ router.post('/edit', adminAuthMiddleware('edit conversions'), async (req, res) =
 			}
 		}
 	};
+	const validatorResult = validate(params, validConversion);
+	return { valid: validatorResult.valid, errors: validatorResult.errors };
+}
 
-	const validatorResult = validate(req.body, validConversion);
+/**
+ * Route for getting all conversions.
+ */
+router.get('/', optionalAuthMiddleware, async (req, res) => {
+	const conn = getConnection();
+	try {
+		const rows = await Conversion.getAll(conn);
+		res.json(rows.map(formatConversionForResponse));
+	} catch (err) {
+		res.sendStatus(HTTP_CODES.INTERNAL_SERVER_ERROR);
+		log.error(`Error while performing GET conversions details query: ${err}`);
+	}
+});
+
+/**
+ * Route for POST, edit conversion.
+ */
+router.post('/edit', adminAuthMiddleware('edit conversions'), async (req, res) => {
+	const validatorResult = validateConversionsParams(req.body);
+
 	if (!validatorResult.valid) {
 		log.warn(`Got request to edit conversions with invalid conversion data, errors: ${validatorResult.errors}`);
 		failure(res, HTTP_CODES.BAD_REQUEST, `Got request to edit conversions with invalid conversion data, errors: ${validatorResult.errors}`);
@@ -100,42 +112,8 @@ router.post('/edit', adminAuthMiddleware('edit conversions'), async (req, res) =
  * Route for POST add conversion.
  */
 router.post('/addConversion', adminAuthMiddleware('add conversions'), async (req, res) => {
-	const validConversion = {
-		type: 'object',
-		maxProperties: 6,
-		required: ['sourceId', 'destinationId', 'bidirectional', 'slope', 'intercept'],
-		properties: {
-			sourceId: {
-				type: 'integer',
-				minimum: 1,
-				maximum: Number.MAX_SAFE_INTEGER
-			},
-			destinationId: {
-				type: 'integer',
-				minimum: 1,
-				maximum: Number.MAX_SAFE_INTEGER
-			},
-			bidirectional: {
-				type: 'boolean'
-			},
-			slope: {
-				type: 'number'
-			},
-			intercept: {
-				type: 'number'
-			},
-			note: {
-				oneOf: [
-					{
-						type: 'string',
-						maxLength: STRING_GENERAL_MAX_LENGTH
-					},
-					{ type: 'null' }
-				]
-			}
-		}
-	};
-	const validatorResult = validate(req.body, validConversion);
+	const validatorResult = validateConversionsParams(req.body);
+
 	if (!validatorResult.valid) {
 		log.error(`Got request to insert conversion with invalid conversion data, errors: ${validatorResult.errors}`);
 		failure(res, HTTP_CODES.BAD_REQUEST, `Got request to insert conversion with invalid conversion data. Error(s): ${validatorResult.errors}`);

--- a/src/server/routes/groups.js
+++ b/src/server/routes/groups.js
@@ -47,6 +47,91 @@ function formatToOnlyNameID(item) {
 }
 
 /**
+ * Validates the body of a group create/edit request.
+ * isEdit=true includes the required 'id' property (edit); isEdit=false excludes it (create), since
+ * id is assigned by the DB on insert.
+ * @param params req.body for a group create or edit request
+ * @param isEdit whether this is validating an edit (true) or create (false) request
+ * @returns {{valid: boolean, errors: array}}
+ */
+function validateGroupsParams(params, isEdit = true) {
+	const properties = {
+		name: {
+			type: 'string',
+			minLength: 1,
+			maxLength: SHORT_STRING_MAX_LENGTH
+		},
+		displayable: {
+			type: 'boolean'
+		},
+		gps: {
+			oneOf: [
+				{
+					type: 'object',
+					required: ['latitude', 'longitude'],
+					properties: {
+						latitude: { type: 'number', minimum: '-90', maximum: '90' },
+						longitude: { type: 'number', minimum: '-180', maximum: '180' }
+					}
+				},
+				{ type: 'null' }
+			]
+		},
+		note: {
+			oneOf: [
+				{ type: 'string', maxLength: STRING_GENERAL_MAX_LENGTH },
+				{ type: 'null' }
+			]
+		},
+		area: { type: 'number', minimum: 0 },
+		childGroups: {
+			type: 'array',
+			uniqueItems: true,
+			maxItems: 1000,
+			items: {
+				type: 'integer',
+				minimum: 1
+			}
+		},
+		childMeters: {
+			type: 'array',
+			uniqueItems: true,
+			maxItems: 1000,
+			items: {
+				type: 'integer',
+				minimum: 1
+			}
+		},
+		defaultGraphicUnit: { 'anyOf': [{ type: 'integer', minimum: 1 }, { type: 'integer', 'enum': [-99] }] },
+		areaUnit: {
+			type: 'string',
+			minLength: 1,
+			maxLength: 50,
+			enum: Object.values(Unit.areaUnitType)
+		}
+	};
+ 
+	const required = ['name', 'childGroups', 'childMeters'];
+ 
+	if (isEdit) {
+		properties.id = { type: 'integer', minimum: 1 };
+		required.push('id');
+	}
+ 
+	const validGroup = {
+		type: 'object',
+		additionalProperties: false,
+		required,
+		// Original /edit schema had no maxProperties cap; added 10 here (9 create-mode properties + id)
+		// to keep edit's property-count check consistent with create's, since this is otherwise the same schema.
+		maxProperties: isEdit ? 10 : 9,
+		properties
+	};
+	const validatorResult = validate(params, validGroup);
+	return { valid: validatorResult.valid, errors: validatorResult.errors };
+}
+
+/**
  * GET info of all groups
  */
 router.get('/', optionalAuthMiddleware, async (req, res) => {
@@ -224,69 +309,9 @@ router.get('/parents/:group_id', optionalAuthMiddleware, async (req, res) => {
 });
 
 router.post('/create', adminAuthMiddleware('create groups'), async (req, res) => {
-	const validGroup = {
-		type: 'object',
-		additionalProperties: false,
-		required: ['name', 'childGroups', 'childMeters'],
-		maxProperties: 9,
-		properties: {
-			name: {
-				type: 'string',
-				minLength: 1,
-				maxLength: SHORT_STRING_MAX_LENGTH
-			},
-			displayable: {
-				type: 'boolean'
-			},
-			gps: {
-				oneOf: [
-					{
-						type: 'object',
-						required: ['latitude', 'longitude'],
-						properties: {
-							latitude: { type: 'number', minimum: '-90', maximum: '90' },
-							longitude: { type: 'number', minimum: '-180', maximum: '180' }
-						}
-					},
-					{ type: 'null' }
-				]
-			},
-			note: {
-				oneOf: [
-					{ type: 'string', maxLength: STRING_GENERAL_MAX_LENGTH },
-					{ type: 'null' }
-				]
-			},
-			area: { type: 'number', minimum: 0 },
-			childGroups: {
-				type: 'array',
-				uniqueItems: true,
-				maxItems: 1000,
-				items: {
-					type: 'integer',
-					minimum: 1
-				}
-			},
-			childMeters: {
-				type: 'array',
-				uniqueItems: true,
-				maxItems: 1000,
-				items: {
-					type: 'integer',
-					minimum: 1
-				}
-			},
-			defaultGraphicUnit: {'anyOf': [{ type: 'integer', minimum: 1 }, { type: 'integer', 'enum': [-99] }]},
-			areaUnit: {
-				type: 'string',
-				minLength: 1,
-				maxLength: 50,
-				enum: Object.values(Unit.areaUnitType)
-			}
-		}
-	};
+	// isEdit=false: id must not be present, since it's assigned by the DB on insert.
+	const validatorResult = validateGroupsParams(req.body, false);
 
-	const validatorResult = validate(req.body, validGroup);
 	if (!validatorResult.valid) {
 		log.error(`Got request to create group with invalid data, errors: ${validatorResult.errors}`);
 		failure(res, HTTP_CODES.BAD_REQUEST, "Got request to create group with invalid data. Error(s): " + validatorResult.errors.toString());
@@ -325,69 +350,9 @@ router.post('/create', adminAuthMiddleware('create groups'), async (req, res) =>
 });
 
 router.put('/edit', adminAuthMiddleware('edit groups'), async (req, res) => {
-	const validGroup = {
-		type: 'object',
-		additionalProperties: false,
-		required: ['id', 'name', 'childGroups', 'childMeters'],
-		properties: {
-			id: { type: 'integer', minimum: 1 },
-			name: {
-				type: 'string',
-				minLength: 1,
-				maxLength: SHORT_STRING_MAX_LENGTH
-			},
-			displayable: {
-				type: 'boolean'
-			},
-			gps: {
-				oneOf: [
-					{
-						type: 'object',
-						required: ['latitude', 'longitude'],
-						properties: {
-							latitude: { type: 'number', minimum: '-90', maximum: '90' },
-							longitude: { type: 'number', minimum: '-180', maximum: '180' }
-						}
-					},
-					{ type: 'null' }
-				]
-			},
-			note: {
-				oneOf: [
-					{ type: 'string', maxLength: STRING_GENERAL_MAX_LENGTH },
-					{ type: 'null' }
-				]
-			},
-			area: { type: 'number', minimum: 0 },
-			childGroups: {
-				type: 'array',
-				uniqueItems: true,
-				maxItems: 1000,
-				items: {
-					type: 'integer',
-					minimum: 1
-				}
-			},
-			childMeters: {
-				type: 'array',
-				uniqueItems: true,
-				maxItems: 1000,
-				items: {
-					type: 'integer',
-					minimum: 1
-				}
-			},
-			defaultGraphicUnit: {'anyOf': [{ type: 'integer', minimum: 1 }, { type: 'integer', 'enum': [-99] }]},
-			areaUnit: {
-				type: 'string',
-				minLength: 1,
-				maxLength: 50,
-				enum: Object.values(Unit.areaUnitType)
-			}
-		}
-	};
+	// isEdit=true: id is required here since the client must tell us which group to update.
+	const validatorResult = validateGroupsParams(req.body, true);
 
-	const validatorResult = validate(req.body, validGroup);
 	if (!validatorResult.valid) {
 		log.error(`Got request to edit group with invalid data, errors: ${validatorResult.errors}`);
 		failure(res, HTTP_CODES.BAD_REQUEST, "Got request to edit group with invalid data. Error(s): " + validatorResult.errors.toString());

--- a/src/server/routes/maps.js
+++ b/src/server/routes/maps.js
@@ -35,6 +35,106 @@ function formatMapForResponse(map) {
 	return formattedMap;
 }
 
+/**
+ * Validates the body of a map create/edit request.
+ * isEdit=true includes the required 'id' property, along with 'displayable', 'note', 'origin', and
+ * 'opposite' as required (edit); isEdit=false excludes them (create), since id is assigned by the DB
+ * on insert and the others are not needed to create the initial map entry.
+ * @param params req.body for a map create or edit request
+ * @param isEdit whether this is validating an edit (true) or create (false) request
+ * @returns {{valid: boolean, errors: array}}
+ */
+function validateMapsParams(params, isEdit = true) {
+	const properties = {
+		name: {
+			type: 'string',
+			minLength: 1,
+			maxLength: SHORT_STRING_MAX_LENGTH
+		},
+		filename: {
+			type: 'string',
+			maxLength: 500
+		},
+		modifiedDate: {
+			type: 'string',
+			minLength: 1,
+			maxLength: STRING_GENERAL_MAX_LENGTH
+		},
+		mapSource: {
+			type: 'string',
+			minLength: 1,
+			maxLength: STRING_GENERAL_MAX_LENGTH
+		},
+		note: {
+			oneOf: [
+				{ type: 'string', maxLength: STRING_GENERAL_MAX_LENGTH },
+				{ type: 'null' }
+			]
+		},
+		displayable: {
+			type: 'boolean'
+		},
+		northAngle: {
+			type: 'number',
+			minimum: 0,
+			maximum: 360
+		},
+		circleSize: {
+			type: 'number',
+			minimum: 1,
+			maximum: 1000
+		},
+		origin: {
+			oneOf: [
+				{
+					type: 'object',
+					additionalProperties: false,
+					required: ['latitude', 'longitude'],
+					properties: {
+						latitude: { type: 'number', minimum: -90, maximum: 90 },
+						longitude: { type: 'number', minimum: -180, maximum: 180 }
+					}
+				},
+				{ type: 'null' }
+			]
+		},
+		opposite: {
+			oneOf: [
+				{
+					type: 'object',
+					additionalProperties: false,
+					required: ['latitude', 'longitude'],
+					properties: {
+						latitude: { type: 'number', minimum: -90, maximum: 90 },
+						longitude: { type: 'number', minimum: -180, maximum: 180 }
+					}
+				},
+				{ type: 'null' }
+			]
+		}
+	};
+ 
+	const required = ['name', 'modifiedDate', 'filename', 'mapSource'];
+ 
+	if (isEdit) {
+		properties.id = {
+			type: 'integer',
+			minimum: 1,
+			maximum: 2147483647
+		};
+		required.push('id', 'displayable', 'note', 'origin', 'opposite');
+	}
+ 
+	const validMap = {
+		type: 'object',
+		additionalProperties: false,
+		required,
+		properties
+	};
+	const validatorResult = validate(params, validMap);
+	return { valid: validatorResult.valid, errors: validatorResult.errors };
+}
+
 router.get('/', optionalAuthMiddleware, async (req, res) => {
 	try {
 		const conn = getConnection();
@@ -80,80 +180,8 @@ router.get('/:map_id', optionalAuthMiddleware, async (req, res) => {
 });
 
 router.post('/create', adminAuthMiddleware('create maps'), async (req, res) => {
-	const validMap = {
-		type: 'object',
-		additionalProperties: false,
-		required: ['name', 'modifiedDate', 'filename', 'mapSource'],
-		properties: {
-			name: {
-				type: 'string',
-				minLength: 1,
-				maxLength: SHORT_STRING_MAX_LENGTH
-			},
-			filename: {
-				type: 'string',
-				maxLength: 500
-			},
-			modifiedDate: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_GENERAL_MAX_LENGTH
-			},
-			mapSource: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_GENERAL_MAX_LENGTH
-			},
-			note: {
-				oneOf: [
-					{ type: 'string', maxLength: STRING_GENERAL_MAX_LENGTH },
-					{ type: 'null' }
-				]
-			},
-			displayable: {
-				type: 'boolean'
-			},
-			northAngle: {
-				type: 'number',
-				minimum: 0,
-				maximum: 360
-			},
-			circleSize: {
-				type: 'number',
-				minimum: 1,
-				maximum: 1000
-			},
-			origin: {
-				oneOf: [
-					{
-						type: 'object',
-						additionalProperties: false,
-						required: ['latitude', 'longitude'],
-						properties: {
-							latitude: { type: 'number', minimum: -90, maximum: 90 },
-							longitude: { type: 'number', minimum: -180, maximum: 180 }
-						}
-					},
-					{ type: 'null' }
-				]
-			},
-			opposite: {
-				oneOf: [
-					{
-						type: 'object',
-						additionalProperties: false,
-						required: ['latitude', 'longitude'],
-						properties: {
-							latitude: { type: 'number', minimum: -90, maximum: 90 },
-							longitude: { type: 'number', minimum: -180, maximum: 180 }
-						}
-					},
-					{ type: 'null' }
-				]
-			}
-		}
-	};
-	const validationResult = validate(req.body, validMap);
+	// isEdit=false: id must not be present, since it's assigned by the DB on insert.
+	const validationResult = validateMapsParams(req.body, false);
 	// TODO It is uncertain if the date has a timezone since map creation was not working when that was tested.
 	// This is a comment so if if fails someone knows to see if the second parameter should be false. If it works
 	// then this can be removed.
@@ -196,85 +224,9 @@ router.post('/create', adminAuthMiddleware('create maps'), async (req, res) => {
 });
 
 router.post('/edit', adminAuthMiddleware('edit maps'), async (req, res) => {
-	const validMap = {
-		type: 'object',
-		additionalProperties: false,
-		required: ['id', 'name', 'modifiedDate', 'filename', 'mapSource', 'displayable', 'note', 'origin', 'opposite'],
-		properties: {
-			id: {
-				type: 'integer',
-				minimum: 1,
-				maximum: 2147483647
-			},
-			name: {
-				type: 'string',
-				minLength: 1,
-				maxLength: SHORT_STRING_MAX_LENGTH
-			},
-			filename: {
-				type: 'string',
-				maxLength: 500
-			},
-			modifiedDate: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_GENERAL_MAX_LENGTH
-			},
-			mapSource: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_GENERAL_MAX_LENGTH
-			},
-			note: {
-				oneOf: [
-					{ type: 'string', maxLength: STRING_GENERAL_MAX_LENGTH },
-					{ type: 'null' }
-				]
-			},
-			displayable: {
-				type: 'boolean'
-			},
-			northAngle: {
-				type: 'number',
-				minimum: 0,
-				maximum: 360
-			},
-			circleSize: {
-				type: 'number',
-				minimum: 1,
-				maximum: 1000
-			},
-			origin: {
-				oneOf: [
-					{
-						type: 'object',
-						additionalProperties: false,
-						required: ['latitude', 'longitude'],
-						properties: {
-							latitude: { type: 'number', minimum: -90, maximum: 90 },
-							longitude: { type: 'number', minimum: -180, maximum: 180 }
-						}
-					},
-					{ type: 'null' }
-				]
-			},
-			opposite: {
-				oneOf: [
-					{
-						type: 'object',
-						additionalProperties: false,
-						required: ['latitude', 'longitude'],
-						properties: {
-							latitude: { type: 'number', minimum: -90, maximum: 90 },
-							longitude: { type: 'number', minimum: -180, maximum: 180 }
-						}
-					},
-					{ type: 'null' }
-				]
-			}
-		}
-	};
-	const validatorResult = validate(req.body, validMap);
+	// isEdit=true: id is required here since the client must tell us which map to update.
+	const validatorResult = validateMapsParams(req.body, true);
+	
 	if (!validatorResult.valid || !isValidIsoDateTime(req.body.modifiedDate)) {
 		log.error(`Invalid map data supplied, err: ${validatorResult.errors}`);
 		res.sendStatus(HTTP_CODES.BAD_REQUEST);

--- a/src/server/routes/maps.js
+++ b/src/server/routes/maps.js
@@ -242,9 +242,7 @@ router.post('/create', adminAuthMiddleware('create maps'), async (req, res) => {
 router.post('/edit', adminAuthMiddleware('edit maps'), async (req, res) => {
 	// TODO This is a temporary fix because edit is sending additional values that are not really
 	// needed: calibrationMode, image, calibrationSet, calibrationResult.
-	// The UI should let the admin set the note but dummy up here for now.
 	// It is assumed this will be fixed in the map PR 1314 or soon after that.
-	// req.body.note = '';
 	req.body = omit(req.body, 'calibrationMode', 'image', 'calibrationSet', 'calibrationResult');
 	// isEdit=true: id is required here since the client must tell us which map to update.
 	const validatorResult = validateMapsParams(req.body, true);

--- a/src/server/routes/maps.js
+++ b/src/server/routes/maps.js
@@ -15,6 +15,7 @@ const { DEFAULT_CIRCLE_SIZE } = require('../models/Map');
 const { STRING_GENERAL_MAX_LENGTH, STRING_SHORT_MAX_LENGTH: SHORT_STRING_MAX_LENGTH, NUMERIC_ID_MAX_LENGTH } = require('../util/validationConstants');
 const { HTTP_CODES } = require('../util/httpCodes');
 const { isValidIsoDateTime } = require('../util/timeValidation');
+const omit = require('lodash/omit');
 
 const router = express.Router();
 
@@ -63,7 +64,9 @@ function validateMapsParams(params, isEdit = true) {
 		mapSource: {
 			type: 'string',
 			minLength: 1,
-			maxLength: STRING_GENERAL_MAX_LENGTH
+			// TODO This is a very long string that encodes the actual map. It is unclear the exact maximum
+			// size so it is not clear this is the correct value.
+			maxLength: 100000
 		},
 		note: {
 			oneOf: [
@@ -81,8 +84,9 @@ function validateMapsParams(params, isEdit = true) {
 		},
 		circleSize: {
 			type: 'number',
-			minimum: 1,
-			maximum: 1000
+			// The UI limits 0:2 so do that here.
+			minimum: 0,
+			maximum: 2
 		},
 		origin: {
 			oneOf: [
@@ -92,7 +96,9 @@ function validateMapsParams(params, isEdit = true) {
 					required: ['latitude', 'longitude'],
 					properties: {
 						latitude: { type: 'number', minimum: -90, maximum: 90 },
-						longitude: { type: 'number', minimum: -180, maximum: 180 }
+						longitude: { type: 'number', minimum: -180, maximum: 180 },
+						// TODO For unknown reasons, map edit is sending this.
+						rawType: {type: 'boolean'}
 					}
 				},
 				{ type: 'null' }
@@ -106,16 +112,18 @@ function validateMapsParams(params, isEdit = true) {
 					required: ['latitude', 'longitude'],
 					properties: {
 						latitude: { type: 'number', minimum: -90, maximum: 90 },
-						longitude: { type: 'number', minimum: -180, maximum: 180 }
+						longitude: { type: 'number', minimum: -180, maximum: 180 },
+						// TODO For unknown reasons, map edit is sending this.
+						rawType: {type: 'boolean'}
 					}
 				},
 				{ type: 'null' }
 			]
 		}
 	};
- 
+
 	const required = ['name', 'modifiedDate', 'filename', 'mapSource'];
- 
+
 	if (isEdit) {
 		properties.id = {
 			type: 'integer',
@@ -124,7 +132,7 @@ function validateMapsParams(params, isEdit = true) {
 		};
 		required.push('id', 'displayable', 'note', 'origin', 'opposite');
 	}
- 
+
 	const validMap = {
 		type: 'object',
 		additionalProperties: false,
@@ -180,6 +188,13 @@ router.get('/:map_id', optionalAuthMiddleware, async (req, res) => {
 });
 
 router.post('/create', adminAuthMiddleware('create maps'), async (req, res) => {
+	// TODO This is a temporary fix because create is sending additional values that are not really
+	// needed: id, calibrationMode, image, calibrationSet, calibrationResult.
+	// The UI should let the admin set the note but dummy up here for now.
+	// It is assumed this will be fixed in the map PR 1314 or soon after that.
+	req.body.note = '';
+	req.body = omit(req.body, 'id', 'calibrationMode', 'image', 'calibrationSet', 'calibrationResult');
+
 	// isEdit=false: id must not be present, since it's assigned by the DB on insert.
 	const validationResult = validateMapsParams(req.body, false);
 	// TODO It is uncertain if the date has a timezone since map creation was not working when that was tested.
@@ -199,6 +214,7 @@ router.post('/create', adminAuthMiddleware('create maps'), async (req, res) => {
 				const newMap = new Map(
 					undefined,
 					req.body.name,
+					// TODO req.body had displayable but it is not used. Unclear if user should be allowed to set this when created.
 					false,
 					req.body.note,
 					req.body.filename,
@@ -224,10 +240,18 @@ router.post('/create', adminAuthMiddleware('create maps'), async (req, res) => {
 });
 
 router.post('/edit', adminAuthMiddleware('edit maps'), async (req, res) => {
+	// TODO This is a temporary fix because edit is sending additional values that are not really
+	// needed: calibrationMode, image, calibrationSet, calibrationResult.
+	// The UI should let the admin set the note but dummy up here for now.
+	// It is assumed this will be fixed in the map PR 1314 or soon after that.
+	// req.body.note = '';
+	req.body = omit(req.body, 'calibrationMode', 'image', 'calibrationSet', 'calibrationResult');
 	// isEdit=true: id is required here since the client must tell us which map to update.
 	const validatorResult = validateMapsParams(req.body, true);
-	
-	if (!validatorResult.valid || !isValidIsoDateTime(req.body.modifiedDate)) {
+
+	// TODO edit, unlike create, is not currently sending a time zone with the modifiedDate. It is unclear
+	// why they differ but for now don't require it here.
+	if (!validatorResult.valid || !isValidIsoDateTime(req.body.modifiedDate, false)) {
 		log.error(`Invalid map data supplied, err: ${validatorResult.errors}`);
 		res.sendStatus(HTTP_CODES.BAD_REQUEST);
 	} else {

--- a/src/server/routes/units.js
+++ b/src/server/routes/units.js
@@ -33,6 +33,89 @@ function formatUnitForResponse(unit) {
 }
 
 /**
+ * Validates the body of a unit create/edit request.
+ * isEdit=true includes the required 'id' property (edit, since the client must tell us which unit to
+ * update); isEdit=false excludes it (create, since id is assigned by the DB on insert).
+ * @param params req.body for a unit create or edit request
+ * @param isEdit whether this is validating an edit (true) or create (false) request
+ * @returns {{valid: boolean, errors: array}}
+ */
+function validateUnitsParams(params, isEdit = true) {
+	const properties = {
+		name: {
+			type: 'string',
+			minLength: 1,
+			maxLength: STRING_SHORT_MAX_LENGTH
+		},
+		identifier: {
+			type: 'string',
+			minLength: 1,
+			maxLength: STRING_SHORT_MAX_LENGTH
+		},
+		unitRepresent: {
+			type: 'string',
+			minLength: 1,
+			maxLength: STRING_SHORT_MAX_LENGTH,
+			enum: Object.values(Unit.unitRepresentType)
+		},
+		secInRate: { type: 'number', minimum: 0 },
+		typeOfUnit: {
+			type: 'string',
+			minLength: 1,
+			maxLength: STRING_SHORT_MAX_LENGTH,
+			enum: Object.values(Unit.unitType)
+		},
+		suffix: {
+			oneOf: [
+				{ type: 'string', maxLength: STRING_SHORT_MAX_LENGTH },
+				{ type: 'null' }
+			]
+		},
+		displayable: {
+			type: 'string',
+			minLength: 1,
+			maxLength: STRING_SHORT_MAX_LENGTH,
+			enum: Object.values(Unit.displayableType)
+		},
+		preferredDisplay: { type: 'boolean' },
+		note: {
+			oneOf: [
+				{ type: 'string', maxLength: STRING_GENERAL_MAX_LENGTH },
+				{ type: 'null' }
+			]
+		},
+		minVal: { type: 'number' },
+		maxVal: { type: 'number' },
+		disableChecks: {
+			type: 'string',
+			minLength: 1,
+			maxLength: STRING_SHORT_MAX_LENGTH,
+			enum: Object.values(Unit.disableChecksType)
+		}
+	};
+ 
+	// TODO Consider updating once decide exactly what want.
+	// required: ['id', 'name', 'identifier', 'unitRepresent', 'secInRate', 'typeOfUnit', 'suffix'],
+	const required = ['identifier'];
+ 
+	if (isEdit) {
+		properties.id = { type: 'integer', minimum: 1 };
+		required.push('id');
+	} else {
+		required.push('name', 'unitRepresent', 'typeOfUnit', 'displayable', 'preferredDisplay', 'minVal', 'maxVal', 'disableChecks');
+	}
+ 
+	const validUnit = {
+		type: 'object',
+		additionalProperties: false,
+		required,
+		properties
+	};
+	const validatorResult = validate(params, validUnit);
+	return { valid: validatorResult.valid, errors: validatorResult.errors };
+}
+
+/**
  * Route for getting all units.
  */
 router.get('/', optionalAuthMiddleware, async (req, res) => {
@@ -50,62 +133,9 @@ router.get('/', optionalAuthMiddleware, async (req, res) => {
  * Route for editing a unit by ID.
  */
 router.post('/edit', adminAuthMiddleware('edit units'), async (req, res) => {
-	const validUnit = {
-		type: 'object',
-		additionalProperties: false,
-		required: ['id', 'identifier'],
-		// TODO Consider updating once decide exactly what want.
-		// required: ['id', 'name', 'identifier', 'unitRepresent', 'secInRate', 'typeOfUnit', 'suffix'],
-		properties: {
-			id: { type: 'integer', minimum: 1 },
-			name: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH
-			},
-			identifier: {
-				type: 'string',
-				maxLength: STRING_SHORT_MAX_LENGTH
-			},
-			unitRepresent: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH,
-				enum: Object.values(Unit.unitRepresentType)
-			},
-			secInRate: { type: 'number', minimum: 0 },
-			typeOfUnit: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH,
-				enum: Object.values(Unit.unitType)
-			},
-			suffix: {
-				type: 'string',
-				maxLength: STRING_SHORT_MAX_LENGTH
-			},
-			displayable: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH,
-				enum: Object.values(Unit.displayableType)
-			},
-			preferredDisplay: { type: 'boolean' },
-			note: {
-				type: 'string',
-				maxLength: STRING_GENERAL_MAX_LENGTH
-			},
-			minVal: { type: 'number' },
-			maxVal: { type: 'number' },
-			disableChecks: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH,
-				enum: Object.values(Unit.disableChecksType)
-			}
-		}
-	};
-	const validatorResult = validate(req.body, validUnit);
+	// isEdit=true: id is required here since the client must tell us which unit to update.
+	const validatorResult = validateUnitsParams(req.body, true);
+
 	if (!validatorResult.valid) {
 		log.warn(`Got request to edit units with invalid unit data, errors: ${validatorResult.errors}`);
 		failure(res, HTTP_CODES.BAD_REQUEST, `Got request to edit units with invalid unit data, errors: ${validatorResult.errors}`);
@@ -137,66 +167,9 @@ router.post('/edit', adminAuthMiddleware('edit units'), async (req, res) => {
  * Route for creating a new unit.
  */
 router.post('/addUnit', adminAuthMiddleware('add units'), async (req, res) => {
-	const validUnit = {
-		type: 'object',
-		additionalProperties: false,
-		required: ['name', 'identifier', 'unitRepresent', 'typeOfUnit', 'displayable', 'preferredDisplay', 'minVal', 'maxVal', 'disableChecks'],
-		properties: {
-			// TODO Probably should not be passed
-			// id: { type: 'integer' },
-			name: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH
-			},
-			identifier: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH
-			},
-			unitRepresent: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH,
-				enum: Object.values(Unit.unitRepresentType)
-			},
-			secInRate: { type: 'number', minimum: 0 },
-			typeOfUnit: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH,
-				enum: Object.values(Unit.unitType)
-			},
-			suffix: {
-				oneOf: [
-					{ type: 'string', maxLength: STRING_SHORT_MAX_LENGTH },
-					{ type: 'null' }
-				]
-			},
-			displayable: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH,
-				enum: Object.values(Unit.displayableType)
-			},
-			preferredDisplay: { type: 'boolean' },
-			note: {
-				oneOf: [
-					{ type: 'string', maxLength: STRING_GENERAL_MAX_LENGTH },
-					{ type: 'null' }
-				]
-			},
-			minVal: { type: 'number' },
-			maxVal: { type: 'number' },
-			disableChecks: {
-				type: 'string',
-				minLength: 1,
-				maxLength: STRING_SHORT_MAX_LENGTH,
-				enum: Object.values(Unit.disableChecksType)
-			}
-		}
-	};
-	const validationResult = validate(req.body, validUnit);
+	// isEdit=false: id must not be present, since it's assigned by the DB on insert.
+	const validationResult = validateUnitsParams(req.body, false);
+
 	if (!validationResult.valid) {
 		log.error(`Got request to edit units with invalid unit data, errors: ${validationResult.errors}`);
 		failure(res, HTTP_CODES.BAD_REQUEST, `Got request to add units with invalid unit data, errors: ${validationResult.errors}`);

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -240,13 +240,13 @@ router.post('/delete', adminAuthMiddleware('delete a user'), async (req, res) =>
 		properties: {
 			username: {
 				type: 'string',
-				minLength: 5,
-				maxLength: 254
+				minLength: USERNAME_MIN_LENGTH,
+				maxLength: USERNAME_MAX_LENGTH
 			}
 		}
 	};
 	if (!validate(req.body, validParams).valid) {
-		res.status(HTTP_CODES.BAD_REQUEST).json({ message: 'Invalid params!' });
+		res.status(HTTP_CODES.BAD_REQUEST).json({ message: 'Invalid params' });
 	} else {
 		try {
 			const conn = getConnection();

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -17,6 +17,70 @@ const { HTTP_CODES } = require('../util/httpCodes');
 const router = express.Router();
 
 /**
+ * Validates the body of a user create/edit request.
+ * isEdit=true includes the required 'id' property and makes 'password' optional (edit, since a user
+ * is only sent a new password if it should change); isEdit=false excludes 'id' (assigned by the DB on
+ * insert) and requires 'password' (create).
+ * Note: /edit's body nests the user fields under a 'user' property, unlike /create's flat body, so
+ * this also builds and checks that wrapper when isEdit is true.
+ * @param params req.body for a user create or edit request
+ * @param isEdit whether this is validating an edit (true) or create (false) request
+ * @returns {{valid: boolean, errors: array}}
+ */
+function validateUsersParams(params, isEdit = true) {
+	const properties = {
+		username: {
+			type: 'string',
+			minLength: USERNAME_MIN_LENGTH,
+			maxLength: USERNAME_MAX_LENGTH
+		},
+		password: {
+			type: 'string',
+			// TODO: Optional field - if present, should be 8-1000 chars
+			minLength: PASSWORD_MIN_LENGTH,
+			maxLength: PASSWORD_MAX_LENGTH
+		},
+		role: {
+			type: 'string',
+			enum: Object.values(User.role)
+		},
+		note: {
+			type: 'string',
+			maxLength: STRING_GENERAL_MAX_LENGTH
+		}
+	};
+
+	const required = ['username', 'role', 'note'];
+
+	if (isEdit) {
+		properties.id = { type: 'integer', minimum: 1 };
+		required.push('id');
+	} else {
+		required.push('password');
+	}
+
+	const userSchema = {
+		type: 'object',
+		additionalProperties: false,
+		required,
+		properties
+	};
+
+	// /edit nests the user fields under a 'user' property; /create does not.
+	const validParams = isEdit
+		? {
+			type: 'object',
+			additionalProperties: false,
+			required: ['user'],
+			properties: { user: userSchema }
+		}
+		: userSchema;
+
+	const validatorResult = validate(params, validParams);
+	return { valid: validatorResult.valid, errors: validatorResult.errors };
+}
+
+/**
  * Route for listing all users.
  */
 router.get('/', adminAuthMiddleware('get all users'), async (req, res) => {
@@ -91,32 +155,8 @@ router.get('/:user_id', adminAuthMiddleware('get one user'), async (req, res) =>
 
 // Route for creating a new user.
 router.post('/create', adminAuthMiddleware('create a user.'), async (req, res) => {
-	const validParams = {
-		type: 'object',
-		additionalProperties: false,
-		required: ['username', 'password', 'role', 'note'],
-		properties: {
-			username: {
-				type: 'string',
-				minLength: USERNAME_MIN_LENGTH,
-				maxLength: USERNAME_MAX_LENGTH
-			},
-			password: {
-				type: 'string',
-				minLength: PASSWORD_MIN_LENGTH,
-				maxLength: PASSWORD_MAX_LENGTH
-			},
-			role: {
-				type: 'string',
-				enum: Object.values(User.role)
-			},
-			note: {
-				type: 'string',
-				maxLength: STRING_GENERAL_MAX_LENGTH
-			}
-		}
-	};
-	if (!validate(req.body, validParams).valid) {
+	// isEdit=false: id must not be present, since it's assigned by the DB on insert, and password is required.
+	if (!validateUsersParams(req.body, false).valid) {
 		res.status(HTTP_CODES.BAD_REQUEST).json({ message: 'Invalid params' });
 	} else {
 		try {
@@ -142,46 +182,9 @@ router.post('/create', adminAuthMiddleware('create a user.'), async (req, res) =
 
 // Route for updating an existing user.
 router.post('/edit', adminAuthMiddleware('edit a user'), async (req, res) => {
-
-	const validParams = {
-		type: 'object',
-		additionalProperties: false,
-		required: ['user'],
-		properties: {
-			user: {
-				type: 'object',
-				additionalProperties: false,
-				required: ['id', 'username', 'role', 'note'],
-				properties: {
-					id: {
-						type: 'integer',
-						minimum: 1
-					},
-					username: {
-						type: 'string',
-						minLength: USERNAME_MIN_LENGTH,
-						maxLength: USERNAME_MAX_LENGTH
-					},
-					role: {
-						type: 'string',
-						enum: Object.values(User.role)
-					},
-					password: {
-						type: 'string',
-						// TODO: Optional field - if present, should be 8-1000 chars
-						minLength: PASSWORD_MIN_LENGTH,
-						maxLength: PASSWORD_MAX_LENGTH
-					},
-					note: {
-						type: 'string',
-						maxLength: STRING_GENERAL_MAX_LENGTH
-					}
-				}
-			}
-		}
-	};
-
-	if (!validate(req.body, validParams).valid) {
+	// isEdit=true: id is required and password remains optional, since a user is only sent a new
+	// password if it should change. The wrapper ('user' key) is validated inside the helper too.
+	if (!validateUsersParams(req.body, true).valid) {
 		res.status(HTTP_CODES.BAD_REQUEST).json({ message: 'Invalid params' });
 	} else {
 		try {


### PR DESCRIPTION
# Description

Fixes #1665

It was previously found that the singular schema change that used isEdit to differentiate between schemas used for edit/create was a desired solution. Therefore, this pull request includes changes that applies this singular schema approach on each of the edit/create requests for all routes. Initially, only meters.js had a helper function, validateMeterParams(), that handled creating the schema and validation. Thus, a similar helper function was created for each route. This pull request intends to maintain the existing behaviors of these routes and only clean up the code by introducing a helper function that removes essentially duplicated code.

This issue was brought attention to from a previous issue where the maintainer liked the change to a singular schema approach + using isEdit parameters to control which schema is used. This issue was created to build from that request.

The following files were updated in this issue:
- conversions.js

validateConversionsParams() was created; the same schema was used (single schema created); handles validate()

- groups.js

validateGroupsParams() was created; single schema created with isEdit determines if id is included; handles validate()

- maps.js 

validateMapsParams() was created; single schema created with isEdit determines if id, displayable, note, origin, and opposite is included; handles validate()

This worked brought to the forefront that the newer map validation broke map create & edit. This was fixed in this PR by @huss.

- units.js

validatesUnitsParams() was created; single schema created with isEdit determines the required properties for create/edit; handles validate()

for create: required: ['name', 'identifier', 'unitRepresent', 'typeOfUnit', 'displayable', 'preferredDisplay', 'minVal', 'maxVal', 'disableChecks']

for edit: required: ['id', 'identifier']

- users.js

validatesUsersParams() was created; single schema created with isEdit determines if id is included for edit or password is included for create; handles validate()

This worked brought to the forefront that one could not delete certain shorter-named users. This was fixed in this PR by @huss.

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

I will include my results of testing as a follow up question, but I want to point out that I struggled with testing the changes in maps.js and users.js. At a minimum, I made sure that each commit I pushed passed the 'npm run check' and 'npm run test.'

unitReadings.js was initially mentioned to be related to this issue, but it was discussed that changes to it (and other files that use multi schema + validate() approach) will not happen in this pull request. The maintainer and I have discussed that it is better to wait for a better solution for these files.

Comment to related discussion: https://github.com/OpenEnergyDashboard/OED/issues/1665#issuecomment-5028934924
