### PR TITLE
finalize transition to new build system

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,13 +115,8 @@ services:
             # it is VERY important that it be yes for security reasons. If you are doing
             # development then you should be changing the other docker file as per the help
             # page for developers.
-            # OED_PRODUCTION: yes
-            # TODO THIS VALUE IS TEMPORARILY BEING SET TO no DURING THE TRANSITION TO THE NEW SETUP WHERE
-            #       THERE IS A SEPARATE DOCKER CONFIGURATION FILE FOR DEVELOPERS. THIS ALLOWS DEVELOPERS
-            #       TO CONTINUE TO USE THE CURRENT COMMAND TO START UP OED. THE PLAN IS TO REMOVE THIS
-            #       AFTER THE PHASE IN PERIOD.
-            OED_PRODUCTION: no
-            # See the ports mapping below to change the port used on your system.
+            OED_PRODUCTION: yes
+           # See the ports mapping below to change the port used on your system.
             # Normally OED_SERVER_PORT is not modified.
             OED_SERVER_PORT: 3000
             # Normally these users are fine and there should be no reason to change the next


### PR DESCRIPTION
# Description

This formally makes production the default method and forces use of the new docker file for development. This was scheduled (per a message on the OED Discord server) for on or after 8/15/26. Another message will be posted right after this is merged. This is the final step of the work that was done in PR #1615.

## Type of change

- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.org/developer/pr/) ideas
- [x] I have removed text in ( ) from the issue request
- [x] You acknowledge that every person contributing to this work has signed the [OED Contributing License Agreement](https://openenergydashboard.org/developer/cla/) and each author is listed in the Description section.

## Limitations

None known.
