### PR TITLE
Add Swagger/OpenAPI documentation for REST API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,8 @@
 				"redux": "~4.2.1",
 				"redux-thunk": "~2.4.0",
 				"serve-favicon": "~2.5.0",
+				"swagger-jsdoc": "~6.2.8",
+				"swagger-ui-express": "~5.0.1",
 				"usehooks-ts": "~3.1.0",
 				"xml2js": "~0.5.0"
 			},
@@ -96,6 +98,46 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+			"integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+			"dependencies": {
+				"@jsdevtools/ono": "^7.1.3",
+				"@types/json-schema": "^7.0.6",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^4.1.0"
+			}
+		},
+		"node_modules/@apidevtools/openapi-schemas": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+			"integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@apidevtools/swagger-methods": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+		},
+		"node_modules/@apidevtools/swagger-parser": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+			"integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+			"dependencies": {
+				"@apidevtools/json-schema-ref-parser": "^9.0.6",
+				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/swagger-methods": "^3.0.2",
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"z-schema": "^5.0.1"
+			},
+			"peerDependencies": {
+				"openapi-types": ">=7"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -627,6 +669,11 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+		},
 		"node_modules/@mapbox/geojson-rewind": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
@@ -866,6 +913,12 @@
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@scarf/scarf": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+			"integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+			"hasInstallScript": true
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
@@ -1275,8 +1328,7 @@
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-			"dev": true
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
 		},
 		"node_modules/@types/lodash": {
 			"version": "4.17.4",
@@ -1983,8 +2035,7 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"node_modules/array-bounds": {
 			"version": "1.0.1",
@@ -2129,8 +2180,7 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/base64-arraybuffer": {
 			"version": "1.0.2",
@@ -2310,7 +2360,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2556,6 +2605,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/call-me-maybe": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
@@ -2923,8 +2977,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"node_modules/concat-stream": {
 			"version": "1.6.2",
@@ -3096,9 +3149,9 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -3994,7 +4047,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-			"dev": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -5161,8 +5213,7 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -5879,7 +5930,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6315,7 +6365,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -6499,8 +6548,7 @@
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-			"dev": true
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
 		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
@@ -6511,6 +6559,12 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
 			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
 		},
 		"node_modules/lodash.isinteger": {
 			"version": "4.0.4",
@@ -6536,6 +6590,11 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+		},
+		"node_modules/lodash.mergewith": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
@@ -6887,7 +6946,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -7472,6 +7530,12 @@
 				"wrappy": "1"
 			}
 		},
+		"node_modules/openapi-types": {
+			"version": "12.1.3",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+			"peer": true
+		},
 		"node_modules/optionator": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -7639,7 +7703,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9760,6 +9823,94 @@
 				"svg-path-bounds": "^1.0.1"
 			}
 		},
