### PR TITLE
Fix disabled group delete button after parent group removal (Issue 1653)

### DIFF
--- a/src/client/app/components/groups/EditGroupModalComponent.tsx
+++ b/src/client/app/components/groups/EditGroupModalComponent.tsx
@@ -992,7 +992,12 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 	 */
 	async function validateDelete() {
 		// Get all parent groups of this group.
-		const { data: parentGroupIDs = [] } = await store.dispatch(groupsApi.endpoints.getParentIDs.initiate(groupState.id, { subscribe: false }));
+		const { data: parentGroupIDs = [] } = await store.dispatch(
+			groupsApi.endpoints.getParentIDs.initiate(groupState.id, {
+				subscribe: false,
+				forceRefetch: true
+			})
+		);
 
 		// If there are parents then you cannot delete this group. Notify admin.
 		if (parentGroupIDs.length !== 0) {

--- a/src/client/app/components/groups/EditGroupModalComponent.tsx
+++ b/src/client/app/components/groups/EditGroupModalComponent.tsx
@@ -991,7 +991,14 @@ export default function EditGroupModalComponent(props: EditGroupModalComponentPr
 	 * If not, then continue delete process.
 	 */
 	async function validateDelete() {
-		// Get all parent groups of this group.
+		/**
+		 * Gets all parent groups of this group since it is easy and this is not done often.
+		 * In principle, the Redux state for groups has this information. However, due to the
+		 * recursive nature of groups, it is a harder to get it from that state so the
+		 * code simply uses the existing server/DB functions to do this.
+		 * Redux does not always think the state has changed so it may use stale state, esp. after a delete.
+		 * Thus, the fetch is forced to avoid this.
+		 */
 		const { data: parentGroupIDs = [] } = await store.dispatch(
 			groupsApi.endpoints.getParentIDs.initiate(groupState.id, {
 				subscribe: false,


### PR DESCRIPTION
# Description

This PR fixes the issue where a group cannot be deleted after its parent group has been deleted unles the page is refreshed.
This fix uses forceRefetch to request the latest group data from the server instead of using the data already stored in Redux. After the parent group is deleted, the new response reflects that the original group is no longer being used as a child group. Redux then updates the page with the latest data, which re-enables the delete button and allows the group to be deleted without refreshing the browser.

Fixes #1653 

Contributors:

- Kujoon Kwon (@kujoon226  )
- Neil Cabanilla (@neilcabanilla )

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

N/A