+		"node_modules/swagger-jsdoc": {
+			"version": "6.2.8",
+			"resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+			"integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+			"dependencies": {
+				"commander": "6.2.0",
+				"doctrine": "3.0.0",
+				"glob": "7.1.6",
+				"lodash.mergewith": "^4.6.2",
+				"swagger-parser": "^10.0.3",
+				"yaml": "2.0.0-1"
+			},
+			"bin": {
+				"swagger-jsdoc": "bin/swagger-jsdoc.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/swagger-jsdoc/node_modules/commander": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+			"integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/swagger-jsdoc/node_modules/glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/swagger-jsdoc/node_modules/yaml": {
+			"version": "2.0.0-1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+			"integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/swagger-parser": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+			"integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+			"dependencies": {
+				"@apidevtools/swagger-parser": "10.0.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/swagger-ui-dist": {
+			"version": "5.32.12",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.12.tgz",
+			"integrity": "sha512-ceXE+KNc5LXafhh36trB6nxK+U2EIKUWzHT7sBiMosf2eJLAefalYnTwMouQBmSyED6m7Yz+GYZEcL+Glt3sww==",
+			"dependencies": {
+				"@scarf/scarf": "=1.4.0"
+			}
+		},
+		"node_modules/swagger-ui-express": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+			"integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+			"dependencies": {
+				"swagger-ui-dist": ">=5.0.0"
+			},
+			"engines": {
+				"node": ">= v0.10.32"
+			},
+			"peerDependencies": {
+				"express": ">=4.0.0 || >=5.0.0-beta"
+			}
+		},
 		"node_modules/tapable": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -10359,6 +10510,14 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
+		"node_modules/validator": {
+			"version": "13.15.35",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+			"integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -10796,6 +10955,34 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/z-schema": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+			"integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+			"dependencies": {
+				"lodash.get": "^4.4.2",
+				"lodash.isequal": "^4.5.0",
+				"validator": "^13.7.0"
+			},
+			"bin": {
+				"z-schema": "bin/z-schema"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"commander": "^9.4.1"
+			}
+		},
+		"node_modules/z-schema/node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"optional": true,
+			"engines": {
+				"node": "^12.20.0 || >=14"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
 		"redux": "~4.2.1",
 		"redux-thunk": "~2.4.0",
 		"serve-favicon": "~2.5.0",
+		"swagger-jsdoc": "~6.2.8",
+		"swagger-ui-express": "~5.0.1",
 		"usehooks-ts": "~3.1.0",
 		"xml2js": "~0.5.0"
 	},

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -33,6 +33,8 @@ const units = require('./routes/units');
 const conversions = require('./routes/conversions');
 const ciks = require('./routes/ciks');
 const { HTTP_CODES } = require('./util/httpCodes');
+const swaggerUi = require('swagger-ui-express');
+const swaggerSpec = require('./swagger');
 
 // Detect test environment and use higher rate limits during tests.
 // Rate limiting is critical for security in production but interferes with automated testing.
@@ -147,6 +149,9 @@ app.use('/api/conversion-array', conversionArray);
 app.use('/api/units', units);
 app.use('/api/conversions', conversions);
 app.use('/api/ciks', ciks);
+// Serve API docs before the client static files so `/api-docs` isn't intercepted
+// by the client-side static router.
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use(express.static(path.join(__dirname, '..', 'client', 'public')));
 
 const router = express.Router();

--- a/src/server/routes/conversions.js
+++ b/src/server/routes/conversions.js
@@ -71,7 +71,71 @@ function validateConversionsParams(params) {
 }
 
 /**
- * Route for getting all conversions.
+ * @openapi
+ * /api/conversions:
+ *   get:
+ *     summary: List conversions
+ *     tags:
+ *       - Conversions
+ *     responses:
+ *       '200':
+ *         description: List of conversions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   sourceId:
+ *                     type: integer
+ *                     example: 1
+ *                   destinationId:
+ *                     type: integer
+ *                     example: 2
+ *                   bidirectional:
+ *                     type: boolean
+ *                     example: false
+ *                   slope:
+ *                     type: number
+ *                     example: 1.0
+ *                   intercept:
+ *                     type: number
+ *                     example: 0.0
+ *                   note:
+ *                     type: string
+ *                     nullable: true
+ *                     example: example
+ *             examples:
+ *               sample:
+ *                 value:
+ *                   - sourceId: 1
+ *                     destinationId: 2
+ *                     bidirectional: false
+ *                     slope: 1.0
+ *                     intercept: 0.0
+ *                     note: example
+ *                 description: |
+ *                   cURL example:
+ *
+ *                   ```bash
+ *                   curl -s http://localhost:3000/api/conversions
+ *                   ```
+ *       '500':
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *             example:
+ *               error: Internal server error
+ *     x-codeSamples:
+ *       - lang: curl
+ *         source: |
+ *           curl -s http://localhost:3000/api/conversions
  */
 router.get('/', optionalAuthMiddleware, async (req, res) => {
 	const conn = getConnection();

--- a/src/server/swagger.js
+++ b/src/server/swagger.js
@@ -1,0 +1,20 @@
+const swaggerJsdoc = require('swagger-jsdoc');
+
+const options = {
+	definition: {
+		openapi: '3.0.0',
+		info: {
+			title: 'OED API',
+			version: '1.0.0',
+			description: 'OpenEnergyDashboard API documentation'
+		},
+		servers: [
+			{
+				url: '/'
+			}
+		]
+	},
+	apis: ['./src/server/routes/*.js']
+};
+
+module.exports = swaggerJsdoc(options);

--- a/src/server/swagger.js
+++ b/src/server/swagger.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 const swaggerJsdoc = require('swagger-jsdoc');
 
 const options = {


### PR DESCRIPTION
# Description

This PR adds an initial Swagger/OpenAPI implementation for OED's REST API. It adds Swagger UI at /api-docs and documents the GET /api/conversions endpoint as an example. This is a prototype for maintainer feedback before documenting additional endpoints.

Partly Addresses #1695 

## Type of change

(Check the ones that apply by placing an "x" instead of the space in the [ ] so it becomes [x])

- [ ] Note merging this changes the database configuration.
- [x ] This change requires a documentation update

## Checklist

(Note what you have done by placing an "x" instead of the space in the [ ] so it becomes [x]. It is hoped you do all of them.)

- [ x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [ x] I have removed text in ( ) from the issue request
- [ x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

Currently only the GET `/api/conversions` endpoint is documented as an example. Additional API endpoints still need Swagger/OpenAPI documentation. `swagger-jsdoc` is currently pinned to version 6.2.8 for compatibility with OED's current Node environment.
